### PR TITLE
Feature: Add ability to select words that have not been chosen before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/vcs.xml
 .env
 venv
+past-words.csv

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import ssl
 from email.message import EmailMessage
 import pandas as pd
 from datetime import date
+import csv
 
 # Load in email-related environmental variables
 load_dotenv()
@@ -22,7 +23,21 @@ def det_word_to_send():
     return word, definition
 
 
-word, definition = det_word_to_send()
+def record_word_def_chosen(word, definition, word_id):
+    fieldnames = ['word_id', 'word', 'definition', 'date']
+    if Path('./past-words.csv').is_file():
+        with open('past-words.csv', 'a', encoding='cp1252', newline='') as past_words_csv:
+            writer = csv.DictWriter(past_words_csv, fieldnames=fieldnames)
+            writer.writerow({'word_id': word_id, 'word': word, 'definition': definition, 'date': date.today()})
+    else:
+        with open('past-words.csv', 'a', encoding='cp1252', newline='') as past_words_csv:
+            writer = csv.DictWriter(past_words_csv, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow({'word_id': word_id, 'word': word, 'definition': definition, 'date': date.today()})
+
+
+
+record_word_def_chosen(word, definition, word_id)
 
 # Subject line of email
 subject = f"Maya Word of the Day: {date.today()}"
@@ -57,7 +72,7 @@ em = EmailMessage()
 em['From'] = email_sender
 em['To'] = email_receiver
 em['Subject'] = subject
-em.set_content(body, subtype = 'html')
+em.set_content(body, subtype='html')
 
 # Add SSL security layer
 context = ssl.create_default_context()

--- a/yucatecan-maya-definitions.csv
+++ b/yucatecan-maya-definitions.csv
@@ -1,5067 +1,5067 @@
-words,definitions
-A,prep. ti’. Dícelo a Juana : A’al ti’ X
-A (para interrogar),prep. Tu ba
-ABAJO,"adv. de l. Kaabal, yáanal. Mi zapato está debajo de mi hamaca: Yáanal in k’áan ti’aan in xanab."
-ABANDONAR,v.t. P’aat
-ABANICAR,"v.t. X pikit, pik’it iik’e’. Píipik."
-ABANICO,sus. Pikit
-ABARATAR,v.t. Yéemel u tojol.
-"ABARCAR, RODEAR",v.t. Bak’ paach
-ABDOMEN,sus. Nak’
-ABEJA (APIS MELLIFICA Y MELIPONA SSP),"sus. Ko’olel kaab, kaab , xunáan kaab, yik’el kaab."
-ABEJORRO,sus. Báalam kaab.
-ABERTURA,"sus. Jool, jaatalil, teejelil, buu"
-ABERTURA HONDA,sus. Jet’
-ABIERTO EN FORMA DE BOCA,adv. Jáajaapan
-ABISMO,sus. Julek’
-ABOFETEAR,"v.t. Láaj, p’aak’láaj."
-ABOFETEAR REPETIDAS VECES,"v.t. Máamaaláaj,"
-ABOGADO,Sus. Aj k’ulel
-ABOMINABLE,adj. P’etayenjal
-ABORRECER,v.t. P’eek
-ABORTO,sus. Éemel al
-ABRAZAR,v.t. Méek’
-ABRAZAR UNO AL CUELLO O DE LA CERVIS,v.t. Lóoch
-ABRAZAR REPETIDAMENTE,v.t. Lóolóochbil.
-ABRAZAR A CADA RATO,v.t. Méemek’ik.
-ABRIGAR,"v.t. Teep’, to’owe, piixe’."
-ABRIGO,sus. Chuk bo’oy.
-ABRIR LOS OJOS,v.i. P’iil a wich
-ABRIRSE,v.i. Xit’k’ajal.
-ABRILLANTAR,v.t. Lelekuntal
-ABRIR LA PUERTA,v.t. Je’.
-ABRIR LAS PIERNAS,v.i. Jeech.
-ABRIR VAINAS,v.t. P’eel.
-ABRIR LA BOCA,v.i. Jaap
-ABRIR UNA BOLSA,v.t. Xiit’.
-ABRIR LOS PIES,v.i. Xaach.
-ABRIR CAMINO,v.t. Jool.
-ABRIR,v.i. Jet
-ABRIR,v.t. Je’
-ABRIRSE,v.i. Xíit’il
-ABSORBER,"v.t. Xuuch, chu’uch"
-ABSORBER CON FUERZA,v.t. Xúuxuuch.
-ABUELA,sus. Chiich
-ABUELO,"sus. Nool, taaten, nojoch taata."
-A BUEN TIEMPO,"adv. de t. Tii’, tibilak"
-ABUNDANCIA DE FRUTA EN EL ÁRBOL,adv. de c. Jíijiichki. chinki. ABUNDANTE. Adv. de c. Ch’éech’eeki.
-ABUNDAR,v.i. Ya’abtal
-ABURRIMIENTO,sus. Náak óol
-ABURRIR,v.i. Náakal óol
-ACÁ,"adv. de l. Waye’, weye’, way"
-ACABA,adv. de t. Jach táant
-ACABA DE SER,adv. de t. Je’lakito.
-ACABAR,"v.t. Xu’ul, ts’o’ok, náak. báabaaláaj."
-ABUNDANCIA DE FRUTA EN EL ÁRBOL,adj.Chin
-ACABARSE,v.i. Xu’upul.
-ACABARSE DEL TODO,v.i. Nak’al.
-ACABARSE EL AIRE,v.i. Ku’upul u wiik’.
-A CADA MOMENTO,adv. de t. Junak
-A CADA RATO,adv. de t. Chich muuk’
-ACAECER,v.i. Úuchul
-ACAECER DE REPENTE,v.i. Wasut jal
-ACALORARSE,v.i. Kal k’iin
-ACALLAR,"v.i. Chiltaj, chilkunaj"
-"ACARICIAR, ALISAR","v.t. Báay, baytaj."
-"ACARREAR, TRANSPORTAR",v.t. Púut
-"ACASO, QUIZÁS","adv de d. Binakí, balakix."
-ACAUDALADO,adj. Ayik’al. Aj táak’in máak.
-ACAUDILLAR,v.t. Méek’tantaj
-ACCIDENTE,sus. Loob
-ACCIÓN DE GRACIAS,sus. Ts’aa yaatsil.
-ACECHAR,v.i. Ch’eeneb
-ACEDO,adj. Paj
-ACEITOSO O MANTECOSO,adj.Ch’ach’apki.
-ACEPTAR UNA PROPOSICIÓN,v.t. Ket
-ACEPTAR,v.i. Chíintaj.
-ACEQUIA O CANAL,sus. Bebek
-ACERCAR,v.i. Naats’
-ACERCARSE,v.i. Naats’al
-ACERCARSE REPETIDAMENTE,v.t. Naanaats’
-ACERTAR,v.t. Utsál
-ACERTAR EL TIRO,v.t. Toj k’ab.
-"ACESIDO, DISNEA (RESPIRAR CON DIFICULTAD)",sus. Jéesbal se’en.
-ACEZAR,v.i. Jéesbal
-ACLARAR,"v.i. Sáastal, píik"
-ACOBARDARSE O SER VENCIDO,adj. Kumtantaj
-ACOMETER,"v.t. Kopulba, ts’am k’ab"
-ACOMODAR,v.t. Tsool
-ACOMPAÑAR,"v.t. Tabantaj, láak’intal, láak’intik."
-ACONSEJAR,v.t. Tsool xikin
-ACONTECER,v.t. Úuchchajal
-ACORDADO,adj. Tumaja’an
-ACORDEÓN,sus. Sats’alsats’.
-ACORRALAR,"v.t. K’aal, k’aansaj"
-ACOSTADO,adj. Chilikbal 
-ACOSTAR,"v.i. Chital, chiltal."
-ACOSTAR A ALGUIEN,v.t. Chilkuns.
-ACOSTADO BOCA ARRIBA,adv. de m. Jawtal.
-ACOSTADO BOCA ARRIBA,adv. de m. Jawakbal
-ACOSTARSE BOCA ABAJO,"v.i. Nok, nokakbaj ,chelik"
-ACOSTUMBRADO,adj. Suuk
-ACOSTUMBRADO,adj. Suukbe’en
-ACOSTUMBRAR,v.i. Na’antal
-ACOSTUMBRARSE,v.i. Suuktal
-ACRECENTADA,adj. Chaybesabal
-ACRIBILLAR,v.t. Ts’ots’op loom
-ACTIVIDAD,sus. Sa’ak óolal.
-ACTIVO,adj. T’a’aj
-ACTOR O COMEDIANTE,sus. Balts’am
-ACTOS SEXUALES,"sus.Tal, ts’íis, top."
-ACTUALMENTE,"adv de t. Bejela’e’,beje’ele’, bejla’e’, bejle’, bela’e’, bele’."
-ACUÁTICO,adj. Ja’il
-ACUCHILLAR,v.t. Loom
-ACUERDO,sus. Éejenil.
-ACUERDO O RESOLUCIÓN TOMADA,"sus. Xot óol, multumut, k’aax t’aan."
-ACUÑAR,v.t. Cheej.
-ACURRUCARSE,"v.i. Mochtal, kop, moch"
-ACUSAR,v.t. Takpool
-ACUSACIÓN,sus. Takpoolil
-ACHIOTE,"sus. Kiwi’, k’uxub"
-ADEMÁN,"sus. Béech’ k’ab, t’aan k’ab"
-ADEMÁS,adv. de c. Bey xan
-ADENTRO,"adv. de l. Ich, ichil"
-ADEUDAR,v.t. P’aax
-"ADHERIR, PEGAR",v.t. Tak’
-ADICIONAR,"v.t. Ts’a yóok’ol, ya’abkuns."
-ADINERADO,"adj. Ayik’al, táak’iin máak."
-ADIVINANZAS,sus. Na’ato’ob
-"ADIVINAR, ENTENDER",v.t. Na’at
-"ADMINISTRAR, REGIR, GOBERNAR",v.t. Belankil.
-"ADMITIR, CONCEDER",v.t. Oksaj t’aan
-ADOLESCENCIA,sus. gen. m. Táankelemil; gen. f. x
-ADORAR,v.t. K’ult
-ADORATORIO,sus. Chan naajil k’ultaj
-ADULADOR,adj. Aj bay pool
-ADULAR,v.t. Baytaj
-ADÚLTERO,sus. Aj kalpach
-ADULTERIO DE MUJER,"sus. Kal paach, joy ts’om"
-ADULTO,sus. Nojoch máak.
-ADVERSIDAD,sus. Numya
-A ESTA HORA,adv. de t. Ualkila’
-A EMPELLONES,adv. de m. Ts’alk’abtantaj
-AFECTO,sus. Ts’a óolal
-"AFEITAR, TRASQUILAR","v.t. Ts’iik, jo’och."
-AFEMINADO,"adj. Ch’úupil xiib, síis óol."
-AFERRAR,"v.i. Ch’ik, maach."
-AFIANZADO EN ALGO CON MUCHA FUERZA,adj. Xáaxaachki.
-AFILAR,"v.t. Jáak, ja’i, jóojsaj yeej, juux."
-"AFILAR, DESBASTAR, LIJAR, FROTAR",v.t. Ja’.
-A FIN DE QUE,conj. fin. Utia’al
-AFIRMACIÓN,sus. Jailkunaj t’aan
-"AFIRMAR, ASEGURAR, ASENTAR CON FIRMEZA",v.i. Jeets’
-AFLIGIDO,adj. Naak’al ti’
-AFLOJAR LAS AMARRAS,"v.t. Sáal , waach’."
-"AFLOJAR, DESATAR, SOLTAR",v.t. Cha’
-AFLOJAR ALGO TENSO,v.t. Ch’uuk.
-AFUERA,adv. de l. Táankab
-AGACHADO,"adj. Mot’okbal, p’oka’an,"
-AGACHARSE,"v.i. Mot’al, p’oktal, t’uchtal,"
-AGARRAR,"v.t. Ch’a’an, maach, cháach, laap’, p’okokbal. mot’. ch’a’aj."
-"AGARRAR, ASIR, SUJETAR",v.t. Maach.
-AGAZAPAR,v.i. Mot’kin
-AGAZAPARSE,v.i. Mot’tal.
-AGAZAPADO,adj. Mot’baj.
-ÁGIL,adj. T’a’aj
-AGILIDAD,sus. T’a’ajil.
-ÁGIL DE PENSAMIENTO,adj. Léeleep’ki.
-"AGITARSE, COBRAR FUERZA",v.i. T’a’ajtal
-AGLOMERAR,"v.i. Múuch’kiin, mulkiin, múu"
-AGONÍA,sus. Pa’ muuk’.
-AGORAR,"v.t. Tamaxchi’, tomoxchi’"
-AGOTAR,"v.t. Xuup, sóop’."
-AGRADECIMIENTO,"sus. Nibpixan, nibpixanil,"
-AGRAVIO,sus. K’aas poch’
-AGREGAR,"v.t.Ts’a yóok’ol, ya’abkuns."
-AGRICULTOR,"sus. Koolnáal, j meyji k’áax, niib óolal koolkaab"
-AGRICULTURA,sus.Meyjul k’áax.
-AGRIDULCE,adj. Ch’ujuksu’uts’
-AGRIETAR,v.i. Jet
-AGRIO,adj. Su’uts’
-AGUA,sus. Ja’
-AGUA CALIENTE,sus. Chokoj ja’
-AGUA LLUVIA,"sus. Ka’anil ja’, ch’ulub ja’"
-AGUACATE (PERSEA AMERICANA MILLER),sus. Oon
-AGUACERO,sus. K’a’amkach ja’.
-AGUACERO PEQUEÑO,sus. Luuchil ja’
-AGUADA,"sus. Áak’al, áak’al che’"
-AGUADOR,sus. J koonja’
-AGUADORA,sus. X koonja’.
-AGUARDAR,"v.i. Páak’t, páa’t"
-AGUARDIENTE,"sus. Uk’aj, wiix kisin, k’áaj ja’, ja’i’ káaltal."
-AGUIJÓN,"sus. Aach, k’i’ix"
-ÁGUILA ROJA,sus. Kóot.
-AGUILILLA,sus. Koos
-AGUILILLA NEGRA,sus. Éek’ píip
-AGUJA,sus. Púuts’
-AGUJEREADO,"adj. Jola’an, pota’an"
-AGUJEREAR,v.t. Jo’ol
-"AGUJERAR, PERFORAR, BARRENAR",v.t. Poot.
-AGUJERO,sus. Jool
-AGUTÍ,sus. Tsuub
-AGÜERO,"sus. Tomoj chi’, tomox chi’,tamaxchi’."
-AHÍ,adv. de l. Te’elo’. ¿Qué haces ahí? ¿Ba’ax ka beetik te’elo’?
-AHIJADO,sus. Mejenilan
-AHOGAR,v.t. Kupaj
-AHOGAR APRETANDO LA GARGANTA,v.t. Bits’ nak paach.
-ALCANZAR,"v.t. Chuk, chukik, chukpaachtik,"
-AHORA,"adv. de t. Bejela’e’, teak, teaki’, Chuuk."
-AHORA MISMO,adv. de t. Táan
-AHORCAR,v.t. Jich’kaal
-AHORRAR DINERO,v.t.Líik’esaj táak’iin.
-AHORRO,sus. T’áal k’u’
-"AHUECADO, CON MUCHOS HUECOS",adj. Jóonjo
-AHUYENTAR,v.t. Tóojol
-AIRE,sus. Iik’
-AIRE FUERTE,sus. K’aam iik’
-"AJADAS, ESTROPEADAS",adj. T’u’t’u’uy
-AJENO,adj. Junpayil
-AJONJOLÍ,sus. Sikli’ p’uus
-AJUSTAR,"v.t.P’iiskunaj, p’elkunaj."
-AJUSTICIADO,adj. Malel táankab
-AL,prep.Ti’. Le di ramón al borrego.Tin ts’aj óox ti’ taman
-ALBARRADA,sus. Koot.
-"ALBARRADEAR, HACER ALBARRADA",v.t. Koot.
-ALBOROTO,sus. X wookin.
-AL CONTRARIO,adv. de m. Kuchpaach.
-ALEGRÍA,"sus. Ki’imak óol, ki’ óolal, ki’imak"
-ALFABETIZADOR,"sus. Aj ka’ansaj xook, Aj óolajil. ka’ambesaj."
-AL INSTANTE,adv. de m. Jan
-AL RATO,"adv. de t. Ka’akate’, ma’ sáame"
-ALA,sus. Xiik’
-ALACENA,sus. Balab.
-ALACRÁN,"sus. Síina’an, sina’an"
-ÁLAMO (FICUS COTINIFOLIA HB ET K),sus.
-ALBAHACA (OCIMUM MICRANTHUM WILLD),"sus. Kóopo’, ju’un Kakaltun"
-ALBAÑIL,"sus.J pak’ bal, j meen pak’."
-ALBOROTAR,v.t. P’uj
-ALBOROTAR PUEBLOS,v.t. Liik’saj kaajtal
-ALCALDE,"sus. Aj beelmal, aj nat be "
-"ALCANZAR, ATRAPAR, CAPTURAR PESCAR",v.t.
-ALCANZAR LO DESEADO,v.t. Chuuk sits’il
-ALDABA DE HIERRO,sus. K’aalab máaskab
-ALDEA,sus. Chan kaaj
-ALEGRÍA,"sus. Ki’ ki’ óolal, ki’imak óolal, ki’imal óolajil."
-ALEJADAS,adj. Náachja’antak
-ALEJAR,v.t. Náachkun
-ALEJARSE,v.i. Náachtal.
-ALENTAR,"v.t. Kuxkintaj óol, ch’a’b óol."
-ALEPUSA (ÁCARO QUE VIVE EN GALLINAS CLUECAS),sus. P’aj
-ALETA,sus. Mejen ot’ xiik’o’ob
-ALETEAR,"v.i. Popokxiik’o’ob, poklankil, popokankil."
-ALEVOSÍA,sus. K’eban t’aan
-ALFARERA,sus. X paat k’at.
-ALFARERO,sus. J paat k’at
-ALFORJA,sus. Mukuk
-ALGARABÍA,"sus. Tataj awatil, k’amach awatil"
-ALGO,adv. de c.Ts’e’ets’ek .
-ALGODÓN (GOSSYPIUM HIRRSUTUM L),sus. Jinta
-ALGÚN,adv de c. Babajun.
-ALGUNOS,adv de c. Ts’éets’ek.
-ALGUNA COSA,sus. Ba’abal
-ALGUIEN,sus. Yaan máax.
-"ALHAJA, JOYA",sus. Mejen ba’abal ko’oj.
-ALIANZA,"sus. Jax t’aanil, k’aax t’aan, múuch’ t’aani, mok t’aani."
-ALIENTO,"sus. Iik’, múusik’"
-ALIMENTAR,"v.t. Tséem, téentik."
-ALIMENTO,"sus. Janal, o’och, janalbe’en"
-ALIMENTADO,adj. Tséenta’
-ALISAR,"v.t. Tats’, báay, ji’ik"
-ALIVIAR,v.t. Táan u yutstal.
-ALIVIO,sus. Ch’éensáal
-ALJIBE,sus. Chultun
-AL LADO,adv de l. Tu tséel
-ALMA,"sus. Pixan, óol."
-ALMIZCLE,sus. P’u’us
-ALMORRANA,sus. X mumus
-ALMUD (MEDIDA DE PESO DE 3600 KGS),sus. Muut
-ALMUERZO,"sus. Janal, o’och"
-ALPARGATA,sus. Xaanab k’éewel. ALPARGATAS QUE SE AMARRAN AL TOBILLO CON UN
-CORDEL,sus. X bak’al óoko’ob.
-ALREDEDOR,"adv. de l. Bak’ paach, ba’apach, nak’lik,bak’lam paach."
-ALTAR,"sus. K’atal che’, K’uyen temil"
-ALTAR RÚSTICO DE MADERA,sus. Ka’anche’
-ALTERADO DE LOS NERVIOS,adj. Na’aka’an u
-ALTERAR EL ÁNIMO LIGERAMENTE,v.i. Lep’ óol
-ALTERARSE MUCHO COMO DE ESPANTO,v.i. ch’íich’il. Chaketjal
-ALTIVEZ,"sus. Tsikbail, ka’anal óolil."
-ALTIVO,adj. Ka’anal óol
-ALTO,adj. Ka’anal bak
-ALTURA,sus. Ka’analil
-"ALUMBRAR, AFOCAR",v.t. Juul.
-ALUMNO,"sus. Aj kambal, j káanbal."
-ALUMNA,"sus. Ix kambal, x káanbal"
-ALZAR,"v.t. Li’is, ch’úuy."
-ALZAR O ESTIRAR LAS MANOS O LOS PIES,v.i. Tiich’
-"ALZAR, ASIR CON LOS DEDOS",v.t. T’úuy.
-ALLÁ,adv. de l. Tolo’
-ALLANAR,"v.t. Tax, taxkun"
-ALLANAR CON LA MANO,v.t. Jux k’ab
-"ALLEGAR, ACERCAR",v.i. Taak.
-ALLÍ,"adv. de l. Ti’i, te’elo’, tolo’. Ponlo ahí: Ts’a te’elo’"
-AMABLE,adj. Uts.
-AMABILIDAD,sus. Utsil.
-AMAMANTAR,v.t. Ts’áa chu’uch
-AMANECER,"sus.,v.i. Sáastal, sáastaj, jáatskab k’iin, píik, píik’il."
-AMANECER,"adv. de t.Píik’ij, sáaschajake’."
-AMANSADOR,sus. J suuk kinnáal
-AMANTE,"sus. gen. m. J yaakunaj, gen. f. X AMPARAR ba’al, Ix yaakunaj , weey."
-AMAPOLA,"(PACHIRA AGUATICA. AUBL.) sus. K’uyche’, k’uux che’."
-AMAR,"v.t. Yáakunaj, yaabilaj, yáajkunaj"
-AMARANTO (AMATANTHUS),sus. X tes.
-AMARGO,adj. K’áaj.
-AMARGUÍSIMO,adj. K’áak’áaj.
-AMARGURA,sus. K’áajil.
-AMARGURA,sus. Ok’om óolal.
-AMARILLO,adj. K’an.
-AMARILLÍSIMO,adj. K’ank’an.
-AMARRAR,v.t. K’aax
-AMARRAR FUERTEMENTE,v.t. Jiich’ k’aax.
-AMARRAR FUERTEMENTE,v.t. Móomooch.
-AMARRADO MUY FUERTE VARIAS VECES,adj.
-"AMARRADO CON FUERZA, DIFÍCIL DE DESATAR",adv K’aak’aax. de m. Jíijiich’.
-AMBICIÓN,"sus. Sawin achil, ts’íibol, po"
-AMBICIÓN,sus. Sits’ óol.
-AMBICIONAR,v.i. Sits’
-A MI MISMO,Baatsile’
-AMENAZAR,"v.t. Sajakkun, ts’áa sajak"
-AMIGO,"sus. Et ook, etail, éet bisbail, etchi’ili’, etchi’il."
-AMNISTÍA,sus. Sajtsajil
-AMONESTACIÓN,sus. Pay óolal.
-AMONESTAR,v.t. K’eey.
-AMONTONADO,"adj. Túujkab. AMONTONADO EN EXCESO, MUY ESPONJADO. adj."
-AMONTONAR,"v.t. Mulkin, múuch’kin, nik."
-"AMONTONADO, AGLOMERADO",adj.
-"AMONTONAR, HACER MONTONES",v.t. Túutuu
-"AMONTONAR, TUPIR",v.t. Cheej.
-AMONTONARSE,"v.t. Múuch’ul, múuch’tal."
-AMOR,"sus. Yaakun, yaakunajil, yaabilaj."
-AMOTINAR,v.i. P’ujla’ajal
-AMPARAR,v.t. Bo’oybesaj
-AMPARO,sus. Anat
-AMPLIAR,"v.t. Nojochkinsaj, kóochkinsaj"
-AMPOLLA,"sus. Kum ja’, xaakal, xáakal."
-AMPOLLAR,"v.i. Xaak, xáak, p’ool."
-ÁMPULAS O PROTUBERANCIAS,sus. P’oolen p’óol.
-AMULETO,sus. Pay okil.
-AMURALLAR,"v.t. K’aal, bak’ paach"
-ANARANJADO,adj. Chak k’ank’an
-ANATEMA,sus. Aj tsakom
-ANCIANO,"adj. Nuxib, ch’iija’an"
-ANCLA,"sus. Ch’uuy tuun, Ch’uuy máaskab."
-ANCHO,adj. Kóoch
-ANCHURA,sus. Kóochil.
-ANDAR,v.i. Xíinbal
-ANDAR A LA REDONDA COMO CABALLO DE NORIA,v.i. Kots’ xíinbal
-ANDAR DANDO TRASPIÉS,v.i. Takchalak ANDRAJO. sus. T’u’ut’uy
-ANEGAR,v.i. Búulul
-"ANEGAR, AHOGAR",v.i. Buul
-ANÉMICO,adj. Sakpak’e’en
-ANEMIA,sus. Sakpak’e’enil.
-ÁNGULO,"sus. Ti’its, tu’uk’."
-ANGUSTIA,sus. Ok’om óolal .
-ANGUSTIA DE ÁNIMO Y DE CORAZÓN,sus. Jat’ tsemil
-ANIDAR,v.t. K’u’ankil
-ANILLO,sus. Ts’ipit k’ab
-ANIMAL,sus. Ba’alche’
-ANIMAL DOMÉSTICO,sus. Aalak’
-ANIMAL MITOLÓGICO,"sus. Bob, bobil, boboch"
-ANIMAL MONTARAZ,sus. Ba’alche’
-ANIMAL QUE HA SIDO AMANSADO O DOMESTICA,
-DO,sus. Aalak’bil
-ANIMAR,"v.t. Ts’a óol, líik’esaj óol."
-ÁNIMO,"sus. Chichil óolal, lep’óolal, óol,"
-ANIMOSO,"adj. Chich óol, t’a’aj."
-ANIQUILARSE,v.i. Ch’ejel
-ANO,"sus. Iit, moolo, moolol, mooloj, óolaj chuun. "
-ANOCHE,"adv. de t. Ok’najak, áak’ab, áak’abejak"
-ANOCHECER,"v.i. Áak’abtal, oknaj k’iin ANOLAR (DESGASTAR UN DULCE EN LA BOCA MOVIÉNDOLO DE"
-LADO A LADO),v.t. Nóol .
-ANSIEDAD,"sus.Sowjal, chukul iik’, okom óolil, pochil."
-ANSIOSO,adj. Aj chukul iik’
-"ANSIOSO, MUY DESESPERADO",adj. Paapaach’.
-ANZUELO,sus. Lúuts.
-ANTEPASADOS,sus. Máanja’an ch’i’ibalo’ob.
-ANOCHE,adv. de t. O’niak.
-ANONA (ANNONA CHERIMOLA MILLER),sus. Óop
-ANONA MORADA,sus. Polbox
-ANOTAR,v.t. Ts’íib
-ANTE,adv. de l. Aktáan
-ANTENOCHE,adv. de t. Áak’ab ka’oje
-ANTEPASADO,sus.Úuchben ch’i’ibal.
-ANTES,"adv. de t. Ma’aili’, paybe’en, táanil, táanij, yáax, yáax táanil, payanbe’, tanta"
-ANTERIORMENTE,"adv de t. Úuch, ka’ach."
-ANTIER,"adv. de t. Ka’ojej, kaujeak"
-ANTIGUAMENTE,adv. de t. Ka’ach úuchij.
-ANTIGÜEDAD,sus. Úuchbenil
-ANTIGUO,adj. Úuchben
-ANTORCHA,sus. Tajche’
-ANUDADO,adj. Jiich’il
-ANUDAR,v.t. Mook.
-ANUDAR APRETANDO FUERTE,v.t. Jeep’.
-ANULAR,"v.t. Cháajal, xu’uls"
-ANUNCIAR,v.t. Nub chi’
-AÑADIDA,adj. Chaybesabal
-AÑADIR,v.t. Chaybesaj
-AÑEJAR,"v.i.Úuchbe’enchajal, úuchbe’enjal"
-AÑIL (INDIGOFERA SUFFRUTICOSA MILLER),sus. Ch’ooj.
-AÑO,sus. Ja’ab.
-AÑO PASADO,"sus., adj. Ja’abake’."
-APACIGUAR,v.t. Jets’tal
-APAGADO,adj. Tuupul.
-APAGAR EL FUEGO,v.t. Tuup.
-APAGARSE EL FOGÓN,v.i. Jaab.
-APARATO,sus. Nu’ukul
-APARECER,"v.i. Chíikpajal, tip’"
-APARTAR,v.t. Jaats.
-APARTE,adv. Junpay
-APARTARSE CON ARROGANCIA,v.i. Kusba
-APATÍA,sus. Ma’óolal
-APEDREADO,adj. Ch’íinch’iinabil.
-APENADO,adj. Naak’al ti’
-APENAS,adv. de m. Chéen p’eel APESGAR (TOCAR UN OBJETO PRESIONÁNDOLO CON
-LA MANO ABIERTA O CON UN DEDO),"v.t. Peets’, ts’aal"
-APESTAR,v.i. Tu’
-APESTOSO,adj. Tu’
-APETITO,"sus. Wi’óolal, wi’ij, táak janal."
-APICULTOR,sus. Aj kaabnáal
-APICULTURA,"sus. Meyajil kaab, meyjul kaab."
-APILADO DESORDENADAMENTE,adj. Ts’áats’aap.
-APISONAR,v.t. Bajpéek
-APLANAR,"v.t. Táaxkun, táaxkuntik."
-APLASTADO,adj. Maxal
-"APLASTAR,MAJAR, PRENSAR","v.t. Pech’, pets’, peech’, puuch’."
-"APLASTAR, ARRUGAR",v.t. Yuuch’.
-APLAUDIR,"v.i. Papax k’ab, lalaaj k’ab."
-APLOMO,sus. Toj óolal
-APODO,"sus. P’aat k’aaba’, ko’ko’k’aaba’"
-APORREAR,v.t. P’uuch
-APOSENTO,sus. Tunk’as
-APOYAR,"v.i. Jets’kun, nakkun."
-APOYO,sus. Jets’il
-APRECIO,sus. Tumut
-"APRECIAR, VALUAR, JUSTIFICAR","v.t. Xoot chimil APRECIAR, ESTIMAR, AMAR, v.t. Yaakunaj"
-APREHENDER,"v.t. Chuk, chuuk, maach"
-APREMIO,sus. Yail
-APRENDER,"v.i. Káanbal, kaambal."
-APRENDER,v.t. Kanik.
-APRENDIZAJE,sus. Káanbesajul.
-APRESURADO,adj. Seeb óol ARBUSTO yaach’ Chek’mal. sus. Yeet’
-APRETADO,"adj. K’ak’ax, nu’ut’"
-APRETADO,"adj. Jejep’ki, kankanki."
-APRETADO MUY FUERTE,adv. Jéejeep’ki.
-APRETAR,"v.t. Jep’, p’e’es."
-"APRETAR, CEÑIR",v.t. jiich’.
-"APRETAR, DEFORMAR, ARRUGAR","v.t. Yuuch’,"
-APRETAR ENTRE DOS COSAS,v.t. Jaap.
-APRETARSE COMO LA BALA EN EL ARCABUZ,v.t.
-APRETAR FUERTE,v.t. Káamjep’.
-APRETÓN QUE SE DA CON LA PUNTA DE LOS DEDOS,
-APRISA,"adv. de m. Séebal, seba’an"
-APROBACIÓN,"sus. Éejenil, éejenta’al."
-APROBAR,v.t. Ketbesaj
-APROPIAR,v.t. Pach
-"APROPIAR, AGARRAR, TOMAR, COGER",v.t. Ch’a’
-APROVECHAR,"v.i. Ch’alik, makenjal"
-APROVECHARSE POR SER BASTANTE,v.t. Chanbil
-APROXIMARSE,v.i. Naats’al
-"APROXIMAR MUCHO LAS COSAS, ANIMALES O PER",
-SONAS,v.t. Naanaak’. APROXIMARSE MUCHO A ALGO O ALGUIEN. v.t.Náanaak’.
-APUNTAR PARA TIRAR,v.t. Joltan.
-A PUNTO,adv. de t. Ol
-A PUNTO DE SUCEDER,adv. de t. Ta’aitak
-"APUÑALAR, PUNZAR, HERIR",v.t. Loom
-"APUÑETAR, DAR DE PUÑETAZOS, BOX, BOXEAR",v.t. Loox.
-APÚRATE,"Expresión léxica verbal. Bajaba, péeksaba, lep’ a wóol, chook’aba, chok’ ti’, péenen."
-AQUEL,"adj. Lelo’, le je’elo’."
-AQUÍ,"adv. de l. Te’ela’, waye’, weye’, way."
-AQUIETARSE,v.i. Toj jal óol
-ARAÑA,"sus. Am, le’um"
-ARAÑA NEGRA,sus. X boox le’um
-ÁRBOL,sus. Che’ ARBUSTO CUYOS FRUTOS SE UTILIZAN PARA PROVOCAR EL HABLA EN LOS INFANTES QUE NO
-APRENDEN A HABLAR PRONTO,sus. Sutup
-ARBUSTO MELÍFICO DE FLORES AMARILLAS,sus.
-ARCO IRIS,sus. Cheel
-"ARCO DE EDIFICIO, BÓVEDA","sus. P’um, p’un"
-ARCO FALSO,sus. Tuusil p’un.X ma’ jaajil
-ARCO DE FLECHA,"sus. Tip’ix, tip’ix che’"
-ARCO PARA TIRAR,"sus. Tip’ix, tip’ix che’"
-ARCO DE RAMAS,sus. Ts’ulum
-ARDER,"v.i. Elel, el"
-ARDER ECHANDO LLAMAS,v.i. Jopankil
-ARDIENDO CON CALENTURA,"v.i. T’at’abki, táan u jáabal yéetel chokwil. Está ardiendo con calentura, está consumiéndose con calentura."
-ARDILLA,"sus. Ku’uk, kunab"
-ARENA,"sus. Sam, u lu’umil k’áanab, sinsin."
-ARENGADO,adj. P’ujbesaj
-ARENGAR,v.t. Awat t’aanil
-ARETE,sus. Tuup
-ARGAMASA,sus. Pak’ bitun
-ARISCO,adj. K’o’ox
-ARMADILLO,sus. Weech
-ARMADURA DEL CUERPO,sus. Chej baakel
-ARMAS,sus. Yeemba.
-ARMONÍA DE CANTO,sus. Siinan k’aay
-ARMONÍA DE VIDA,sus. Siinan kuxtal
-ÁRNICA (TILHONIA DIVERSIFOLIA (HEMSLEY A GRAY),sus. Chak su
-AROMA,sus. Ki’ibok
-AROMÁTICO,adj. Ki’ibook
-ARQUEAR,v.t. P’unik.
-"ARRAIGAR, ENRRAIZAR",v.i. Táabal
-ARRANCAR,"v.t. Jok, t’ook"
-"ARRANCAR, BAJAR FRUTOS Y FLORES",v.t. T’ook.
-"ARRANCAR, DESRAIZAR",v.t. Jook
-ARRASAR MEDIDA,v.t. Laj ts’ak
-ARRASTRAR,"v.t. Jiilt, jíil."
-ARRASTRAR ALGO POR EL SUELO,v.t. Bilyaj
-ARREAR,"v.t. Aktantaj, jáalbil ch’apaach."
-ARREBATAR,"v.t. Jáan páay, took. "
-ARREBATAR ALGO,v.t. Tóotóokabi.
-ARRECIAR,v.i. K’a’am
-ARRECIFE,sus. Chaway
-"ARREMANGAR LA FALDA, EL VESTIDO, ETC","v.t. Siil , wol."
-ARREMETER,v.t. Kiblaj
-ARREMETER CON FURIA,v.t. Pul
-ARRIBA,adv. de l. Ka’anal
-ARRIERO,sus. J ts’ik tsíimin
-ARRIMAR,v.t. Juuts’.
-ARRINCONAR,"v.i. Nakkun, ts’aa nak’lik, naak."
-"ARRINCONARSE, APOYARSE EN ALGO",v.t. Naktal.
-"ARRIMAR, JUNTAR, ACERCAR",v.t. Naak’.
-ARROBAMIENTO,sus. Sa’at óol
-ARRODILLADO,"adj. Xóolokbal, xóol k’a’taj"
-ARRODILLAR,"v.i. Xóolkin, xóol píix"
-ARROJADO,adj. Jalanch’inta’ab
-"ARROJAR, APEDREAR, ARROJAR, LANZAR, TIRAR","v.t. Ch’iin, puul"
-ARROJO,sus. Xet’ óolal
-ARROLLAR,"v.t. Kots’, wol."
-ARROYO,sus. Beel ja’
-ARRUGAR,"v.t. Yuuch’, yaach’ ARRUGADO (PARA ROPA O TELAS) adj. Yáayaach’. ARRUGADO (PARA METALES) adj.Yúuyuuch’"
-ARTE,"sus. Its’atil pool, yits’atil"
-ASADO,"adj. Póoka’an, k’áak’bil."
-ASALTAR,v.t. Ts’am k’ab
-ASAMBLEA,sus. Múuch’tsikbalo’
-ASADO A FUEGO LENTO,adv. K’aánk’aanchetaj.
-ASAR,"v.t. Póok, k’áak’tik, k’áak’."
-ASCENDER,v.i. Líik’
-ASCETA,sus. Aj ch’abtan
-ASEGURAR,v.t. Tem kunaj óol
-ASENTADO,"adj. Aka’an, ets’a’an, kuma’an."
-ASENTAR,"v.t. Ak kunaj, ets’kúunsaj, t’uchkíinsaj, xéekt"
-ASENTARSE,v.i. Ets’tal.
-"ASENTARSE, REMOJARSE",v.i. Ts’áamal
-ASENTIMIENTO,sus. Éejenil
-"ASERRAR, MARCAR, SEÑALAR",v.t. Weel.
-ASFIXIAR,v.i. Kupaj.
-"ASFIXIA, AHOGO",sus. Ku’upul yiik’.
-ASÍ,"adv. de m. Bey, beya’, beyo’"
-ASÍ COMO,"conj. comp. Je’ebix, je’ex, je’ebik"
-ASÍ ES,adv. de a. Beyistako’
-ASIENTO,sus. Xiix.
-"ASIENTO, SILLA",sus. Kulxekil
-ASIENTO DE PRINCIPALES,sus. Ts’am
-ASIMISMO,"adv. Beyxan, bey xan."
-ASIR,v.t. Chuk
-ASIR CON FUERZA,v.t. Kan mach
-ASIR CON LA MANO,v.t. Mach
-ASIR CON LOS DIENTES,v.t. Naach’.
-ASIR CON LA PUNTA DE LOS DEDOS,v.t. Biit’
-ASIR ENGARRAFADO COMO AVE DE RAPIÑA,v.t.
-ASIR FUERTEMENTE CON LA MANO,v.t. Kan lap’
-ASMA,"sus. Kok se’en, lot’ kok, tusba."
-ASOLEAR,v.i.Jaykunaj ti’ k’iin.Lechekbal ti’ Lap’ k’iin.
-ASOMAR,v.i. Tíip’.
-ASOCIARSE,v.t. Náakultik
-ASOLEARSE,v.i. Lechekbal
-ÁSPERO,"adj. Pe’ech, to’och"
-"ASTILLA, LASCA",sus. Ts’ej.
-ASTILLAR,v.t. Ts’ej.
-ASTUTO,sus. Aj numan
-ASUSTARSE REPENTINAMENTE,v.i. Jáajaak’óol.
-ATACAR,"v.t. Kiblaj, ch’a’apachtik,ts’áancha btik"
-ATADA,adj. Jep’
-ATADO,adj. Jiich’il
-ATADO LIGERAMENTE,adj. K’a k’aax
-ATADO EN MUCHAS OCASIONES,adv. K’aak’aasjoltaj.
-ATADO TODO JUNTO,adj. Mek’ k’aaxa’an
-ATALAYA,sus. Ch’uuk beej.
-ATAR,v.t. K’aax
-"ATAR, ANUDAR, ENGANCHAR",v.t. Jook’.
-ATARDECER,sus. Chíinik k’iine’
-ATEMORIZAR,v.t. Saajbeskunsik.
-ATENCIÓN,sus. Ts’a óolal AUNQUE
-ATENDER,"v.t. Táanlaj, táan óoltik."
-"ATENDER, ESCUCHAR CON ATENCIÓN",v.t. Ch’e’enxikintej.
-"ATESTARSE, LLENARSE DE GENTE UN LUGAR",v.i. Chok’ba.
-ATOLE,"sus. Sa’a, sa’"
-ATOLE DE MAÍZ NUEVO,"sus. Áak’ sa’a, iis uul."
-"ATORADO, TRABADO MUY FUERTE",adj. Kankan
-ATORARSE,v.i. Léechel.
-ATRAER A LA MUJER CON HALAGOS,v.t. K’ubsaj ki. óol
-ATRAGANTAR,"v.i. Jak’ab, ku’uchul"
-ATRAPAR,"v.t. Cháach, chuk, laap’ik, laap’, chúuchmachtik."
-ATRAPAR,v.t. Léech.
-"ATRAPAR CON TRAMPA, CERRAR",v.t. Nuup’.
-ATRAPADO CON LA BOCA,adj. Náanaach.
-ATRAPADO VARIAS VECES,adj. Chúuchuukab.
-ATRÁS,"adv. de l. Paach, paachil.Estoy atrás o detrás : Paachil yaaneen."
-ATRAVESAR,"v.t. Maanch’akat, taats’jul, taats’ mansa’ak, k’at."
-"ATRAVESAR, CRUZAR",v.t. K’áatal.
-ATRAVESADO,adj. K’áak’at.
-ATRAVESARSE,v.i. K’áatal.
-ATREVERSE,v.t. Xet’ óolal
-ATREVIDO,"adj. Aj koo, aj xet’ óol, k’ul ich."
-ATROPELLAR,"v.t. Jéentan, náatan, naktáan."
-ATURDIDO,adj. Sata’an
-AUGURIO,"sus. Tomoj chi’, tomox chi’, tamaxchi’,yáajil."
-AULLIDO,sus. Ok’ol chi’ibal.
-AUMENTAR,"v.t. Chaybesaj, ya’abkunaj, ya’abkunsaj."
-AUMENTARSE,v.i. Chaketjal
-AUN,conj. Kex
-AÚN NO,"adv. de t. Ma’ to, ma’ili’."
-AUNQUE,"conj. advers. Kex, bakakix. Aunque no tengas hambre : Kex min’anteech wi’ij. Kex ma’ wi’ijeechi’."
-AUNQUE ESTÉ,Kex ti’aan
-AUNQUE NO,conj. advers. Kex ma’
-AUNQUE SEA,conj. advers. Kextúun
-AUNQUE SEA ESO,Kexelo’.
-AUSENTE,"adj. Ma’ kula’an, ma’ kula’ani’"
-AUSENCIA,sus. Mana’an.
-AUTOMÓVIL,sus. Kiis buuts’
-AUTORIDAD,sus. Jo’ol póopil.
-AVALANZAR,v.t. Pul
-AVARICIA,"sus. Ts’u’util, kok siits’il."
-AVARO,"adj. J ts’u’ut, ts’u’ut"
-AVENTAR,v.t. Tojlaj
-AVENTURA,sus. Mamantats’il
-AVENTURERA,adj. X ma’ beelil.
-AVENTURERO,"adj. J Ma’ beelil,"
-AVERIGUAR,"v.t. Ojelt, ojel"
-AVISAR,"v.t. Kuxkinaj óol, num chi’"
-AVISPA,sus. Yiik’el xuux.
-AVISPA GRANDE AMARILLA Y NEGRA,sus.Xanab
-AVISPA NEGRA,sus. Boox xuux.
-AVISPA DE LARVA COMESTIBLE,"sus. Ek, cháak. ts’eelem."
-AVISPERO,sus. Xuux
-AVIVAR EL FUEGO,v.i. Jop
-"AXILA, ALA",sus. Xiik’
-AYER,"adv. de t. Jo’oljeak, jo’oljej, jo’oljeake’."
-AYER AL AMANECER,adv de t. Jatskab joljej.
-AYUDA,"sus. áant, mak bo’oy"
-AYUDANTE,sus. Aj áantnáal.
-AYUDAR,"v.t. Áantik, áantaj."
-AYUDAR RECÍPROCAMENTE,v.t. Paklan áantu
-AYUNAR,v.i. Su’uk’iin
-AYUNTAMIENTO,sus. Mul kaajo’ob
-AZOTAR,v.t. Jaats’
-AZOTAR CON CINTURÓN O BEJUCO,v.t. Jaats’
-AZOTAR CON BEJUCO,v.t. Wíiwiich’
-AZOTE DE LA LLUVIA,sus. Jaats’ab ja’
-AZÚCAR,"sus. Monkaab, moom, ch’ujuk."
-AZUL,"adj., sus. Ch’ooj"
-AZUL TURQUESA,"adj., sus. Ya’axka ."
-AGUA AZUL TURQUESA,sus. ya’axkaja’.
-AZUZAR,"v.t. Tojl, toojol"
-BABA,"sus. K’aab chi’, lúul"
-BABAZA,sus. Lúul
-BÁCULO,sus. Xóolte’
-BAGAZO DEL HENEQUÉN,sus. Ta’ kij
-BAGRE,"sus. Lu’, booxkaay"
-BAHÍA,sus. Wats’ k’áanab.
-BAILADOR,adj. Aj óok’ot
-BAILADORA,adj. Ix óok’ot
-BAILAR,v.i. Óok’ot
-BAILE,sus. Óok’ot
-BAILE DE LA CABEZA DEL COCHINO,sus. Óok’ostaj pool
-BAJAR,"v.i. Éemel, éem"
-BAJAR FRUTAS O FLORES,"v.t. T’ook, jéek’, p’iik."
-BAJAREQUE,sus. Kolóojche’
-BAJO,adj. Kaabal
-BALA,sus. U yóol ts’oon
-BALANCEARSE,v.i. Ch’uyk’alakil
-BALBUCEAR,v.i. Altal yaak’
-BALBUCENCIA,sus. Ses
-BALBUCIENTE,"adj. Aj ses, nuntal"
-"BALDE, CUBETA",sus. Ch’óoy
-BALDÍO,adj. X tokoy
-BALEAR,v.t. Ts’oon
-BALSA PARA PASAR RÍOS,"sus. Poyte che’, payte che’."
-BALUARTE,sus. Jil che’
-BALLENA,sus. Masam.
-BAMBOLEAR,v.i. Takchalak
-BAMBOLEO,sus.Nayal kab.
-BAMBOLEAR,v.i. Nayal kab.
-BAMBOLEAR,v.i. Nayk’alankil.
-BANDADA,sus. Piktanil ch’íich’
-BANDERA,sus. Láakam.
-"BANDERA, PABELLÓN, ESTANDARTE",sus. Pan
-"BANQUETA, MUEBLE DE COCINA",sus. Banka’ k’a.
-BANQUETE,"sus. Waajil, nonoj ki’ki’ janal"
-BANQUILLO,"sus. K’áanche’, kisi che’"
-BAÑAR,v.i. Ichkíil
-BAÑO,"sus. Ichkíil BAÑO, LUGAR. sus. U kúuchil ichkíil."
-BARATO,"adj. Ma’ ko’oji’, junp’íit u tojol"
-BARBA,sus. Me’ex
-BARBARIE,sus. Tachi’achil
-BARBERO,sus. Aj k’oos
-BARBILLA,sus. No’och
-BARCO,sus. Cheem
-BARQUERO,sus. Aj cheemnáal.
-BARRANCA,sus. Bekan
-BARRANCA OBSCURA,sus. Jom
-BARRANCO,"sus. K’om, k’óom"
-BARRENAR,v.t. Poot
-BARRER,"v.t. Míist, míis"
-BARRER SIN ORDEN,v.t. Míimiiste
-BARRETA,sus. Xúul máaskab
-BARRIDO,adj. Míisa’an
-BARRIGA,sus. Nak’
-BARRIO DE PUEBLO O CIUDAD,sus. Kuchteel
-BARRO,sus. K’at
-"BASE, CIMIENTO, TRONCO",sus. Chuun
-BASILISCO,sus. Tóolok
-"BASINICA, BASÍN",sus. Ch’eeneb iit
-BASTANTE,adv. de c. Ya’ab
-BASTAR,v.i. Chabiljal
-BASTIMENTO,"sus. O’och, janal."
-BASTÓN,sus. Xóolte’
-BASTÓN PLANTADOR,sus. Xúul
-BASURA,"sus. Sojol, ta’ míis."
-BATALLA,"sus. Ba’ate’il, k’atunyaj"
-BATALLÓN,"sus. K’atun, molay k’atuno’ob"
-BATEA,"sus. Panaab, pox che’."
-"BATIDA,CLAMOREO, CACERÍA COLECTIVA",sus. P’uuj.
-BATIDOR,"sus. Bok’obxut’en, bok’ol"
-BATIR,"v.t. Book’ BATIR, AGITAR, REVOLVER LÍQUIDOS, MEZCLA,"
-LODO,v.t. Book’.
-BATIDO,adj. Bobook’.
-BATIR EL CHOCOLATE,v.t. Jaax.
-BAUTIZO,sus. Okja’
-BEBÉ (NIÑO DE BRAZOS),"sus. Nux, chanpaal, chanba’al"
-BEBER,v.i. Uk’ul
-BEBER SIN PARAR,v.i. Bits’kal
-BEBER A SORBOS,v.i. Xúuch
-BEBIDA,sus. Uk’ul
-BEBIDA RITUAL,sus. Sakab
-BEBIDA FRESCA Y VIRGEN,sus. Sujuy síis óola’
-BEBIDA RITUAL FERMENTADA HECHA CON LA COR,"TEZA DE UN ÁRBOL (LONCHOCARPUS VIOLACEUS),"
-AGUA Y MIEL,sus. Báalche’
-BEJUCO,sus. Aak’
-BELLEZA,"sus. Ki’ichpamil (f), ki’ichkelmil (m),"
-BENDECIR,"v.t. Kikit’aanta’ak, lóojsiko’ob"
-BENDICIÓN,sus. Ki’ki’t’aan
-"BENEFICIAR, HACER BIEN, HACER FAVOR","v.t. Meen uts, beet uts."
-BEODO,adj. Kala’an
-BESAR,v.t. Ts’u’uts’
-BESO,sus. Ts’u’uts’
-BESTIA,sus. Ba’alche’
-BICICLETA,sus. Balak’ t’íinchak ook. Tíinchak balak’ ook.
-BIEN,adv. de m. Ma’alob
-BIENES O PROPIEDADES,sus. Ba’alba. 
-BIENVENIDA,sus. K’aambe’enil.
-BIFURCACIÓN,sus. Xa’ay
-BIGOTE,"sus. Me’ex, ts’ukuti"
-BILIS,sus.K’anchik’íin
-BIOGRAFÍA,sus. Siyan
-BÍPEDO,sus. J ka’a ts’iit ook
-BIZCO,adj. Ts’eeb
-BLANCO,"adj. Sak, sasak."
-BLANCURA,sus. Sakil
-BLANCUZCO,adj. Sakpose’en.
-BLANDIR,v.t. Bik’yaj
-BLANDO,"adj. Mamayki, o’olki"
-BLASFEMIA,sus. Pooch’
-BOA (CONSTRICTOR SP),"sus. Ooch kaan, k’axab"
-BOBO,adj. Neets.
-BOCA,sus. Chi’
-BOCA ABIERTA,sus. Jáapal chi’
-BOCA ABAJO,"adv. de m. Nokokbaj, nokokbal,"
-"BOCA ABAJO, EMBROCARSE",adv. de m. Noktal.
-BOCA ARRIBA (ACOSTADO),adv de m. Jawtal. nóonoojkan. jawakbal.
-BOCANADA,sus. Pats’baj
-"BOCETAR, BOSQUEJAR",v.t. Túunt ts’íibtik
-BODA,sus. Ts’o’okol beel
-BOFETADA,sus. Laaj.
-"BOLAS, POR BOLAS","adv. Wóowool, wóol"
-BOLSA,"sus. Pawo’, sáabukan"
-BOLSA DEL PANTALÓN,sus. Témil
-BONDAD,sus. Utsil
-BONITA,"adj. Jats’uts, ki’ichpam."
-BONITO,adj. Jats’uts.
-BORDADO DE PUNTA DE CRUZ O DE HILO CONTADO,sus. Xookbil chuuy
-BORDADO HECHO A MANO,sus. Ts’íib chuuy
-BORDAR,v.t. Chuuy.
-BORRACHERA,. sus. Káaltal
-BORRACHO,adj. Kala’an
-BORRADO,adj. Tuupul
-BORRAR,v.t. Tuup.
-BORREGO,sus. Taman
-BOSTEZAR,"v.i. Jaayab, jaaya’."
-BOTÓN DE FLOR,sus. Totop’
-BÓVEDA,sus.Jobon túun.
-BOXEAR,v.t. Loox
-BRAVO,"adj. Ts’íik, p’uujul, J ts’íits’ikil."
-BRAVURA,"sus. Ts’íikil, p’uujulil."
-"BRAMAR, GEMIR, QUEJARSE",v.i. Áakam
-"BRAMIDO, GEMIDO, QUEJA",sus. Áakam
-BRASA,"sus. Kuxul chúuk, náaxche’ BRASERO O BRASA QUE SE PONE DEBAJO DE LA"
-BRASILETE ( CAESALPINIA PLATYLOBO (S WAT,
-CAMA,sus. Moj
-SON)),sus. Chakte’
-BRAVO,adj. Ts’íik
-BRAVO,adj. J ts’íits’ikil
-BRAZA (MEDIDA DE LONGITUD),sus. Sáap
-BRAZO,sus. K’ab BRECHA QUE SE ABRE ALREDEDOR DEL MONTE PARA
-FACILITAR SU MEDICIÓN,sus. Jolche’
-BRILLAR,"v.i. Jopba, lets’bal, léembal."
-BRILLOSO,adj. Ts’íits’iiban.
-BRINCAR,"v.i. P’iitik, p’iit, síit’, waransíit’."
-BRINCO,"sus. Síit’, p’iit"
-BRINDAR,v.t. Chun luch
-BRISA DE LA NOCHE,sus. Síiskabil áak’ab. BUSCAR
-BROMEAR,"v.i. Tuskep, tuuskeep"
-"BROTAR (LOS VEGETALES, LAS AVES)","v.i. Tóop’, tóop’ol."
-BROTE,sus. Alamil
-BRUJO,"sus. Bal jol, Aj puul yaaj. BRUJO QUE SE CONVIERTE EN MARRANO, CHIVO,"
-"TORO, BORREGO",sus. Wáay.
-BRUÑIR PLANCHAR,v.t. Yúul.
-BRUTO,"adj. Ba’alche’, maknal"
-BUCHE,"sus. Tsuuk, chíim."
-BUENO,"adj. Uts , ma’alob."
-BUEY,sus. J meyjil waakax
-BÚHO,"sus. Tunkuluchuj, xooch’"
-BULLIR,v.i. Om
-BULLIR (MUCHA GENTE),v.i. momolankil
-BURBUJA,"sus. P’op’oot, yóom ja’."
-"BURBUJEAR, HERVIR","v.i. Óomankil, óo"
-BURLA,sus. P’a’as
-BURLAR,v.i. P’a’ast
-BURRO,sus. Chowak xikin
-"BUSCAR, ENCONTRAR","v.t. Kaxan, kaxáan,"
-BUSCAR (OLIENDO COMO EL PERRO),"v.i. U’us kaax, xaak’al ni’ktik"
-CABALLERO,sus. Ts’uul.
-CABALLO,sus. Ts’íimin
-CABAÑUELAS,v.i. Xook k’iin
-CABECEAR DORMITANDO,sus. Nikib
-CABECEAR,"v.i. Bebechtik u pool, t’óont’on pool."
-CABECILLA,sus. Jool poop
-CABELLO,sus. Tso’ots
-CABER,v.i. Chabiljal
-CABEZA,"sus. Pool, jo’ol"
-CABEZA DE BRUJO,sus. K’ok’ol tsek’.
-CABILDO,sus. Mul kaajo’ob
-CACAREAR,v.i. Totojk’e’
-CACAREO,sus. Totojk’e’.
-CACERÍA,"sus. Ts’oon, p’uuj"
-CACERÍA COLECTIVA,sus. P’uuj
-CACIQUE,sus. Aj beelmal
-CADA,prep. Amal
-CADA UNO (PARA REFERIRSE A ANIMALES Y PERSONAS),loc pronom. Jujuntúul. Dale un plátano a cada niño :Ts’a jun ts’iit ja’as ti’ junjuntúul paal.
-CADA UNO (PARA REFERIRSE A OBJETOS),loc pro
-"CADALSO, TEMPLETE",sus. Sak’ che’.
-CADÁVER,sus. Aj kiimén
-CADENA,"sus. Máaskab suum, jok’enjok’"
-CADERA,sus. T’e’et’
-CADILLO QUE SE PEGA A LA ROPA,sus. Aj mul
-CAER,v.i. Lúubul
-"CAER, DESPRENDERSE, DESMORONARSE",v.i. Báa
-"CAER, DERRUMBARSE",v.i. Níikil.
-CAER DE BRUCES,v.i. Noktal.
-CAIDOS,adj. Lúuluuban
-CAJA,sus. Máaben
-"CAJA DE MUERTO, ATAUD",sus. Máaben kíimen.
-CAJA DEL CUERPO,sus. Ba’asil kukut.
-CAJETE,sus. Lak
-CAL,sus. Ta’an
-CALABAZA (CURCUBITA PEPO C ARGYROSPERMA (CUR,
-CUBITA SPP)),sus. K’úum
-CALABAZA BLANCA DE PEPITA GRUESA,"sus. X ka’, x tóop’. Chúuj ."
-CALABAZO (LAGENARIA SICERARIA (STANDLEY)),sus. CALABAZO PARA LLEVAR SEMILLAS DURANTE LA
-SIEMBRA,sus. Joma’
-CALAMBRES,sus.X lot’kej iik’
-CALANDRIA,sus. Jon xa’an.
-"CALAVERA, CRÁNEO",sus. Tséek’
-CALCAÑAR,"sus. Kuuy, tuunkuy"
-CALCINANTE,adj.Ku ta’anbesik
-CÁLCULO RENAL,sus. K’aal wiix.
-CALDO,sus. K’aab
-CALDO DE COMIDA,sus. K’aab janal.
-CALENTARSE CON EL SOL O JUNTO A LA BRASA,v.i. K’iich.
-"CALENTAR, ENTIBIAR",v.t. K’íin
-CALENTURA,"sus. Chakawil, Chokwil"
-CALIENTE,"adj. Chokoj, k’inal"
-CALMA EN EL MAR,sus. Leman
-CALMAR,v.t. Mal
-"CALMARSE, AQUIETARSE",v.i. Jets’tal.
-CALOR,sus. Ooxoj CALOR O VAPOR NOCIVO QUE SALE DE LAS TIERRAS
-DELGADAS O DE RAÍCES DE ÁRBOLES PODRIDOS,sus. Buy
-CALUMNIA,sus. Líilsaj t’aan.
-CALVARIO,sus. Kuuch numya.
-CALZADO,"sus. Xanab, xana’."
-CALZÓN,sus. Eex
-CALZONCILLO,sus. Kul eex
-CALLAR,v.i. Mak chi’. ¡Cállate! ¡Mak a chi’!
-CALLE,sus. Yam kaaj.
-CALLO,sus. T’aajam
-CAMA,"sus. Ch’áak, ch’áakche’"
-CAMADA,sus. Pakab
-CÁMARA FOTOGRÁFICA,sus. Nu’ukul ch’a’
-"CAMBIAR, TROCAR","v.t. Jeel, k’ex, k’eex."
-"CAMBIADO, MUY CAMBIADO",adv. de m. oochel K’éexk’eex.
-CAMINANTE,sus. Aj xíinbal
-CAMINAR,v.i. Xíinbal
-CAMINO,"sus. Bej, beel, belil"
-CAMINO QUE SE BIFURCA,Sus. Xa’ay bej.
-CAMISA,sus. Búuk.
-CAMOTE ( IPOMOEA BATATAS),sus. Iis.
-"CAMPAMOCHA , MANTIS, CABALLITO DEL DIABLO",sus. Ts’awayak
-CAMPANA,sus. Balamte máaskab
-CAMPAÑA,sus.Xíinbalil k’atunyaj
-CAMPESINO,"sus. J koolnáal, j koolkaab, j me"
-CAMPO,sus. K’áax. CANASTA TEJIDA CON BEJUCOS QUE SE UTILIZA EN
-LA COSECHA,sus. Xuxak
-CANCIÓN,sus. K’aay
-CANDADO,sus.K’aalab máaskab.
-CANDENTE,adj. Chakjole’en
-CANÍCULA,sus. Kin pek
-CANOA,sus. Cheem
-CANSAR,"v.i. Ka’anal, ka’anan"
-"CANTANTE, CANTOR","sus. Aj k’aay, ix k’aay."
-CANTAR,v.i. K’aay CARGAR
-CÁNTARO,sus. P’úul
-CANTIDAD,sus. Buka’aj.
-CANTIDAD CONCRETA,adv. de c. Tusinil
-CANTO,sus. K’aay.
-CANTO CÓMICO,sus. P’a’ast’aan k’aay
-CAÑA ÁSPERA,sus. Semet’
-CAÑA DE MAÍZ (MILPA DEL SEGUNDO AÑO EN ADE,
-LANTE),sus. Sak’ab
-CAÑA O TALLO DEL MAÍZ Y DE LA CAÑA DE AZÚCAR,sus. Sak’ab
-CAÑOTO (ARUNDO DONAX L),sus. Jalal
-CAOBA (SWIETENIA MACROPHYLLA (G KING)),"sus. Punab, ka’awakche’."
-CAOS,"sus. Xa’ak’, xa’ak’il."
-"CAPA, CAPOTE",sus. Suyen.
-"CAPACITAR, ENSEÑAR","v.t. Ka’anbesaj, ka’ansaj."
-"CAPITAL, DINERO",sus. Táak’in.¿Cuánto capital tienes? ¿Buka’aj táak’in yaanteech?
-CAPITANEAR,v.t. Jool poopintaj
-CAPTURAR,"v.t. Chukik, chukpachtik"
-"CARA, ROSTRO","sus. Ich, tán ich. CARACOL COMESTIBLE QUE VIVE EN LA ORILLA DE"
-LAGOS Y CENOTES,sus. K’awa
-CARACOL DE AGUA,sus. T’ot’
-CARACOL DE LOS JARDINES,sus. Úurich
-CARACOL MARINO,sus. Jub
-"CARACOL, ESPECIE QUE SE DA EN COZUMEL",sus.
-CARAPACHO,sus. Sóol
-CARBÓN,sus. Chúuk
-CARBONERO,sus. J tok chúuk
-CARCAJADA,sus. Awat che’ej
-CÁRCEL,"sus. K’aalab che’, t máaskab, k’aalab máaskab"
-CARCOMA DE LA SARNA,sus. Bibikankil
-CARDENAL,sus. Chak ts’íits’ib
-CARECER,"v.i. Mana’an, mina’an, sáap’al."
-CARGA,sus. Kuuch
-CARGADOR,"sus. Aj kuuch, j kuuch."
-CARGAR,v.t. Kuuch
-CARGA QUE SE LLEVA EN LA ESPALDA,sus. Kuuch
-CARGAR EN LA ESPALDA,v.t. Kuuch
-CARGAR EN LACABEZA,v.t. K’óoch.
-CARGAR EN EL HOMBRO,v.t. Paaj kuuchtaj
-CARGAR A HORCAJADAS,v.t. Jéets’ méek’.
-CARGAR COLGANDO,v.t. Ch’úuy.
-CARICIA,sus. Baay
-CARIDAD Y MERCED QUE SE RECIBE,sus. Yatsil
-CARNE,sus. Bak’
-CARNE HORNEADA EN LA TIERRA,sus. Píib
-CARNICERÍA,sus. U kúuchil kóon bak’.
-CARNICERO,sus. J kóon bak’
-CARO,adj. Ko’oj
-CARPINTERO,"sus. J póol che’, j xoot che’."
-CARRASPERA,sus. Sasak’ kaal
-CARRETA,"sus. Tsíimin che’, peten che’, suut che’"
-CARRETERA,sus. Noj beej.
-CARRETERA PETROLIZADA,sus. Yuyul beej.
-"CARRILLO, POLEA",sus. Balak’
-CARRIZO,"sus. Jalal, siit"
-CARTA,"sus. K’uben t’aan, túuxtaj t’aan, chi’t’aan, ts’íibil ju’un."
-CASA,"sus. Naaj, otoch, taanaaj, nay."
-CASA RÚSTICA QUE SE HACE EN LA MILPA PARA RE,K’uche’
-FUGIO,sus. Pasel.
-CASADO,adj. Ts’o’oka’an u beel
-CASA REAL,sus. Tepalil
-CASAMIENTO,sus. Ts’o’sklabeel
-CASCABEL DE LA VÍBORA,sus. Tsáab
-CASCAR,"v.t. Buuj, tej"
-CASCAR Y ROMPER SU CASCARÓN EL POLLITO,v.t. Ts’ej
-CÁSCARA,sus. Sóol
-CASCO DE CABALLO,sus. May
-CASI,adv de m.
-CASINO,sus. Naajil buul.
-CASPA,sus. Chab.
-"CASPA, ROÑA",sus. Sóok’.
-CASTA,sus. Ch’i’ibal.
-CATELLANO,sus. Kastlan t’aan.
-CASTIDAD,sus. Okol k’u
-CASTIGAR CON RIGOR,"v.t. Yaya ts’ektaj  t’aan, kastelan"
-CASTIGO,"sus. Xoot óol, bo’olal, nolche’."
-CASTIGADO,sus Aj mak pachtaj.
-CASTILLO,"sus. Pa’, tulum"
-CASTRAR,v.t. Pets’ toon
-CATARATAS,sus. Sak t’aj
-CATARRO,sus. Se’en
-CATÁSTROFE,sus. Kal numya
-CATORCE,sus. Kanlajun
-"CAUDAL, RIQUEZA",sus. Ayik’alil
-CAUDILLO,sus. Jo’ol poopi’
-CAUSA,"sus. Chuun, uchbal"
-CAUSA DE RUINA,sus. Naak’an óotsilil.
-CAUTELOSO,adj. Aj na’at ach
-CAUTERIZAR,v.t. Chuuchuujik
-CAUTIVO,"sus. Baksaj, kuuch chimal"
-CAVAR,v.t. Páan.
-CAVERNA,"sus. Áaktun, jom áaktun"
-"CAVIDAD, FOSO",sus. Bekan
-CAZADOR,sus.J ts’oonnáal.
-CAZAR,v.t. Ts’oon.
-CEBOLLA (ALLIUM CEPA L),sus. Kukut
-CEDRO (CEDRELA MEXICANA (M ROEMER)),sus.
-"CÉFIRO, VIENTO SUAVE",sus. Juyuknak iik’ CEIBA (CEIBA PENTANDRA (L. GAERTH)) .
-CEJA,sus. Mo’ojtun
-"CELDA, CUARTO",sus. Tunk’as
-CELEBRACIÓN,sus. K’iinbesaj
-CÉLEBRE,adj. Tsikbe’en.
-CELO,sus. Noj yail.
-CELOSA,adj. Ix sawinil.
-CELOSO,adj. Aj sawinil.
-CELOSÍA,"sus. Selesum, tsats tun"
-CEMENTERIO,"sus. Sujuy lu’um, tan múuknal, kúuchil múuknalo’ob, x kojolte’"
-CENA,sus. Áak’ab janal
-CENAGAL,sus. Ts’aats’
-CENIT,sus. Chúumuk ka’an
-CENIZA,sus. Ta’an
-CENOTE,sus. Ts’ono’ot
-CENTINELA,"sus. Aj ch’a’a beej. Aj pikit be, Aj"
-CERRAR LA LA BOCA,v.i.Nuup’ a chi’.Maak a CINTURA naajil toj óolali’.
-CERRO,"sus. Buk’tun, múul, pu’uk, wiits,"
-CENTRO,"sus. Chúumuk, ts’u’."
-CENTRO DE LA POBLACIÓN,sus. Chúumuk kaaj.
-CENTRO DE LA POBLACIÓN,sus. K’íiwik
-CENTRO DE SALUD,"sus. U najil ts’aak yaaj, u"
-CENZONTLE,sus. Sak chiik
-CEÑIRSE,v.i. Jíich’il
-CEPILLAR PARA QUITAR EL POLVO,v.t.Púus.
-CEPILLAR MADERA,"v.t. Jo’och, súus."
-CEPILLAR LOS DIENTES,v.t. Ja’koj.
-CERA,sus. Kib
-CERA MUY PEGAJOSA,sus. Lolok
-CERA VIRGEN,sus. Sujuy chaalij yik’el kaab.
-CERCA,"adv. de l. Naak’, naats’"
-CERCA DE LA MILPA,sus. Nok ch’áak
-CERCAR,v.t. Bak’ paach
-"CERCAR CON PALOS, RAMAS O ÁRBOLES SEMICORTA",
-DOS,v.t. Suup’.
-CERCENAR,v.t. K’up.
-"CERCENAR, CORTAR DE RAÍZ, EMPAREJAR",v.t. Muus.
-CERDO,sus. K’éek’en
-CEREBELO,sus.X tuchts’o’om.
-CEREBRO,sus. Ts’om
-CEREMONIA AGRARIA PARA IMPLORAR LLUVIA,sus. Ch’a’ cháak CEREMONIA EN QUE SE CARGA POR PRIMERA VEZ
-A HORCAJADAS SOBRE LA CADERA A UN NIÑO,sus. Jéets’ méek’
-CEREMONIA PARA BENDECIR EL CORRAL,sus. Loj k’aalche’ wakax.
-CERILLO,sus. Jiri’ich joop
-CERNIR ENTRE LOS DEDOS,"v.t. Xíit, xíixt"
-"CERNIR, COLAR",v.t. Máay.
-"CERRAR, ENCERRAR, ENJAULAR","v.t K’aal, k’aalik,"
-CERRAR LA PUERTA,v.t. K’aal le joonaj.
-CERRAR EL PASO,v.t. Mak beej
-CERRAR LOS OJOS,"v.i. Muuts’ a wicho’ob, ch’oot. muuts’."
-CERRAR EL CAMINO,v.t. Nuuts le bejo’.
-CERRAR LA OLLA,v.t.Maak le kuumo’.
-CERRAR UN CANDADO O CERRADURA,v.t. chi’. Ch’óotol. mulu’uch.
-CERVIZ,sus. Kulkaal
-CESAR,"v.t. Jáaw, jáawal"
-CESTA,"sus. Xáak, xúuxak"
-CESTO,"sus. Xáak, xúuxak"
-CICATERO,adj. J ts’u’ut
-CICATRIZ,"sus.Chakax, cheek"
-"CÍCLICO, SERIE",adj. Wuts’
-CICLÓN,"sus. Chak íik’, molay íik’"
-CIEGO DE CATARATA,"sus. Aj buy. CIEGO QUE TIENE LOS OJOS CLAROS, MAS NO VE CON"
-ELLOS,sus. Éek’ may
-CIELO,sus. Ka’an. CIELO AMARILLENTO QUE TRAE LLUVIA CALIENTE
-QUE CAE EN AGOSTO Y QUEMA LOS CULTIVOS,sus. K’ank’ubul
-CIEN,sus. Jo’o k’aal
-CIÉNAGA JUNTO AL MAR,sus. Uk’um
-CIGARRA QUE CANTA DE NOCHE Y ANUNCIA LLUVIA,"sus. Ch’och’elem, ch’och’lin."
-CIGARRA QUE CANTA DE DÍA Y ANUNCIA SEQUÍA,sus.Ts’ay k’iin.
-CIGARRO,sus. Chamal
-CIERTO,adv. de afirmación. Jaaj
-CIMENTAR,v.t. Ak kunaj
-CIMIENTO,"sus. Tsek, buk’tun, chuun."
-CINCO,sus. Jo’o. Cinco mujeres : Jo’otúul : Jo’op’éel ko’olelo’ob. Cinco piedras tuunicho’ob. Cinco velas : Jo’o ts’iit kibo’ob. Cinco árboles de ceiba : Jo’o kúul ya’axche’ob.
-CINCUENTA,sus. Lajun p’éel ti’ óox k’aal
-CINEMATÓGRAFO,sus. Péeksoochelsáasil
-CINTA,sus. K’aax
-CINTILAR,"v.i. Jopba, lets’bal"
-CINTURA,sus. Ui’it’il
-CINTURÓN,sus. K’aax nak’
-CÍRCULO,"sus. Ba’al wóolis, pet."
-CIRCUNCISIÓN,"sus. Suy k’up, Suy k’upil (CORDIA DODECANDRA D.C.)."
-CIRUELA ( SPONDIAS MOMBIN L (SPONDIA LUTEA)),K’óopte’ sus. Abal
-"CIRUELA SECA AL ASOLEARSE, UTILIZADA PARA HA",
-CER DULCE QUE SE OFRENDA A LOS DIFUNTOS,sus. K’ulin.
-CISTERNA HECHA POR LOS MAYAS PREHISPÁNICOS,
-CIUDAD,sus. Noj kaaj.
-CIZAÑA,"sus. A’al t’aan , líik’saj t’aan, a’alaj sus. Chultun ba’al."
-CIZAÑERO,"adj. J a’al t’aan, j líik’saj t’aan."
-CLARABOYA,sus. Kisneb
-CLARIDAD,sus. Sáas
-CLARÍN,"sus. Jom CLARINERO, DIVES DIVES (LICHTENSTEIN)TORDO"
-NEGRO CANTADOR,sus. Aj pich’
-CLAROSCURO,sus. Sáasbal kaab.
-CLARO QUE SÍ,adv. de a. Binmaake’
-"CLASE, SESIÓN DE TRABAJO ESCOLAR",sus. Xook CLAVADAS O HINCADAS LAS PUNTAS COMO FLECHAS
-"O ESPINAS, COSA FUNDADA Y ASENTADA",adj. Ch’ika’an
-CLAVAR,"v.t. Baj, ts’oop."
-CLAVARSE,v.i. Ts’oop.
-"CLAVAR, SEMBRAR, PRENDER",v.t. Ch’iik.
-CLAVAR VARIAS VECES ALGO,v.t. Ba’abaje’.
-CLAVARSE DE PUNTA,v.i. Ch’iikil
-CLAVÍCULA,sus. J nutsp’ep’o’ob.
-CLAVO,sus. Xolob COA (INSTRUMENTO CORTANTE DE HIERRO CON FORMA
-"CURVA Y MANGO DE MADERA, SIRVE PARA DESYER",
-BAR),"sus. Lóobche’, loo’che"
-COAGULAR,v.i Olmal
-COBARDE,"adj. J sajlu’um, oyonta’achil."
-"COBERTOR, COBIJA",sus. Teep’
-"COBIJAR, TAPAR, CUBRIR,",v.t. Teep’
-COCER,v.i. Tajal 
-"COCERSE, SAZONAR",v.i. Tak’al.
-COCIDO,adj. Tak’an
-COCINA,sus. K’óoben
-COCINERA,sus. Ix meen janal.
-COCINERO,sus. Aj meen janal
-"COCHINO, MARRANO, CERDO",sus. K’éek’en.
-COCOYOL (ACRONOMIA MEXICANA (KARW)),sus. Tuk’
-CODO,sus. Kúuk
-CODORNIZ,sus. Beech’
-COGER,v.t. Ch’a’b
-COGOLLO,"sus. Yol, wii’"
-"COGOTE, PARTE SUPERIOR Y POSTERIOR DEL CUE",LLO. – sus. Paachka’
-"COHETE, VOLADOR",sus. Eelnak báaxal.
-COITO,"sus. Ts’iis, paklam, taal, toop, naach’"
-COLA,sus. Nej. COLA NEGRA (OFIDIO DE GRAN TAMAÑO QUE DEVORA
-A OTRAS SERPIENTES MAYORES QUE ELLA SE LE CO,
-NOCE COMO LA REINA DE LAS SERPIENTES),sus. Éek’uneil
-COLABORAR,v.t. Áantaj.
-COLABORADOR,sus. Aj áantaj.
-COLADOR,sus. Cháachab
-COLAR,v.t. Máay.
-COLGAR,"v.t. Ch’úuykins, ch’úuykint."
-"COLGAR, TRABAR",v.t. Leech.
-COLGARSE,v.i. Lechtal.
-"COLGADO, HOLGADO",adj. Pojpoj.
-COLGADO DE ALGO VARIAS VECES,adj.Léele’ech.
-COLIBRÍ,sus. Ts’unu’un
-COLILLA DE CIGARRO,sus. Xotem
-COLMENA,sus.U naajil kaab.
-COLMILLO,sus. Ts’a’ay
-"COLOCAR, PONER","v.t. Ts’aa, ts’áaj, ts’ik."
-COLOR,"Lágab, boon."
-COLOR DE FUEGO IGNEO,adj. Chakjole’en
-COLUMNA DE CONSTRUCCIÓN,"sus. Okom tuun, okom tuunich."
-"COLUMNA , FILA, LÍNEA","sus.T’o’ol, t’o’olol."
-COMADREJA,sus. Sáabin
-COMAL,sus. Xamach
-COMARCA,"sus. Kuchkabal, petén"
-COMBATE,sus. K’atunyaj
-COMBATIR,"v.t. Ba’ate’el, p’is, p’isba"
-COMEJÉN,sus. K’amas
-COMELÓN,sus. Aj báamban janal
-COMENTAR,v.t.Tsikbal.
-"COMENTARIO, NOTICIA",sus.Péeksil.
-COMENZAR,"v.t. Chumbesik, chuna’an, chunbesaj, chúunpajal, jop’, jo’op’ol, káa"
-COMENZAR ALGÚN TRABAJO,"v.t. Xip, chunsej."
-COMENZAR EL ÁRBOL A CARGARSE DE FRUTOS,v.i. Chojba
-COMER,v.i. Janal.
-COMER A MORDISCOS,v.i. Níich’.
-COMER SIN ÁNIMO,v.i.Nées.
-"COMER SIN MASTICAR, COMER APRESURADAMEN",
-TE,v.i. Maak’
-COMER GRANOS SECOS,v.t. K’uux.
-COMER A CADA RATO,v.t.Báamban janal.
-COMERCIANTE,"sus. Aj p’olom, j kóonol"
-COMERCIO,sus. P’olmal
-COMETA,sus. Buts’ eek’
-COMEZÓN,"sus. Saak’, saak’il."
-"COMEZÓN, MUCHA COMEZÓN",sus. Sa’asaak’
-COMIDA,"sus. O’och, janal, janaj, janalbe’en."
-COMIENZO,sus. Chúusa’al
-CÓMO ES,pron. rel. Bixi
-COMO,adv. de m. Bey
-COMO,conj. comp. Bix
-COMPADRE,sus. Et yuum
-COMPAÑERO,"sus. Etóol, nuup, nuupul, éet, batsil."
-COMPAÑÍA,sus. Láak’ankil
-COMPARACIÓN,sus. Etjun t’aan
-COMPARAR,"v.t. Ketbesik, etjun t’aan."
-COMPARECER,v.i. Suukab
-COMPARTIR,v.t.Páay óoltik
-COMPASIÓN,"sus. Ok’ol ich, ch’a’ óotsilil"
-COMPATRIOTA,sus. Et kaajal
-COMPLETAR,"v.t. Chukbes, chúukbesaj"
-COMPLETO,"adv. de c. Chúuka’an, páanche’, pak lis CINFORTAR"
-COMPONER,"v.t. Utskíinsik, utskins."
-COMPRAR,v.t. Maan
-COMPRENDER,v.i. Na’at.
-COMPROBAR,v.t. Táan óolte.
-COMUNICAR,v.t. A’al.
-COMUNIDAD,sus.Kaaj.
-CON,conj. cop. Yéetel
-CON,prep. Ti’
-CON BUENA VOLUNTAD,adv. de m. Ki’ki’
-CONCLUIR,"v.t.Ts’o’okol, ts’o’oksaj."
-CONCUBINA,sus. Weey
-CON DIFICULTAD,adv. de m. Istikia
-CONDIMENTO,sus. Xa’ak’.
-CONFIANZA,"sus. Jets’ óol, ts’aa óol."
-CON FLUJO SUAVE LAS AGUAS,adv de m. Yiyibki
-CON FRECUENCIA,adv. de t. Bukyaj
-CON PERFECCIÓN,adv. de m. Ki’ki’
-"CON, EN COMPAÑÍA",adv. de m. Wéet
-CONCEDER,v.t. Silk’a
-CONCERTACIÓN,sus. Ts’a t’aantanba.
-"CONCERTAR,, TOMAR ACUERDO","v.t. Ak kunaj, Ch’a’ t’aanil."
-CONCERTAR EL PRECIO,v.t. Chimtaj
-CONCERTARSE,v.t. K’aax t’aan
-CONCLUIR,"v.t. Jáawal, jaw, jepajal óol"
-CONCORDAR,v.t. Ketbesaj
-CONCHA DE MAR,sus. Xixim
-CONDENA,sus. Yaya xoot k’iinil
-CONDENACIÓN,sus. Yaya xoot k’iinil
-CONDENADO,sus. Aj bo’ol k’eban
-CONDENAR,v.t. Yaya tse’ ktaj
-CONDIMENTOS,sus. Xa’ak’
-CONEJA,sus. Ch’úupul t’u’ul
-CONEJO,sus. Xiibil t’u’ul
-CONFEDERARSE,v.t. K’aax t’aan
-CONFESAR,"v.t. A’al k’eban, p’aa chi’"
-CONFIANZA,sus. Alab óol
-CONFIAR,v.t. Alab óoltaj
-CONFIAR EN OTRO,v.t. Alkunaj óol
-CONFIDENTE,sus. Nup t’aan
-CONFIRMAR,v.t. Jaajkuntik
-CONFORTAR,v.t. Kuxkintaj óol
-CONFUNDIR,v.t. Lam.
-CONFUNDIRSE,v.i. Lamal.
-"CONFUSIÓN, DESCONCIERTO",sus. Jub t’aan
-CONGREGARSE,v.i. Bantal
-CONGRUENCIA,sus. Najil
-"CONJUNTO,EJÉRCITO, REBAÑO, ENJAMBRE","sus. Molkab, Molkabil."
-"CONJURO, HECHIZO, ENCANTAMIENTO",sus. Ku
-CONCIENCIA,sus.Sajak puksi’ik’il
-CONMIGO,pron. Tin wéetele’
-CONO,sus. Wóolis p’ich
-CONOCER,"v.t. K’a óol, k’ajóol, ojelt, ojel"
-CONOCIMIENTO,"sus. K’aj óolal, k’ajóolo, yits’atil."
-COMPLACENCIA,sus. Núukbesaj.
-CON QUE,prep. Likil
-CONQUISTA,sus. Baksajil.
-CONSAGRADO,adj. K’uyenkunsa’ab
-CONSAGRAR,v.t. K’uyenkunsaj
-CONSEJERO,sus. Aj otlom kabal
-CONSEJO,"sus. A’almajxikin, molay aj kano’ob"
-CONSIDERACIÓN,sus. Tumut
-CONSIDERAR,v.i. Mana óol
-CONSIDERAR,v.t. Nen óol
-CONSOLAR,"v.t. Baytaj, kuxkintaj óol"
-CONSOLARSE,v.i. Toj jal óol
-CONSOLIDAR,v.t. Táak muk’ pajak
-CONSTANTE,adj. K’uchpaja’an yóol
-CONSTANTEMENTE,adv. de t. Jun tiich’
-CONSTELACIÓN,sus. Tsool eek’o’ob CONSTELACIÓN DE TRES ESTRELLAS QUE ESTÁN EN
-EL SIGNO GÉMINIS,sus. Áak eek’
-CONSTRUIR,"v.t. Meent, beet."
-CONSUEGRO,sus. Jachil
-CONSULTAR,v.t. K’áat chi’.
-CONTAGIO,"sus. Taak’, paak’."
-CONTAGIOSO,adj. Paak’be’en.
-CONTAR CUENTOS,v.t. Tsikbal.
-CONTAR,v.t. Bak’ xook.
-CONTAR MENTIRAS O CHISMES,v.t. Líik’saj t’aan 
-CONTAR NÚMEROS,v.t. Xook.
-CONTEMPLAR,"v.t. Cha’ant, nen óol"
-CONTENER ALGUNA COSA,v.t. Balinaj
-CONTENTO,"sus. Ki’ ki’ óolal, ki’imak óol."
-CONTERRÁNEO,sus. Et kaajal
-CONTESTAR,"v.t. Núuk, núuk t’aan."
-CONTESTAR MAL,v.t. Núunuuka.
-CONTESTACIÓN,sus. Núukbesaj.
-CONTIENDA,sus. Ok yail
-CONTIGO,"pron. Ta wéetel, ta wéeteli’."
-CONTINUAR,"v.i. Bayjal, bayli’"
-CONTINUARSE,v.i. Malel k’iin
-CONTRA,"prep. Ta wok’ol, tu nup"
-CONTRACCIÓN,sus. Motsa’anil.
-CONTRACORRIENTE,adv. Tu nup nix.
-CONTRALUZ,sus. Nup sáasil.
-CONTROLAR,v.t. Pets’
-CONVENIENTE,adj. Yalpak’a
-CONVENCIDO,adj. Oyan óol.
-CONVERSACIÓN,sus. Tsikbalile’
-CONVERSAR,v.t. Tsikbal
-CONVICTO,adj. Oksaja’an óol ti’
-CONVIDAR,v.t. Chaybesaj
-CONVOCAR,"v.t. Tsabaj, molaj, t’aanaj"
-CÓNYUGE,sus. De la mujer : íicham ; del hombre : atan.
-COORDINACIÓN,sus. Tsool
-COPAL (PROTIUM COPAL (ENGL)),sus. Pom
-COPETE,sus. P’oot.
-COPIAR LO ESCRITO,"v.t. Joch, ts’íib, ka’a ts’íib."
-COQUETA,adj. X ken k’oj
-CORAJE,"sus. Lep’ óol, lep’óolal"
-CORAZÓN,sus. Puksi’ik’al
-CORDILLERA,sus. Bolon wits
-CORMORÁN,sus. Bich’
-CORNEAR,v. K’óoch
-CORNETA,sus. Jom
-CORNIZUELO ( ACACIA CORNIGA (WILLD)),sus. Su
-CORO,sus.Múuch’ k’aay.
-CORONA,"sus. K’aax jo’ol, nak, pet jo’ol"
-CORONA DE CLÉRIGO,sus. Pet
-CORONILLA,sus. Suy jo’ol
-COROZO (ATTALEA COHUNE (MART),"sus. Ch’unkuy, muklil"
-"COSA CLARA, MANIFIESTA, PATENTE",sus. Ma’ mop
-CORPIÑO,sus.Láat’ab iimo’ob
-CORRAL,sus. Pak’ tuunil wakax
-CORRECCIÓN,sus. Xoot óol
-CORRECTAMENTE,Adv de m. Tu beel.
-CORREO,sus. Mukul tuchiil ts’íib
-CORREOSO,adj. Ts’u’uy
-CORRER,v.i. Áalkab
-"CORRESPONDE, SER DE SU INCUMBENCIA",sus. Lay
-"COSA COLMADA, QUE POR ESTAR MUY LLENA SE DE",
-RRAMA,sus. Tutul nak
-COSA CONCERTADA,"adj. Keta’an, ketbesaj."
-COSA CURVA Y VUELTA COMO GARFIO,sus. Pakax ye
-COSA DADA A DIOS Y CONSAGRADA,sus. K’uya’an
-COSA DIBUJADA,sus. Ts’íiben ts’íib
-COSA DIFÍCIL,"sus. Talam, toop."
-COSA DIGNA DE SER CONSIDERADA,sus. u t’aanul. Lumtabe’en.
-CORRIDA DE TOROS,sus. Paywakaxil
-CORRILLO,sus. Múuch tsil
-CORTAR CON CUCHILLO O SERRUCHO,v.t. Xoot
-"CORTAR, DIVIDIR, PARTIR",v.t. Xoot’.
-CORTAR CON GOLPE DE HACHA O MACHETE,v.t. Ch’áak Ch’áach’áak. Ch’áach’áakbil
-CORTAR EN PEDAZOS CON HACHA O MACHETE,v.t.
-CORTADO EN PEDAZOS CON HACHA O MACHETE,adj.
-CORTAR CON TIJERAS,v.t. K’oos.
-CORTAR O MAL CORTAR REPETIDAMENTE CON TIJE,
-RAS,v.t. K’óok’oos.
-CORTE DE CAÑA DE AZÚCAR,v.t. Paak sak’ab.
-CORTÉS,adj. Uts
-CORTESÍA HECHA INCLINANDO LA CABEZA,sus. Chíin pool
-"CORCHAR, HILAR",v.t. Jaax.
-CORTEZA,sus. Sóol
-CORTO,adj. Kóom
-CORVA DE HIERRO,sus. Loch máaskab
-CORVA DE MADERA,sus. Loch che’
-COSA,sus. Ba’al
-COSA ARDIENDO,adj. T’aba’an
-"COSA ARRASTRADA, HOLLADA, MUY SUCIA",adj. Ki’irits’.
-COSA ASENTADA,sus. Ets’a’an
-COSA BUENA Y VIRTUOSA,sus. Tibil
-COSA CARA,sus. Ko’oj u tojol
-COSA CLARA Y MANIFIESTA,sus. Ajajbil
-COSA DIVINA,"sus. K’uyen, k’ul."
-COSA ENCENDIDA,adj. T’aba’an
-COSA ENREDADA (COMO LOS CABELLOS),sus. Tsu’uy
-COSA EXTRAÑA E INCREÍBLE,adj. Maktsil
-COSA FALSA,sus.Ba’al ma’ jaaji’
-"COSA FIJA, QUE NO SE MENEA",sus. Babanki
-COSA FIRME,sus. Ets’a’an
-COSA FIJA,sus. Ets’a’an
-COSA GORDA,sus. Nuk
-COSA GRUESA,"sus. Nuk, piim."
-COSA HARTA,adj. P’up’ulki
-COSA HINCHADA,adj. Chup
-COSA HONRADA,adj. Tilis
-COSA ILUSTRE,adj. Tilis
-COSA HECHA DE CORAZÓN,sus. Olbil
-COSA HORRIBLE QUE CAUSA PAVOR,sus. Tibibt
-COSA HUECA,sus. Ma’ba’l
-COSA HUNDIDA EN EL HORIZONTE,adj. Lam
-COSA INFINITA,adj. Cheket
-COSA INNUMERABLE,adj. Cheket
-COSA LABRADA,sus. Winkilis
-COSA LADEADA,sus. Tsela’an
-COSA LARGA Y FRÁGIL,sus. K’ajlakum
-"COSA LEJANA, QUE ESTÁ MUY APARTADA",adj. Lam
-COSA LLAMADA,sus. Paybil
-COSA MARAVILLOSA,adj. Maktsil
-COSA MELLADA,adj. P’eja’an
-COSA PINTADA,"sus. Ts’íiben ts’íib, winkilis"
-COSA PROVECHOSA Y NECESARIA,sus. Ma’kenlik
-COSA QUE ANDA ACOMPAÑADA,sus. Lak’alak
-COSA QUE ES LLAMADA,adj. Paya’an
-COSA QUE ESTÁ OFRECIDA,adj. Siibil
-COSA QUE SE ESCONDE,sus. Balaknak
-COSA QUE SE HA TROCADO POR OTRA,sus. K’exa’an
-COSA QUE SE RECIBE,sus. K’ambe’en
-COSA REAL,adj. Ajawiil
-COSA REPLETA,adj. P’up’ulki
-COSA RESPETABLE Y HONESTA,adj. Talan
-COSA SAGRADA,"sus. K’ul, k’uyen"
-COSA SOLEMNE,adj. Tilis
-COSA TERRIBLE,sus. Tibantsil
-COSA UNIVERSAL QUE LO COMPRENDE TODO,sus. Yuk’
-COSA VACÍA,sus. Ma’ba’l
-COSA VENERABLE,adj. Tilis
-COSA VOLUNTARIA,sus. Olbil
-COSECHAR ELOTES,v.t. Jooch.
-COSECHAR FRUTOS,"v.t. T’ook, éemsaj."
-COSER,v.t. Chuuy
-COSMOS,sus. Balkaaj
-COSMOGONÍA,sus. Tsikbal yóok’ol balkaaj.
-COSTA,"sus. Jáal ja’, chi’"
-COSTADO,adv. de l. Tséel.
-COSTADO,"sus. Tsel, tselil"
-COSTAL,"sus. Ba’al, mukuk, nasa."
-COSTEAR,v.t. Tojolt
-COSTILLA,sus. Ch’ala’at
-COSTO,sus. Tojol
-COSTUMBRE,"sus.Suuk, suukil, suukbe’en."
-COSTURA,sus. Chuuy
-"COSTURAR, COSER, BORDAR",v.t. Chuuy
-COXIS,"sus. K’uul, bobox"
-CRÁNEO,sus. Tséek’
-"CREADOR, DIOS",sus. Aj Síijsajul.
-CREADOS,adj. J síijsa’ab
-CRECER EL HOMBRE,v.i. Ch’iil
-CRECER,"v.i. Nojochtal, ch’íijil"
-CRECIDO,adj. Ch’íija’an 
-CREENCIA,"sus. Ok óolal, oka’an óolal"
-CREER,"v.i. Tuukul, oksaj óoltik."
-CREER,v.t. Oksaj óol.
-CREENCIA,"sus.Oksaj óol, ok óoltik."
-CREER,v.i. Táan óolte.
-CREPITACIÓN,sus. Wawak’il
-CREPÚSCULO,sus. Okol k’iin
-CRESTA,sus. P’iich
-CRÍA DE AVES O DE CUALQUIER ANIMAL CUADRÚPE,
-DO,sus. Pakab
-CRIADO,"sus. (m) J k’oos, (f) X k’oos."
-"CRIAR, ALIMENTAR","v.t. Tséem, tséent"
-CRISTAL DE ROCA,sus. Nenus.
-CROAR,v.i. Awat muuch
-CRUCIFICADO,sus. Aj simsim che’
-CRUCE,sus. Xa’ay
-CRUDO,"adj. Che’che’, ma’ tak’ani’, chéecheb."
-CRUEL,adj. J kalbach.
-CRUELDAD,sus. Tachi’achil
-CRUELDAD EXCESIVA,sus. Kalbach
-CRUJIR,"v.i. Jech’,jíirich’, wáak’ach."
-CRUZ,sus. K’atab che’.
-CRUZADO,adj. K’atakbal.
-CRUZAR,v.t. K’aat.
-CUADRADO,sus. Amayte’.
-"CUADRÚPEDO DEL TAMAÑO DE UN PERRO, DE CO",
-"LOR NEGRO, HABITA EN LAS CAVERNAS",sus. E’e muuch.
-CUÁL,pron. rel. ¿Máakalmáak?
-CUALQUIER ANIMAL,sus. indef. Na’kjal
-CUALQUIERA,pron. indef. Je’ máaxak Je’
-"CUAJAR, COAGULAR",v.i. Olmal
-"CUAJADO, COAGULADO",adj. Olmalja’an.
-CUÁNDO,"Interrogación. Ba’ax k’iin, bik’iin, bik’ix"
-CUANDO,"adv. Kéen, káan"
-CUÁNTO,"adv. de c. Bajux, bajun ¿CUÁNTOS ANIMALES O adv.¿Jaytúul? ¿CUÁNTOS OBJETOS?."
-CUARENTA,sus. Ka’a k’aal
-PERSONAS?,le ba’alo’ob
-CUARTA,sus. Náab
-"CUARTEADO, MUY CUARTEADO",adj. Xíixi’ik.
-CUARTO,sus. Tunk’as
-CUATRO,sus. Kan. Cuatro mujeres: Kantúul ko’olelo’ob. Cuatro piedras: : Kanp’éel tuunicho’ob. Cuatro velas: : Kan ts’iit kibo’ob. Cuatro árboles de ceiba : Kan kúul ya’axche’ob.
-CUBETA,sus. Ch’óoy
-"CUBRIR, TAPAR","v.t. Bal, bo’oybesaj, piix,"
-CUCARACHA,"sus. K’uuluch, x k’úuruch"
-CUCHARA,"sus. K’ab kum CUCHAREAR, COMER CON LA CUCHARA."
-CUCHICHEAR,v.i. X muukult’aan
-CUCHICHEO,v.i. Tutukchi’
-CUCHILLO,"sus. Xooteb, xootob"
-CUELLO,sus. Kaal.
-CUENTA,"sus. Xookil, xookul"
-CUENTA EN GENERAL,sus. Buk’xookil
-CUENTERO,"sus. Aj kansiyaan, tsikbali máak."
-CUENTO,"sus. Jajal t’aan, jujub kan, weyil t’aan, tsikbal, xookil, tuusil t’aan, tuus tsikbal, tsikbal tuus, popolt’aan."
-CUERNO,sus. Baak.
-CUERNO DE VENADO O DE OTRO ANIMAL,sus. Xu
-CUERO,sus. K’éewel
-CUERPO,"sus. Wíinklil, kukutil, wíinkil"
-CUEVA,sus. Jomlil ¡CUIDADO!.
-"CUIDAR, PROTEGER","v.t. Kanáant, kaláant, ka"
-CULEBRA,sus. Kaan CULEBRA QUE ATACA Y ENGULLE A SU VÍCTIMA COMO
-BOA,sus. K’aaxab yuuk
-CULEBRA QUE TRAGA A OTRAS,sus. Tsel kaan.
-CULEBREAR,v.i. Bik’chalák
-CULPA,"sus. Si’ipil, k’ochil."
-CULPABLE,sus. Aj k’ocha’n
-CULPADO,sus. Aj k’ocha’n
-CULPAR,v.t. K’óochbesaj.
-"CULTO, VENERACIÓN",sus. K’áat óolal.
-CULTURA,sus. Miatsil
-"CULTO, SABIO, DOCTO","adj. Aj miats, j miats."
-CUMBRE DE UNA ALTURA,sus. Ni’
-CUMPLEAÑOS,sus. K’iin k’aaba’
-CUMPLIR,"v.i. Bojol t’aan, chukbesaj"
-CUMPLIRSE EL PLAZO,v.i. Je’ep’el
-CUÑADA,"sus. Muil, mu’il, múu, x"
-CUÑADO,sus. Baal.
-"CURA, MEDICAMENTO",sus. Ts’aak.
-CURANDERA,"sus. Ix ts’aak, x ts’aak"
-CURANDERO,"sus. Aj ts’aak, j ts’aak"
-CURAR,v.t. Ts’aak
-"CURIOSIDAD, MAÑA, INGENIO NATURAL",sus. Its’atil
-CURSO,"sus. Belili’, beelil"
-CURVA,sus. Ka’lop.
-CURVA O VUELTA,sus. Wats’
-"CURVEADO, MUY CURVEADO",adj.K’éek’eech.
-CURVEAR,v.i. P’uum.
-CHACHALACA (ORTALIS),"sus. Baach, koba’"
-CHAPARRO,". sus. Aj kaabaj, j kiis lu’um."
-CHAPEAR,v.t. Jaran ch’áak.
-CHAPOTEAR,"v.t. Bok’ol ja’, bok’ol naktik."
-CHARAL,sus. Tsak’.
-CHARCO,"sus. Chulub, temanja’, ja’akakbal. CHAYA (EUPHORBIACEAE (CNIDOS COLUS CHAYAMANSA (MC"
-VAUGH)),. sus. Chay. CHAYOTE (SECHIUM EDULE (JACQ) SWARTZ) .
-CHICLE,"sus. Sikte’, cha’"
-CHICO,"adj. Chichan, chan, mejen."
-CHIFLAR,v.i. Xuuxub
-CHILE (CAPSICUM ANNUUM CASPSICUM SPP),sus. Iik
-CHILE ROJO QUE SE SECA AL SOL,sus. Chak iik
-CHILLAR,v.i. Awat
-CHINCHE,sus. Kisil
-CHISME,"sus. A’al t’aan, líik’saj t’aan, tak"
-CHISMOSO,"sus. (m) Aj a’al t’aan, (f ) Ix a’al t’aan. t’aan."
-CHISPA,"sus. Tip’ix k’áak’, p’ilis, xikin k’áak’"
-CHISPAS DEL HERRERO,sus. P’ilis k’áak’
-CHISPORROTEAR,v.i. Tip’ix.
-CHISTE,"sus. Báaxal t’aan, che’ej t’aan."
-CHOCOLATE,sus. Chukwa’
-"CHORREAR, MANAR",v.i. Chooj.
-"CHUPAFLOR, COLIBRÍ",sus. Ts’unu’un
-CHUPAR,v.t. Chu’uch
-DADOS,sus. Baakil buul
-DAMA,"sus. Xunáan, ko’olel"
-DAÑADO,adj. Loobkinan
-"DAÑAR, HERIR",v.t. Loob
-DAÑO,sus. Loob
-DAÑO MUY GRANDE,sus. Noj loob.
-DAR,"v.t. Tich’, ts’áaj, ts’ik."
-"DAR DE COMER, MANTENER",v.t. Tséen.
-DAR EJEMPLO,v.t. Joch jaban
-DAR EL PASO,v.t. Xáak’abt
-DAR FRUTOS,v.i. Iichankil.
-DAR LIMOSNA,v.t. Ts’áaj yatsil.
-DAR NOTICIA,v.t. Num chi’
-DAR ORDEN,v.t. Ts’áaj u tumutil
-DAR PRINCIPIO,v.i. Belbesaj
-DAR REVUELCOS Y RODAR,v.i. Kukchalankil.
-DAR SOMBRA,v.t. Bo’oybesaj
-DAR SU BENEPLÁCITO,v.t. Ts’áaj óol
-DAR SU CONSENTIMIENTO,"v.t. Ts’áaj óol, éeje"
-DAR TESTIMONIO,v.t. Jalkunaj
-DARDO,sus. Juul
-DE (para interrogar),Tu ba
-DE,prep. Ti’
-DE ABDOMEN PROMINENTE,"sus., adj. P’urux nil. nak’."
-DE ALGUNA PARTE,adv. de l. Lik’ul
-DE ANTES,adv. de t. Ka’ach
-DEBAJO,prep. Yáanal.
-DEBAJO,adv. de l. Yáanal.
-"DEBER, OBLIGACIÓN",sus. Unaj.
-"DEBER, DE DEUDA",v.t. P’aax.
-DEBE SER,Unaj
-DÉBIL,"adj. T’ona’an, ma’ muuk’il, ma’ t’a’aji’."
-DE CABEZA,adj. Chíinchinpool
-DE CADA DÍA,adv. de t. Ti’ amalk’iinil
-DE CAMINO,adv. de t. Jun k’uli’
-"DECANTAR, ESCURRIR UN LÍQUIDO","v.i. Ts’ibt,"
-DECENCIA,"sus. Subtal, su’tal"
-"DECIR, MANDAR, ORDENAR","v.t. A’alaj, a’almaj tsi’its. , a’al."
-DECIDIR,v.i. Tumaja’an.
-DE COLOR CENIZO,adj. Chukim.
-DE COLOR CENICIENTO,"adj. Éek’pose’en, koob."
-DEDO,sus. Yaal k’ab.
-DEDO DE LA MANO,"sus. Aal k’ab, ts’elek. (Hon"
-DEDO DEL PIE,sus. Aal ook
-DEDO ÍNDICE,sus. Tuch’ub.
-DEDO MEÑIQUE,sus. T’uup.
-DE DOS FILOS,adj. Ka’amat yeej
-DE ESTE TAMAÑO,adv. de c. Buka’aj
-DEFECAR,v.i. Ta’
-DEFENDER,"v.t. Tóok, bo’oybesaj"
-"DEFENDER, VENGAR",v.t. Tokbaj.
-DEFINIR,v.t. Ts’ok.
-DEGLUTIR,v.t. Luuk’
-DEGOLLAR,v.t. Xoot kaal.
-DEGRADAR,v.t. T’ooki
-DEGÜELLO,sus. Xoot kaalil DEIDAD MAYA DE LA CAZA MENCIONADA POR DIEGO
-DE LANDA,sus. K’u bolay.
-"DEJAR, ABANDONAR","v.t. Cha’, p’aat."
-DEJARSE VARIAS VECES,v.t. P’aap’aat.
-DEJAR SILENCIOSO,adj. Ch’enaj
-DEJAR EN LIBERTAD,"v.t. Cha’aj, cha’b,"
-DERRAMAR,"v.t. Week, tiix"
-DERRAMARSE,v.i. Wéekel.
-"DERRAMAR, VERTER UN LÍQUIDO A CHORROS",v.t. jáalk’ab t. Tselepk’iin. DE LAS TRES DE LA TARDE EN ADELANTE.
-DELANTE,"adv. de l. Bat’an, aktáan."
-DELANTE,prep. Táanile.
-DELANTERO,sus. Aktáanil.
-DELATAR,"v.t. Manchi’taj, tak pool,"
-DELGADO,"adj. Bek’ech, bi’ich, ts’ooy, ts’uuts’, pa’apchi’it. ts’oya’an."
-DELIBERACIÓN,sus. Xot óol
-DELICADO,adj. Mamayki
-DELICIOSO,adj. Ki’
-DELIRAR,"v.i. T’aant’an pool, t’aant’aan, ko’ja."
-DELIRIO,sus. K’aak’as waya’asbe’ene’.
-DELITO,"sus. Si’ipil. (Hondzonot, municipio de Tulum, Q. Roo)"
-DE MAÑANA,adv. de t. Ja’atskab k’iin.
-DEMASIADO,"adv. de c. Máanal, jach ya’ab."
-DEMASIADO,adj. Nóonooj.
-DEMENTE,sus. Choko jo’ol.
-DEMOLER,v.t. Juut
-DEMONIO,"sus. Kisin, xulub, k’aak’as ba’al."
-DEMORARSE,v.i. Xáantal.
-DESMORONAR,v.i. Báanal.
-DEMOSTRAR,"v.i. E’es, e’esaj"
-DENODADO,adj. Aj koo.
-DENTRO,"prep. Ich, ichil"
-DENUNCIAR,v.t. Manchi’taj
-DE OJOS ZARCOS,sus. Sak buye’en ich
-DE PASO,adv. de t. Jun k’uli’ DE POCO PESO.
-"DEPORTE, JUEGO",sus. Báaxal.
-DEPOSITADO,adj. K’uba’an
-"DEPRESIÓN, DESÁNIMO",sus. Lúubul óol.
-DERECHA,"sus. No’oj, x no’oj ."
-DERECHAMENTE,adv. de m. Juntats’
-DERECHO,"adj. Napul, no’oj, toj. Tóox."
-"DERRETIR, FUNDIR",v.i. Yiib
-DERRIBAR,"v.t. Jeen, juut"
-"DERRIBAR, DERRUMBAR, DESTRUIR",v.i. Niik.
-DERROTAR,"v.t. Lúubesaj, lúubsaj, lúusaj."
-DERROTERO,"sus. Belili’, beelil"
-DERRUMBADO,adj. Juutul.
-DERRUMBADO POR PARTES,adj. Jéejeem
-DERRUMBAR,"v.i. Juut, niik, jeen"
-DERRUMBARSE,v.i. Jéenel
-DESAGRAVIAR,v.t. Loj
-DESAGRAVIO,sus. Loj.
-DESAHUCIAR AL ENFERMO,v.t. Xet’ óol.
-"DESÁNIMO, DEPRESIÓN",sus. Lúubul óol.
-DESAPARECER,"v.i. Balk’ajalak, sa’at, báalal."
-DESAPARECER,v.i. Samk’aj.
-DESAPARECER DE LA MEMORIA,v.t. Tubul
-DESAPARECER DE LA VISTA,v.t. Samchajal
-DESARMADO,adj. Sipa’an.
-"DESATAR, DESABROCHAR",v.t. Waach’
-"DESATAR, AFLOJAR, DESENREDAR",v.t. Chóol.
-DESATAR SIN ORDEN,v.t. Wáawaach’.
-DESAYUNAR,v.i. Uk’ul.
-DESAYUNO,sus. Uk’ul.
-"DESBARATAR, DESHACER, DESMORONAR","v.t. Juub, juut."
-DESBASTAR,"v.t. Póol, ji’ixtik"
-DESBOCA,adj. Pich’il chi’.
-DESCALZO,"adj. Ma’ xaanab, x ma’ xaanbil, j ma’ xaanbil."
-DESCANSADERO,sus. Je’eleb
-DESCANSAR,v.i. Je’elel
-DESCARNAR,v.t. Ch’awak.
-DESCENDENCIA,sus. Ch’i’ibal
-DESCENDER EL AVE,v.i. Jáayal.
-DESCOMPONERSE,v.i. K’aastal.
-DESCONCERTAR,v.i. Kowol
-DESCONFIANZA,sus. Péek óol
-DESCONOCER,v.t. Kúulpaachkúuns
-DESCONOCER A OTRO,v.t. Maklaj
-DESCORTEZAR LOS ÁRBOLES A GOLPES,v.t. Bax
-"DESCORTEZAR, DESCASCARAR, DESINFLARSE, DES",
-HINCHARSE,v.i. Ts’úumul.
-DESPELLEJAR CON LAS UÑAS,v.t. Le’ep’.
-"DESPRENDERSE, CAERSE",v.i. Júutul
-"DESCORTEZAR, ROER",v.t. Néet’.
-DESCOYUNTAR,v.t. Juk’
-DESCUARTIZAR,v.t. Xo’xo’ot.
-DESCUBIERTO,adj. Jok’a’an
-DESCUIDAR,"v.i. Náay, náays óol"
-DESCUIDO,"sus. Manak’óol, náay óolal"
-DESDE,"prep. Ix tak, lik’ul, lik’bal,takti."
-DESDECIRSE,v.i. Jelaj
-DESDOBLAR,v.t. Waach’al
-DESEAR,"v.t. Táan óoltik, ts’íiboltik, sits’, k’áat DESGRANAR MAZORCAS DE MAÍZ (GOLPEÁNDOLAS"
-"CON UNA VARA EN UN COSTAL, HAMACA, KA’ANCHE’)",v.t. P’uch
-DESGRANAR ALGO,"v.t. P’éep’eel, p’eel"
-DESHABITARSE,v.t. Joch jal
-DESHACER,"v.t. Cháajal, puuk’"
-DESHEBRAR (CARNE),v.t. Tsíik.
-"DESHIERBAR, ARRANCAR LAS HIERBAS O MALEZA",v.t. Páak.
-"DESHINCHARSE, DESINFLARSE",v.i. Ts’úumul.
-DESHONESTIDAD,sus. Ko’il
-DESIERTO,"sus. Ch’ena’an, x tokoy lu’um, x tokoy sam."
-DESIGNAR,v.t. Yéey.
-DESILUSIÓN,sus. Tuup óolal.
-DESILUSIONADO,"adj. J tuupa’an óol, j óoltik, táak óol tuupa’an ich."
-"DESEAR, QUERER","v.t. Óot, k’áat."
-DESENCAJARSE EL HUESO,v.i. Juk’ul
-DESENCOGER,"v.t. Tats’, ji’b"
-"DESENGAÑO, DESILUSIÓN",sus. Tuup óol.
-DESENROLLAR,v.t. Waach’al.
-DESENVAINAR,"v.t. P’el, jíil."
-DESEO,"sus. Ts’íibol, ts’íibolal."
-DESEOSO,"adj. Pooch, siits’."
-DESERTAR,v.i. Púuts’ul.
-DESERTOR,sus. J púuts’ wíinik.
-DESESCAMAR,"v.t. Pox, poxtik."
-DESESPERACIÓN,sus. Xet’ óolal
-"DESESPERADO, ANGUSTIADO",adj. Chíichiiknak
-DESESPERADO,adj. Yáanyaanki.
-DESFIBRAR,v.t. Jo’och kij.
-DESFIGURAR,v.t. K’aaskunaj ich.
-"DESFLORAR, DESVIRGAR",v.t. T’aak.
-DESFONDAR,v.t. Joom.
-DESGAJAR (QUEBRAR UNA RAMA),v.t. Jéek’
-DESGAJADO,adj. Jéejéek’.
-DESGARRAR,v.t. Jatlom.
-DESGRACIA,"sus. Loob, ilálalil."
-"DESGRACIAR, DAÑAR",v.t. Loob.
-DESGRANAR A MANO LAS MAZORCAS DE MAÍZ,"v.t. Oxo’omt, oxo’om"
-DESINFLADO O VACÍO,adj. Pats’
-DESINFLAR,v.i. Chaak’al.
-"DESLEIR, DISOLVER, DESHACER",v.t. Puuk’
-DESLUMBRADO,"adj. Chaaj iich, tupa’an ich."
-DESMAYADO,adj. Sajkíimeen
-DESMENUZAR LA CARNE,v.t. Tsíik.
-"DESMONTAR, TALAR LA SELVA",v.t. Ch’akbe’ent.
-"DESMONTAR, TALAR ÁRBOLES, HACER MILPA",v.t. Kool. yóok’ol.
-DESMONTAR DE UNA CABALGADURA,v.t. Éemel
-DESMONTE,"sus. Kool k’áax, kajkool, kool."
-DESMORONAR,v.i. Juut.
-DESNIVELADO,adj. Nixa’an
-DESORDEN,"sus. K’ok’otkij, xa’axak’."
-DESOVAR,"v.t. E’elankil, e’elankal, e’el ."
-DESPACIO,"adv. de m. Chaanbéel, xanbel"
-"DESPARRAMAR , ESPARCIR","v.t. K’iit’, t’iit’."
-"DESPARRAMARSE, ESPARCIRSE","v.i. K’íitil, k’i’itpajal. DESPARRAMADO, DERRAMADO, MANCHADO CON"
-LÍQUIDO,adj.Wéeweek.
-DESPEDAZADO,"adj. Xéexeet’. DESPEDAZADO, HECHO JIRONES. Adj.Tsiitsiik."
-DESPEDAZAR,v.t. Xe’exet’.
-FRAGMENTAR,v.t.
-DESPEJADO,"adj. Jaabal, sáasil, DESPEJADO UN TERRENO. Adj. Jáanch’in."
-DESPEJAR,"v.i. Jabkuba, píik’il."
-DESPEJAR O ESCOMBRAR UN LUGAR,v.t. Ch’óoch’
-DESPEGADO,adj. Láakal.
-"DESPEGAR, DESPRENDER",v.t. Láak.
-DESPERDICIAR,"v.t.Pak’mab, manba’alkuntik."
-DESPERTAR UNO MISMO,v.i. Ajal.
-DESPERTAR A ALGUIEN,v.t. Ajsaj.
-DESPIERTO,adj. P’ixa’an ich
-"DESPLUMAR, DESHOJAR","v.t. P’éep’, p’ep’,"
-DESPOBLARSE,v.t. Joch jal
-DESPEINADO O DE PELO MUY ESPONJADO,adj. t’úut’ik. Xáaxaak.
-DESPRECIO,sus. Pinab ach
-DESPRECIABLE,adj. P’eekbe’en.
-DESPRENDER,"v.i. Báanal, láak, lúub, poots."
-DESPRENDERSE,v.i. Báanal
-DESPRENDIDO,adj. Láakal
-DESPRESTIGIAR,v.t. Manba’alkunsik.
-DESPUÉS,"adv. de t. Je’ ka’, je’lilie’"
-"DESTEJER, DESFLECAR",v.t.T’iik.
-DESTETE,sus. Took chu’uch.
-DESTINO,"sus. K’iintaj, k’iin."
-DESTREZA,"sus. Noj ach óolal, péek, séeba’anil"
-DESTREZA EN CUALQUIER COSA,sus. Nonojil
-DESTRUCCIÓN,sus. Jay kaabal.
-DESTRUCCIÓN DEL MUNDO,sus. Jay kaabal.
-DESTRUIR,"v.t. Jay aj , nojmal."
-DESVANECER,v.i. Koo’ jal óol.
-DESVARIAR,v.i. T’aant’aan.
-DESVELO,sus. Benel weenel.
-DESVESTIR,"v.t. Pit nook’, luk’saj nook’, tsel nook’. "
-"DESVIAR, LADEAR",v.t. K’uuy.
-DESYERBAR,v.t. Páak.
-DESYERBE (CON TODO Y RAÍZ),sus. Lo’che’páak. DESYERBE (SUPERFICIAL O MAL HECHO).
-DETENER,v.i. T’íilit
-DETENER EL RESUELLO,v.i. Kuup.
-DETENERSE EN CASA DE ALGUNO CONTRA SU VO,
-LUNTAD,v.t. Koyba
-DETENIDO,adj. Kuma’n
-DETERIORADO,adj. Laab
-DETERIORAR,"v.i. K’astal, laab"
-DETERMINACIÓN,sus. Xot óol
-DETERMINAR,v.t. Jepajal óol
-DETESTAR,"v.t. P’éek, p’ek"
-DETONACIÓN,sus. Wáak’
-DETONAR,v.i. Wáak’
-DETRÁS,prep. Tu paach
-DEUDA,sus. P’áax
-DE UNA VEZ POR TODAS,adv. de t. Junpuli’
-DEVOCIÓN,"sus. Ts’áaj óolal, ts’a óolal, yaaku"
-DEVOLVER,v.t. Suut.
-DÍA,sus. K’iin
-DÍA CALIENTE,"sus., adj. Chokoj k’iin"
-DÍA NUBLADO,"sus., adj. Nookoy k’iin"
-DIABLO,"sus. Kisin, xulub, k’aak’as ba’al"
-DIADEMA,sus. Nak
-DIARIAMENTE,adv. de t. Sáansamal
-DIARIO,adv. de t. Sáansamal.
-DIARREA,"sus. Waach’, tirix ta’, waach’iit"
-DIBUJADO,adj. Jochol
-DIBUJAR,"v.t. Ts’íib oochel, boon."
-DIBUJO,sus. Ts’íibil oochel
-DICTAR,v.t. A’albil utia’al ts’íibil.
-DICTADO,sus. A’albil ts’íib.
-DICHOSO,adj. Ki’óol
-DIECINUEVE,sus. Bolon lajun
-DIECISÉIS,sus. Wáaklajun
-DIECISIETE,sus. Úuklajun
-DIENTE,sus. Koj
-DIEZ,sus. Lajun
-DIFERENCIAR,v.t. Jelkunaj
-DIFERENTE,"adj. Jela’an, jejelás"
-DIFÍCIL,adj. Talam.
-DIFICULTAD,"sus. Toop, talamil."
-DIFUNTO,sus. Kimen
-DIGERIR,v.i. Éemel janal
-DIGNIDAD,"sus. Subtal, su’tal"
-DIGNO,adj. Tsikbe’en
-"DILIGENCIA, GESTIÓN, TRÁMITE",sus. Noj ach óolal
-DILIGENTE,"adj. Noj ach, sa’ak’ol"
-DILUIR,"v.t. Puuk’, yaach’"
-DILUVIO,sus. Búul kaabil.
-DINERO,sus. Táak’in
-DIOS,"sus. K’uj, yuum, yuumtsil"
-DIOS CREADOR,sus.Aj síijsajul.
-DIOS DEL VINO,sus. Aj akaan
-DIRECCIÓN,"sus. Jel, belil, u tojil, u bejil."
-DIRECTAMENTE,adv. de m. Napul
-DIRIGENTE DE UN POBLADO,"sus. Tatich, pooli, nojochil."
-DIRIGIR,"v.t. Paybe, paybe’en, belbesaj."
-DISCÍPULO,"sus. (m) Aj kanbal, j káanbal (f) Ix kanbal, x káanbal."
-DISCORDIA,"sus. Jeb óolal, nupankil, ok yail, óolal xab óolal"
-DISCRECIÓN,"sus. Kux óol, tumut óolal"
-DISCURSO,sus. Tse’ek
-DISCUTIR,"v.t. Sakach t’aan, ba’ate’el t’aan."
-DISGUSTADO,"adj. K’u’ux, ts’íik, p’u’uj."
-DISGUSTAR,"v.i. K’uux, ts’íikil, p’u’ujul"
-DISGUSTO,"sus. K’uuxil, ts’íikil, p’u’ujul."
-DISMINUIR,v.i. Jáatspajal
-DISPARAR,v.t. Sipit
-DISTINTO,"adj. Jela’an, jejeláas. DON"
-DISTRACCIÓN,"sus. Nay óolal, náay óol"
-DISTRIBUIR,v.t. T’oox.
-DIVERSIÓN,sus. Ki’imakkunaj óol.
-DIVERSIFICACIÓN,sus. Jelkunaj
-DIVERSO,"adj. Jela’an, jejeláas."
-"DIVIDIR, REPARTIR, SEPARAR",v.t. Jaats.
-DIVINA,adj. K’uyen
-DIVINO TABERNÁCULO,sus. Sujuy máakaben.
-DIVISIÓN,sus. Jeb óolal
-DIVISIÓN EN PORCIONES,sus. Jaatslil DOBLADO FORMA EN DE
-RESORTE,"adj. Ch’óoch’oot. DOBLADO, MUY DOBLADO SE APLICA AL METAL Y LA"
-MADERA,adj.Wúuwuuts.
-DOBLADILLO,sus.Paakalil.
-"DOBLAR, PLEGAR",v.t. Paak
-DOBLAR ALGUNA COSA,v.t. Uuts’. DOBLAR (LAS CAÑAS DE MAÍZ PARA QUE PROTEJAN LAS
-MAZORCAS DE LA HUMEDAD),v.t. Waats’
-DOBLEGAR,v.t. T’ooki
-DOCE,sus. Laj ka’a
-DÓCIL,"adj. Suuk, suuka’an"
-DOCTOR,sus. Ts’aak yaaj.
-DOCUMENTACIÓN,sus. Ju’un.
-DOLER,"v.i. K’i’inam, yáajtal"
-DOLOR,"sus. Chi’ibal, k’i’inam, yaaj, ok’om"
-DOLOR DE ESPALDA,sus. Kampaach
-DOLOR DE ESTÓMAGO Y NÁUSEAS,sus. Ki’inak’
-DOMADO,adj. Suuk kinsaja’an
-DOMESTICAR,v.t. Yaalak’tik
-DOMÉSTICO (ANIMAL),adj.Aalak’.
-DOMÉSTICO (TRABAJADOR),"adj.X k’oos.(f), j k’oos (m)"
-DOMICILIO,sus. Otoch.
-"DOMINIO, PROPIEDAD, HACIENDA",Ba’alba.
-"DON, SEÑOR",Yuum.
-DON O MERCED QUE UNO DA O HACE,sus.
-DON O PRESENTE QUE UNO DA,sus. Ts’áaul
-DONAR,v.t. Ts’áabilaj
-DONCELLEZ,adj. Suju’uyil
-DONDE QUIERA,adv. de l. Tatalak
-DÓNDE,Interrogación. Tu’ux.
-"DOÑA, SEÑORA","X nuk ko’olel, x nuk xunáan"
-DORADO,adj. K’anjoojop.
-DORADO,adj. Naban ti’ k’an.
-DORADO,adj. K’anjuul.
-DORMILONA (MIMOSA PÚDICA L),sus. X mu
-DORMIR,v.i. Weenel
-DORMIR PROFUNDAMENTE,v.i. T’uubul wee
-DORMITAR,v.i. K’aas weenel
-DORSO DE LA MANO,sus. Paach k’ab.
-DOS,sus. Ka’a. Dos perros: Ka’atúul peek’o’ob; Dos machetes: Ka’ap’éel máaskabo’ob; Dos árboles de ciricote : Ka’a kúul k’óopte’ob; Dos velas: Ka’a ts’iit kibo’ob.
-DOS COSAS JUNTAS,adv. de m. Ka’a lot
-DOS COSAS UNIDAS,adv. de m. Ka’a lot
-DOSCIENTOS,sus. Lajun k’aalo’ob
-DOTE PARA EL CASAMIENTO,sus. Mujul
-DUDA,sus. Péek óol.
-DUDAR,v.i. Ch’ajal óol
-DUEÑO,sus. Yuumil
-DULCE,"sus., adj. Ch’ujuk"
-"DUNA, MÉDANO","sus. Múul saam, múul sin"
-DURANTE,"adv de t. Kalikil, kali’ikil , láakej."
-DURAR,"v.i. Baili’, malel k’iin"
-DURO,"adj. Chich, pe’ech, ts’u’uy"
-E,conj. cop. Yéetel
-"ECHARSE, TIRARSE AL SUELO",v.i. Pektal.
-ECLIPSE DE LUNA,sus. Chi’ibil uj
-ECLIPSE DE SOL,"sus. Chi’ibil k’iin, máansaj táanbo"
-ECO,sus. Eets’
-ECHAR,"v.t. Tojl, toojol"
-"ECHADO, TIRADO",adj. Pekekbaj.
-ECHAR FLORES LOS ÁRBOLES O HIERBAS,v.i. Nikankil
-ECHAR MAZORCAS EL MAÍZ,v.i. Jejekankil
-ECHAR RAÍCES,v.i. Motsankil
-EDAD,"sus. Kian, ya’abil, ja’abil."
-EDAD EN QUE SE TIENE FUERZA Y VIGOR,sus. Ke
-EDAD O TIEMPO EN QUE UNO NACIÓ,sus. Siyan
-EDUCACIÓN,"sus. Ka’ambes, kaans"
-EDUCAR,"v.t. Ka’ansaj, ka’anbesaj."
-EDUCADOR,sus. Aj Ka’anbesaj .
-EDUCADORA,Ix Ka’anbesaj.
-EFECTO,sus. Kuchul
-EGOISMO,sus.ts’u’utkepil. ts’u’util.
-EGOÍSTA,adj. J ts’u’ut (m) x ts’u’ut (f)
-EJEMPLO,"v.t. Joch jaban, e’esaj, e’esajil."
-EJERCICIO (TAREA),"Sus. Meyaj, meyaj ts’íib, ts’íibil meyaj, meyaj ti’ xook."
-EJERCICIO CORPORAL,sus. Jóok’esaj muuk’.
-EJÉRCITO,"sus. K’atun, molay k’atuno’ob"
-EJIDO,sus. K’áax.
-"EL, ELLA",pron. pers. Leti’
-"ELLOS, ELLAS",pron. pers. Leti’ob.
-ELABORAR,"v.t. Meent, beet."
-EL COMPAÑERO QUE ESTA SENTADO CON OTRO,sus. Éetkulik.
-EL MAYOR O MEJOR,sus. Lalail
-ELÁSTICO,"adj. Saats’, sasats’kil"
-ELECCIÓN,"sus. Wakunaj, yéey, téet."
-ELECCIONES,sus.Yéey táanbalo’.
-ELECTO,adj. Wakuna’an
-ELEGIDO PARA ALGUN CARGO,adj. Wakunaj
-ELEGIR,"v.t. Téet, yéey"
-ELEVAR,v.t. Na’aks
-"ELEVAR, ALZAR",v.t. Tuuch’
-ELOGIAR,v.t. Ki’ki’t’aanta’al
-ELOTE HORNEADO BAJO TIERRA,sus. Píibinal
-EMBARAZADA,sus. Yo’om ko’olel
-EMBARAZAR,v.t. Yo’omkin
-EMBARAZARSE,v.i. Yo’omtal
-EMBARRO,sus. Pak’ lu’um
-EMBAUCADOR,"sus. Aj es, aj naysaj óol"
-EMBAUCAR,v.t. Esaj
-EMBELESO,sus. Sa’at óol
-"EMBESTIR, CORNEAR","v.t. Kiblaj, K’óoch"
-"EMBONAR, EMPATAR, EMPALMAR, UNIR",v.t. Tsaay
-EMBORRACHAR,"v.i. Káalkun, káaltal"
-EMBOSCADA,sus. Balbaj
-EMBOSCAR,v.t. Balba
-EMBRIÓN,sus. Baal nak’.
-EMBROCADO,"adj. Nooka’an, nóonook."
-EMBUTIR,"v.t. Bababuut’, buut’"
-"METER, ACHOCAR, ATESTAR, EMBUTIR",v.t. Cho
-EMOCIÓN,sus. Jak’ óolal
-EMPACAR,"v.t. Paak, wool"
-"EMPAPADO, QUE HA ABSORBIDO MUCHA AGUA",adj. Jaja’kij
-EMPAREJAR,"v.t. Keet, táaxkun, taxkun"
-EMPAREJAR CON LA MANO,v.t. Jaax.
-EMPATADO VARIAS VECES CON AMARRAS,adj.
-EMPEZAR,"v.t. Chumpajal, chúun, jo’op’ol, Jóojook’ káajal, káajsaj"
-"EMPEZAR, INICIAR",v.i. Léekel.
-EMPINARSE,v.i. Jottal.
-"EMPINARSE, ESTAR A GATAS",v.i. Xaktal.
-EMPLEO,sus. Meyaj.
-EMPOLLAR,"v.t. Pajkun, júuk"
-EMPONZOÑADO,adj. Ts’akan
-EMPRENDER,v.t. Chumbesik
-EMPUJAR,"v.t. Túulch’in, léench’in , túul."
-EMPUJAR A EMPELLONES,v.t. Ts’ats’a kabil
-EMPUJAR ALGO,"v.t. Jentan, júul."
-EMPUÑADURA,sus. Lap’k’abil
-EMPUÑAR,v.t. Lap’
-EN,prep. Ti’ ENAMORAR.
-ENANO,"sus. Áak wíinik, aklax , p’utum wíi"
-ENANO CORCOVADO,sus. P’uus
-ENCABEZAR,"v.t. Jo’olpóop, jool poopintaj"
-ENCAMAR GALLINAS O PAVAS,v.t. Pajkuns
-ENCAMINAR,v.i. Belbesaj
-ENCANDILADO,"adj. Chaaj iich, tupa’an ich"
-ENCANTADOR,"sus. Aj es, aj kunaj t’aan, bal"
-ENCANTADOR DE JAGUARES,sus. Aj kunaj báa
-ENCANTAR,v.t. Esaj
-ENCARCELAR,"v.t. K’aal, k’aal máak."
-ENCARGAR,v.t. K’uben.
-ENCARGO,sus. K’uben EN (para interrogar).
-ENCALLAR,v.i. Kuulul cheem
-ENCANDILAR,"v.t. Tupul ich, chaa ich. "
-"ENCARAMARSE, ENCAMARSE",v.i. Paktal.
-ENCARNADO,adj. Chakboxe’en.
-ENCENDER,"v.t. T’aab, joop"
-ENCENDER FUEGO,v.t. Joop.
-"ENCENDERSE, PRENDERSE",v.i. T’áabal.
-ENCERRAR,v.t. K’aal.
-ENCIMA,"prep. Yóok’ol, yóok’."
-EN COMPAÑÍA,adv. de m. Pak’te
-ENCONTRAR,v.t. Kaxan
-"ENCONTRARSE, DAR CON OTRO",Naktan.
-EN CONTRARIO,prep. Tu nup
-ENCRUCIJADA,sus. Xa’ay beej
-"ENCUENTRO, DAR CON EL OTRO",sus.Naktan.
-EN DÓNDE,adv. de l. Tu’ubi’
-EN EFECTIVO,adj. Túujkab
-EN EL MUNDO,adv. de l. Yóok’ol kaab
-ENERVAR,v.t. T’ona’ankinsik ENCENDER Y PROPAGAR EL FUEGO DE LA QUEMA
-ALREDEDOR DEL TERRENO DESMONTADO,sus. Bat’aab
-ENCERRADO,"adj.(m) J k’aala’an, (f) x k’ala’an."
-ENCÍA,sus. Niich’o’
-"ENCOGER, AGAZAPAR","v.i. Moot’, moots’"
-ENCOGIDO AL DORMIR,adv. Móomoochki.
-ENCONTRAR,"v.t. Kaxan, kaxtik"
-"ENCONTRARSE, DAR CON OTRO",v.t. Naktan.
-ENCORVADO,adj. Koopil
-ENCOSTALAR,v.t. To’oy
-ENCRUCIJADA,sus. Xa’ay
-ENCUBIERTO,adj. Muukul
-ENCUBRIR,"v.t. Bal, balantik"
-ENDEREZAR,"v.t. Tats’, tojkíinsik, ji’b , t’ees."
-ENDULZAR,v.t. Ch’ujukinsik
-ENEMIGOS,"sus. K’uxtaanbalo’ob, k’ux lu’um taanbalo’ob"
-ENEMIGO,sus. K’ajual
-ENEMISTAD,sus. Nupankil
-ENERGÍA,"sus. Óol, k’inaj."
-ENERVACIÓN,sus. T’ona’anil
-ENFERMAR,v.i. K’oja’antal.
-ENFERMEDAD,sus. K’oja’anil.
-ENFRENTE,adv. de l. Aktáan
-BIOS,sus. Xayak’.
-ENFERMEDAD DE LA VISTA,sus. Áak’abich
-ENFERMERA,sus. X áantaj ts’aak yaaj.
-"ENFERMO, ENFERMA",adj. K’oja’an.
-ENFILADO,adj. Tsoola’an
-ENFLAQUECER,"v.i. Ts’oy, not’bal"
-ENFRENTE,"prep. Aktáan, táan"
-ENFRIAR,v.i. Síiskunsik
-ENFRIARSE,v.i. Síistal
-"ENFUNDAR, ENCAJAR",v.t. Juup.
-ENGAÑAR,v.t. Tuus
-ENGAÑO,sus. Tuusil.
-ENGARROTADO,adj. Lóoloot’
-ENGENDRAR,v.t. Tsay
-ENGRANDECER,v.t. Nojochkunkik.
-ENGRANDECER,"v.i. Nojochtal, nojochchajal."
-ENGULLIR LA COMIDA SIN MASCARLA,"v.t. Pot luuk’, totop luuk’"
-"ENHEBRAR, ENSARTAR",v.t. Juul.
-ENJAMBRE,sus. Jom.
-ENJUAGAR,v.t. Chaal.
-EN LA NOCHE,adv. de t. Óok’iin
-EN LA TARDE,adv. de t. Éek’same’en
-ENMARAÑADO,"adj. Loob, so’osok’"
-ENMARAÑAR,v.t. Chu’uy.
-EN MEDIO,"adv. de l. Chúumukil, tu chúu"
-ENMIENDA,sus. Tojkilnaj óol.
-ENMUDECER,v.i. Tootnaj
-ENSORDECER,"v.i. Kóokkinaj, mak xikin."
-EN NINGÚN LUGAR,adv. de l. Mix tu’ux
-EN OTROS TIEMPOS,"adv. de t. Ka’atuchi, ka’achuchi"
-ENOJADO,"adj. P’uja’an, ts’íik, k’uux"
-ENOJAR,"v.i. P’u’uj, k’uux, ts’íik, ts’íikil."
-ENOJO,"sus. Lep’ óol, tachi’achil"
-EN PRESENCIA,prep. Tu táan
-EN PRESENCIA,prep. Tak’ kabal ich.
-EN TODAS PARTES,adv. de l. Tatalak ENTREGA
-ENRAMADA,"sus. Makan, máakan."
-ENREDADERA,sus. Aak’il
-ENREDADO,adj. So’osok’
-ENREDAR,"v.t. Babak’taj, baak’"
-"ENREDADO, MUY ENREDADO",adj So’oso’ok’
-"ENROLLAR, TORCER","v.i. Kopej, biil"
-ENROLLAR,v.t. Wóolis wuts’.
-"ENROLLAR, ENROSCAR",v.t. Koots’
-"ENROLLAR, ENCORVAR, ENROSCAR",v.i. Koop.
-ENROLLARSE,v.i. Kóots’ol
-ENROSCADO,adj. Koopa’an
-ENROSCARSE LA CULEBRA,v.i. Koopba
-ENSALADA DE CÍTRICOS Y JÍCAMA,sus. Xe’ek’
-ENSANGRENTARSE,v.i. Tul k’ik’jal
-ENSARTAR,"v.t. Juul, loom"
-ENSAYAR,v.t. Túuntaj
-ENSEGUIDA,adv. de t. Séeb
-ENSEÑANZA,"sus. Káanbesajulo’, kanbesaju"
-ENSEÑAR,"v.t. Ka’ans, ka’ansaj."
-ENSEÑAR VARIAS VECES,v.t. Yéeye’esaj.
-ENSORTIJADO,adj. Mu’uch
-ENSUCIAR,v.t. Éek’kunaj
-ENTARIMADO DE MADERA,sus. Tsatsal che’
-ENTENDER,"v.t. Na’at, na’atbe’en."
-ENTENDIMIENTO,"sus. Its’atil pool, na’at"
-ENTERO,adj. Túulis
-ENTERRADO,"adj. Múukul, múuka’an."
-ENTERRADO POR PARTES,adj. Múumuuk.
-ENTERRAR,"v.t. Múuk, mu’ukul."
-ENTONAR,v.i. U núuk u k’aayil.
-"ENTONCES, PUES",adv. de m. Túun
-ENTONCES,"adv. de t. Ti’ túun, túun."
-ENTORNO,sus. Bak’paach
-ENTRAÑAS,sus. Jobnel
-ENTRAR,"v.i. Okol, ok"
-ENTRE,"prep. Ich, ichil"
-ENTRE ELLOS,adj. Batanbao’ob
-"ENTREGA, ENCARGO",sus. K’uub.
-ENTREGAR,v.t. K’uub.
-ENTRE TANTO,adv. de t. Tamuk’
-ENTREGA,"sus. K’uubilaj, k’uuba’an paach"
-ENTREGADO,adj. K’uuba’an
-"ENTREGAR, SOMETERSE",v.t. K’uub
-ENTRETENER,"v.i. Náay, náays óol"
-ENTRISTECER,"v.i. K’om óol, yaaj óol"
-ENTUMIDO,adj. Si’is
-ENTURBIADO,adj. Puuk’a’an
-ENTUSIASMO,sus. Ki’óolal
-"EN VANO, INÚTIL",adj. Najel.
-"ENVEJECER,CRECER",v.i. Ch’íijil
-ENVENENADO,adj. Ts’akaja’an
-"ENVIAR, MANDAR",v.t. Túuxt
-ENVIDIA,"sus. Sawin achil, ts’íibol."
-ENVOLTURA,sus. To’.
-ENVOLTURA DE LA MAZORCA DEL MAÍZ,sus. Jolo
-ENVOLVER,"v.t. Teep’, to’."
-ENVOLVER CON SÁBANA O COBERTOR,v.t. Babaltep’ik
-ÉPOCA,sus. K’iinil.
-ÉPOCA DE LA FLORACIÓN FEMENINA DEL MAÍZ,sus. Chakpak’e’en
-ÉPOCA DE LLUVIA,"sus. Ja’aja’al, ja’ ja’ab"
-EQUINOCCIO,sus. Laket k’iin yéetel áak’ab
-EQUIPO,sus. Múuch’ul.
-EQUIVOCACIÓN,"sus. K’ebaan t’aan, k’ex óol"
-"ERECTO, MUY DERECHO",adj. Tsantsanki.
-"ERGUIR, QUEBRADO DE ESPALDAS, QUE SACA EL PE",
-CHO,adj. T’es.
-ERIZARSE,v.i. Xíibil.
-ERIZO,sus. K’i’ixpach ooch
-ERIZO DE MAR,sus. K’i’ixpach ooch ja’
-ERMITAÑO,sus. Ch’abtan
-ERUCTAR,v.i. Kéeb
-ERUCTO,sus. Kéeb
-ESA,pron. dem. Lelo’
-ESBELTA,adj. Toj basts’e’en
-ESCALDADO,adj. Máak’an
-ESCALDAR,"v.i. Máak’an., xaak."
-ESCALERA,sus. Eeb
-ESCALOFRÍO,sus. Xixib ke’el.
-ESCALÓN,sus. Tem
-"ESCAPAR, HUIR","v.i. Púuts’, púuts’ul. "
-"ESCAPE, HUIDA, FUGA",sus. Púuts’ul.
-ESCARABAJO PELOTERO,sus. Kuklim
-ESCARBAR,"v.t. Pan, páan"
-"ESCARBAR, ARAR",v.t. Buuk’.
-"ESCARBAR, HACER HOYOS",v.t. K’óoy.
-"ESCARBAR, LIMPIAR DE ESCOMBROS UNA CAVI",
-DAD,v.t. Pa’as
-"ESCARNIO, BURLA",sus. P’a’as
-ESCLAVITUD,sus. Paalitsilta’alil
-ESCLAVO,"sus. Palitsil, palbil, p’entak"
-ESCOBA,sus. Míisib
-ESCOBILLA DEL PECHO DEL PAVO,sus. Tsum
-"ESCOGER, ELEGIR, SELECCIONAR","v.t. Téet, yéey"
-ESCOMBROS,sus. Ta’il pak’
-ESCONDER,"v.t. Balantik, ta’ak"
-ESCONDER DEBAJO DE ALGO,v.t. Bal
-ESCONDIDO,adj. Ta’akmauba
-ESCONDITE,sus. Ta’akun
-ESCOPETA,sus. Ts’oon
-ESCORA DE TORTILLAS O BILLETES,adj.Ts’apab.
-ESCOZOR,sus. Saak’
-ESCRIBIR,v.t. Ts’íib
-ESCRITURA,"sus. Wooj, ts’íib."
-"ESCUCHAR, OIR","v.i. U’uy, u’ub."
-ESCUCHAR DE MANERA OCULTA,v.i. Xikintaj
-ESCUDO,sus. Chimal
-ESCUELA,sus. Naajil xook
-ESCUPIR,v.i. Túub
-ESCURRIR,v.t. Tsi’itspajal
-ESE,pron. dem. Lelo’
-ESENCIA,sus. Yelmal
-ESFUERZO,"sus. Chichil óolal, lep’óolal"
-ESÓFAGO,sus. Yúule’
-ESPACIO,sus. Yaambesaj. kúuchil.
-ESPACIO EN LA HAMACA,sus. Xáax
-ESPALDA,"sus. Pu’uch, paach"
-ESPANTAJO,sus. Wenak
-ESPANTAR,"v.t. Ja’as óol, jak’ óol"
-ESPANTO,sus. Baba’al
-ESPAÑOL,"sus. Kastlan t’aan, kastelan t’aan."
-ESPARCIR,"v.t. K’iit, t’iit’, toos, t’óot’."
-ESPARCIDO EN UN ÁREA GRANDE,adj. K’íik’iit.
-ESPECIAL,adj. Mina’an uláak’ beyo’.
-ESPECÍFICO,adj. Jach leti’.
-ESPECTÁCULO,"sus. Cha’ant, cha’an"
-ESPECULAR,v.i. Mana óol
-ESPEJEAR,v.i. Néent
-ESPEJISMO,sus. Tuus náach ja’il.
-ESPEJO,sus. Néen ESPELÓN LEGUMINOSAE (VIGNA UNGUICULATA) (L)
-WALP),sus. X
-ESPERANZA,sus. Alab óol
-"ESPERAR, AGUARDAR","v.i. Pa’at, pa’atik, páak’t"
-ESPESO,adj. Tat.
-"ESPESO, MUY ESPESO",adj. Ma’amaaki
-ESPÍA,sus. Aj ch’uukt (m) x ch’uukt (f) ESPÍA QUE MIRA DONDE ENTRA Y SALE UNO Y QUE
-TRATOS HACE,sus. Aj Ch’uukt paach.
-"ESPIAR , ACECHAR","v.t. Ch’uukt, ch’úuk."
-ESPIGA DE MAÍZ,"sus. Yi’ij, p’och"
-ESPIGAR EL MAÍZ,"v.i. P’ochakal, p’ochajal, P’o’ochajal."
-ESPINA,sus. K’i’ix
-ESPINILLA,sus. Tselek
-ESPIRAL,sus. Babak’
-ESPÍRITU,sus. Iik’
-ESPÍRITU SANTO,"sus. Kili’ich pixan, kili’ichiik"
-ESPOLÓN,sus. Subin
-"ESPOLVOREAR, ESPARCIR",v.t. Tóos.
-ESPOLVOREAR SEMILLAS EN ERAS,v.t. T’ot.
-ESPONJARSE COMO PAVO,v.i. P’olba
-ESPONJADO,adj. So’oso’op’.
-ESPOSA,"sus. Atan, atantsil. Mi esposa, in watan ; tu esposa, a watan ; su esposa, u yatan."
-ESPOSO,"sus. Íicham, íichamtsil. Mi esposo ,in wíicham; tu esposo , a wíicham ; su esposo, u yíicham."
-"ESPUELA, ACICATE",sus. Xok’ lich.
-ESPULGAR,"v.t. Ch’íich’, xíit, xíixt"
-ESPUMA,sus. Óom
-ESPUMAR,v.i. Óomankal
-ESQUELETO,sus. Chej baakel
-ESQUELETO PINTADO,sus. Chamay baak ESTRELLA
-ESQUINA,"sus. Ti’its, tu’uk’il."
-"ESQUIVAR, EVITAR",v.i. Jeech.
-ESTA,pron. dem. Lela’
-"ESTABILIZAR, PONER EL PENSAMIENTO EN ASIEN",
-TO,v.i.Kulkinaj tuukul.
-ESTABLECER,v.i. Aantal.
-ESTACA,sus. Ts’op che’
-ESTALACTITA,sus. Ch’ak xiik
-ESTALLIDO,sus. Wáak’
-ESTAMPIDA,sus.Mul xa’ak’ yáalkab.
-ESTÁN,"Ti’aan, ti’ yaan"
-ESTANCADA,adj. Ets’ekbal
-"ESTAR, HABER",v.i. Yaantal.
-ESTAR DE CUATRO PATAS,v.i. Xaktal
-ESTAR INFLADO,adj. P’op’oltal
-ESTAS,pron. dem. Lelo’oba’
-ESTATURA,sus. Ka’analil baakel.
-ESTE,pron. dem. Lela’
-"ESTE, ORIENTE",sus. Lak’iin
-ESTERNÓN,"sus. P’ep’táan, p’éep’tanil."
-ESTERO,sus. Uk’um
-ESTERO DE MAR O RÍO,sus. Bots
-ESTIBAR,v.t. Ts’aap
-"ESTIBA, ESCORA",sus. Ts’aap.
-ESTIMA EN QUE SE TIENE A UNO,sus. Kobol
-ESTIMADO,"adj. (m) Aj yaakunta’an, Aj x"
-ESTÍMULO,sus. Líik’il óol.
-ESTIRAR,v.t. Saats’
-ESTIRADO (MUY ESTIRADO),adj. Sáasaats’.
-ESTIRAR LOS PIES,v.t. T’íinchak’
-ESTÓMAGO DE LOS RUMIANTES,sus. Tsúk.
-ESTÓMAGO DE LOS HUMANOS,sus. Nak’
-ESTORNUDAR,"v.i. Je’esíim, je’etsíim."
-ESTORNUDO,sus. Je’etsíim.
-ESTOS,pron. dem. Lelo’oba’
-ESTOY,"Táan, tun"
-ESTRADO,"sus. Poopts’áan, ts’am"
-ESTRANGULAR,v.t. Bits’ kaal
-ESTRELLA,sus. Eek’
-ESTRELLA DEL NORTE O POLAR,sus. Xaman
-ESTRELLAR,"v.t. Pak ch’iintaj, week’"
-ESTREÑIMIENTO,sus. K’aal ta’
-ESTRUCTURA,sus. U wíinkilil.
-ESTUCO,sus. Pak’ bitun
-ESTUDIANTE,"sus. Aj káanbal, J"
-ESTUDIAR,"v.t. Xook, kanbal."
-ESTUDIO,sus. U kúuchil xook.
-ESTÚPIDO,adj. Maknal
-ESTUPRO,"sus. Sat suju’uyil, jaat suju’uyil"
-ETERNAMENTE,adv. de t. Maxulik’iin
-"ETERNO – adj Junk’ul, ma’ jaway, ma’ xulum",te’
-EVADIR,v.t. Xáak’abt
-EVAPORAR,"v.i. Saap’, k’osmal."
-EVITAR,v.t. Weet’.
-EXACTO,adj. P’elech
-EXAMEN,"sus. Tumut, túuntaj ka’anbale’, p’iis káanbal."
-EXAMINAR,"v.t. Túumtaj, túuntaj."
-EXCAVAR,v.t. Páan
-EXCESIVO,adv. de c. Maanal
-EXCESO,sus. Tip’a’an.
-EXCITACIÓN,sus. Ko’il
-EXCOMULGADO,"sus. Aj tsakom, aj ak’ayil"
-EXCREMENTO,sus. Ta’
-EXIGIR,v.t. Yaayantik.
-EXISTIR,"v.i. Aantal, yaantal"
-EXPERIENCIA,"sus. Pak’ tumut, túuntajil."
-EXPLICACIÓN,sus. U tsoolil.
-EXPLICAR,v.t. Tsool.
-EXPLORAR UN LUGAR CON INTERÉS,v.t.Uéej.
-"EXPLOTAR, ESTALLAR",v.i. Wáak’al.
-EXPRESAR,v.t. A’al.
-EXPRIMIDO,adj. Yets’bil
-EXPRIMIR,v.t. Yeets’.
-ÉXTASIS,sus. Sa’at óol
-EXTENDER,"v.t. Jayba, sin, jaik’iint, jaay."
-EXTENDER VARIAS VECES ALGO,v.t. Xíixiit’.
-EXTENDER O ABRIR LO DOBLADO,v.t. Xiit’
-"EXTENDERSE, REGARSE",v.i. Jáayal.
-EXTENDIDA COMO PLASTA,adj. Jenekbal
-EXTERMINAR,v.t. Xu’ulsik
-EXTRAER MIEL DE ABEJA,"v.t. Púus, jóok’saj kaab"
-"EXTRANJERO, CABALLERO",sus. Ts’uul
-EXTRAÑAR,v.t. Maklaj
-"EXTRAVIARSE, PERDERSE",v.i. Sa´atal
-EXTREMO DE LA MILPA,sus. Xu’uk’il.
-"EXTREMO, LADO",sus. Tséel.
-FÁCIL,"adj. Chéen ch’a’abil, ma’ talami’"
-FACILITAR DINERO O ALGUNA COSA,"v.t. Páay, k’inam"
-FEROZ (BESTIA BRAVA Y FIERA),"adj. Ts’íik, aj majan. maan."
-FACTURA,"sus. U ju’unil koonol, u ju’unil"
-FAISÁN,sus. K’anbul
-FAJA,sus. K’aax nak’
-FAJINA,sus. Múuch’ meyaj
-FALO,"sus. Keep, toon"
-FALTAR,"v.i. Mana’an, mina’an, na’antal."
-FAMILIA,"sus. Ch’i’ibalil, láak’tsilil, kuchkabal"
-FAMILIAR,"sus. Láak’, láak’tsil"
-FANFARRÓN,"adj. Sakach, ko’ chi’"
-FANTASMA,sus. Áak’ab kulenkul
-FARDO,sus. Kuuch
-FARINGE,sus. Yúul
-FARO,"sus. Tajche’ k’áanáab, U no’oj beej chemnáal, mumutsil sáasil k’aa’náab."
-FAROL,sus. Ch’úuyubsáas
-FASTIDIAR,v.t. Toop
-FATIGA,"sus. Ok’om óolal, ka’ana’anil."
-FAVOR,"sus. Anat , mamakbo’oy , meent uts."
-FAVORECER,v.t. Boch’besaj
-FECUNDAR,v.t. Tsay
-FECHA,sus. K’iin.
-FELICIDAD,sus. Ki’imak óolal
-FELICITACIÓN,sus. Peulil
-FELONÍA,sus. K’eban t’aan
-FÉMUR,sus.Chakbakel
-FEO,adj. K’aas
-FERMENTAR,"v.i. Omankal, pajtal"
-FERROCARRIL,sus. Wakax k’áak’
-FERVOR,sus. Ts’a óolal
-FETIDEZ,sus. Tu’ bookil.
-FÉTIDO,adj. Tu’
-FETO,"sus. Balnak’ , baalnak’il"
-FIBRA DE HENEQUÉN,sus. Sóoskil
-"FIBROSO, DIFÍCIL",adj. Ts’u’uy
-FIEBRE,"sus. Chakawil, chawakil, chokwil,"
-FIEBRE QUE QUEMA,sus. T’at’abki
-FIEBRE TERCIANA CON FRÍO O CON CALENTURA,chokuil sus. Yax ke’el
-"FIERRO, HIERRO",sus. Máaskab.
-FIESTA,"sus. Cha’an, cha’ant, mánk’iinal, mánk’iinalil, ki óotsilil K’iinbesaj."
-FIESTA DE GUARDAR,sus. Ta’akumbilo’ob
-FIGURA,"sus. Oochel, wíinkilis"
-FIJAR,v.t. Tak’
-FIJO,adj. Muuk’a’an
-FILA,"sus. T’is, t’isil, tsool"
-FILO,sus. Yeej
-FILÓSOFO,sus. J miats
-FILTRAR,"v.i. T’aj, xix,"
-FIN,"sus. Cheel, ts’o’ok"
-FINAL,"sus. Xu’ul, xuul."
-"FINALIDAD, UTILIDAD","sus. Beelal, biilal."
-FINALIZAR,"v.t. Xu’ul, ts’o’okbesaj"
-FINGIDOR,"adj. Aj ken k’oj, J ken k’oj"
-FINGIDORA,"adj. Ix ken k’oj, X ken k’oj."
-FINO,adj. Mamaykij
-FIRMA,sus. Joron ts’íib.
-FIRMAR,"v.t. Chikibelsaj, joron ts’íib."
-FIRME COMO EDIFICIO,"adj. Muuk’a’an, chich ets’ekbal."
-FIRMEMENTE,adj. Chich ets’ekbal
-FIRMEZA,sus. Jets’il
-FIRMEZA Y CONSTANCIA,sus. Jun xotoma
-"FISCALIZAR, VIGILAR EL INGRESO",v.t. P’ix náaja
-FISURA,sus. Teejel
-"FLÁCIDO, SIN FUERZA PARA ERGUIRSE",adj. Jóo
-FLACO,"adj. Ts’oya’an, bek’ech, k’ak’al baak."
-FLAGELAR,v.t. Jaats’
-FLAMA,sus. Yaak k’áak`
-FLAQUEZA DE ÁNIMO,sus. Tseem óolal.
-FLAUTA,sus. Chul
-FLECHA,"sus. K’aax jalal,"
-FLOJERA,sus. Mak’óolil.
-FLOJO,"adj. Mak’óol, jooy keep, meelen keep. te’"
-FLOR,"sus. Lool, nikte’."
-FLOR DE MAYO (PLUMERIA ALBA L),sus. Saknik
-ET ARN),sus. Chaklolmakal
-FLORECER,"v.i. Loolankil, loolankal"
-FLORECER EL MAÍZ,v.i. Jekankil
-FLOTAR,v.i. K’ak’aknak
-FLUIR SUAVEMENTE,v.i. Yiyibankil
-FLUJO DE SANGRE POR LA NARIZ,sus. X k’ulimkan
-FOGAJE,sus. K’áak’
-FOGÓN,sus. K’óoben
-FONDO,sus. Yit
-FORASTERO,"sus. J táanxenil, j ma’ wayil"
-FORCEJEAR,"v.t. P’iislant, p’iisbaj, p’iis muuk’o’ob."
-FORCEJEAR POR SOLTARSE,v.i. Chopayba
-"FORMA, FIGURA",sus. Patul. FORMADA (SE APLICA A LA MUJER DE PROPORCIONES 
-ARMONIOSAS),adj. K’úuk’uutki.
-FORMAR MONTONES,v.t. Tutukal
-FORMAR OVILLO,v.t. Wóol
-FORNICAR,"v.t. Pak’ k’eban, ko’il"
-"FORRAR, CUBRIR",v.t. Piix
-FORTALEZA,"sus. Muk’óolalil, pa’, tulum"
-FORTALEZA DE ÁNIMO,adj. Jich’ óolal
-FORTALEZA DE UNA COSA,sus. Chichil
-FORTIFICAR,v.t. Lem
-FORTIFICAR ALGUNA COSA,v.t. Cheeb
-FORTUNA,sus. Ayik’alil
-FÓSFORO,sus. Jiri’ich joop
-FOSA,sus. Mok’och.
-FOSO,"sus. Bekan, ok’op lu’um"
-FOTOGRAFÍA,"sus. Oochel, etpatkunaj"
-FRACTURA,sus. Kaach
-FRAGANCIA,sus. Ki’ibokil
-FRÁGIL,adj. Kakachki
-"FRÁGIL, QUE SE LASCA CON FACILIDAD",adj. Ts’éets’e’ejki.
-FRASCO,sus. Chan sáasil p’úul.
-FRATRICIDA,sus. J kíimsaj láak’
-FRECUENTE,adj. Mantats’
-FRECUENTEMENTE,adv. de t. Chich muuk’
-FREÍR,v.t. Tsaaj
-FRENESÍ,sus. Koo’ tamkas
-FRENTE,prep. Aktáan.
-FRENTE (PARTE DE LA CABEZA),sus. Táan jo’ol.
-FRESCO,"adj. Áak’, síis óol."
-FRESCURA,sus. Síist’ube’ FRESCURA Y SOMBRA QUE HACEN LOS ÁRBOLES
-GRANDES,sus. Síisal
-FRIJOL (PHASEOLUS SPP),sus. Bu’ul
-FRIJOL DE LIMA (PASHEOLUS LUNATUS),sus. Ib
-FRÍO,"sus. Ke’el, síis"
-FRITO,adj. Tsaajbi
-FROTAR,v.t. Jaax
-FROTAR APLICANDO UN POLVO,v.t. Ku’ult
-FRUTO,"sus. Ich, u yich che’. FRUTO ESFÉRICO DE PERICARPIO DURO QUE SIRVE"
-PARA CONSERVAR SUAVES Y CALIENTES LAS TOR,
-TILLAS,sus. Leek
-FUEGO,sus. K’áak’
-FUEGO CONSUMIDO,sus. Jabal
-FUENTE,sus. Sayabil
-FUERA,"sus. Junpachil, táankab"
-FUERTE,"adj. Muuk’a’an, muuk’náal"
-"FUERTE (SE UTILIZA PARA EL VIENTO, LA LLUVIA)",adv.
-FUERZA,"sus. Chichil, k’inam, lox t’aan, de m. K’aam muuk’, yail"
-FUERZA DE HOMBRE FUERTE,sus. Lox t’aan
-FUERZA PARA HACER ALGO,sus. Kal
-FUGA,sus. Púuts’ul
-FUGAR,v.i. Púuts’
-FUGARSE,v.i. Púuts’ul
-FUMAR,v.t. Ts’u’uts’
-FUNDA,sus. Piix
-FUNDAMENTAL,"adj. Jach k’a’abéet, k’abéet."
-FUROR,sus. Lep’ óol
-FUSILAR,v.t. Ts’oon
-FUSTÁN,sus. Piik
-GAJO O RAMA,"sus. K’ab che’, xa’ay che’, jéek’ che’."
-GAJO Y DESGAJAR UNA RAMA,sus. Jéek’
-GALARDÓN,sus. Makul
-GALLINA,"sus. X káax, káax"
-GALLINA CLUECA,"sus., adj. X si’is ook káaxo’."
-GALLINERO,sus. So’oy
-GALLO,sus. T’eel
-GANADERO,sus. Yuumil wakaxo’ob
-GANADO VACUNO,sus. Wakax
-GANANCIA,sus. Náajal
-GANAR DINERO,v.t. Náajalt
-"GANAR, VENCER","v.t. Ts’áanchek, ts’áanchak’."
-GANAR VARIAS VECES,v.t. Jóojo’och.
-GANCHO PARA BAJAR FRUTAS,sus. Kóokool
-GANGLIO DEL SOBACO O DE LA INGLE,sus. Ma’aj
-GARGANTA,"sus. Kaal, bab kaltaj"
-GARGANTA CORTA,sus. Kulkaal
-GARRA,sus. Iich’ak
-GARRA DE LOS FELINOS,sus. Mo’ol
-GARRAFÓN,sus. Sáasil p’úul
-GARRAPATA,sus. Peech
-GARZA BLANCA,sus. Sak bok
-GASTAR,"v.t. Nojmal, xuup"
-GASTAR POR GASTAR DINERO O ALGUNA COSA,v.t. Xúuxuup.
-GASTO,sus. Xuup.
-GATEAR,v.i.Juuk’
-GATO,sus. Miis
-GAVILÁN,"sus. Ch’úuy, i’"
-GEMELO,sus. Iich 
-GEMIDO,sus. Áakam
-GENTE,"sus. Máak, máako’ob."
-GENTE QUE TIENE UNO A SU CARGO,sus. Kuchka
-GERMINAR,"v.i. Top’ol, jok’ol."
-GESTO,sus. Eets’
-GIBA,sus. P’uus
-GIGANTE,"sus. Wa paach, wa’n chak, chawak ach wíinik"
-GIRAR,v.i. Pirin suut
-"GIRAR, VOLTEAR, REGRESAR",v.i. Suut.
-GLIFO,sus. Wooj
-GLORIA,"sus. Ki’ ki’ óolal, tepalil, nojbe’enil."
-GLOTONA,"adj. X balnak’, x banban janal."
-GLOTÓN,"adj. Aj balnak’ , aj banban janal"
-GLOTONERÍA,"sus. Bal nak’il, balta’achil"
-GLÚTEO,sus. P’u’uk iit
-GOBERNADOR,"sus. Aj belnal, aj mek’tan"
-GOBERNANTE,"sus. Jalach wíinik, nojoch jaa"
-GOBIERNO,sus. Mek’tan mail
-GOLONDRINA,sus. Kusam
-GOLPE QUE SE DA A COSAS HUECAS,sus. Boj
-GOLPEADO O AZOTADO VARIAS VECES,adj. Jáajaats’an.
-GOLPEAR,"v.t. jaats’, k’ool, k’op, kooj"
-"GOLPEAR, APISONAR, ABATANAR",v.t. Kooj.
-GOLPEAR CON EL PUÑO,v.t. Loox
-GOLPEAR CON LA PALMA DE LA MANO,v.t. Laaj
-GOLPEAR CON LOS NUDILLOS,"v.t.Boboj, k’op."
-GOLPEAR CON MARTILLO,v.t.K’op yéetel bajab.
-GOLPEAR POR GOLPEAR,"v.t.Báabaaloox. GOLPEAR, ROMPER O DESHACER A GOLPES ALGO"
-DURO,v.t. Baax.
-GOLPEAR VARIAS VECES,v.t. P’úup’uuchbil.
-GONORREA,sus. Puj tu bell wiix
-GORDO,"adj. Polok, werek’, p’urux, p’uk’us."
-GORDITO,"adj. Kukutki, yúujúus."
-"GORJEAR, CANTAR",v.i. K’aay.
-GOTA,sus. X t’un
-GOTA DE AGUA O DE LICOR,"sus. X t’un, t’aj, ch’aj"
-GOTA PEQUEÑA,sus. T’un
-GOTEAR,v.i. Ch’aaj
-GOTERO,sus. Ch’aaj
-GRACIA,"sus. Chich óolal, ts’aabilaj"
-"GRACIA, DÁDIVA",sus. Ts’aabilaj
-GRACIAS,"sus. Niib óolal, Ki’ichkelem Yuum bo’otik, Yuum bo’otik."
-GRACIOSO AL HABLAR,adj. Ki’ki’ t’aan.
-GRADA,sus. Tem
-GRADA PARA SUBIR,sus. Tem
-GRAJO,sus. K’a’aw
-GRAN SEÑOR,sus. Ajau
-GRANDE,"adj. Nojoch, noj, nonoj, nuuk."
-GRANDES,adj. Plural. Nukuch
-"GRANDES, COSAS GRANDES",adj Núunuuktal.
-GRANDEZA,"sus. Lakam, nojil"
-GRANERO,"sus. Ch’iil, kumche’"
-GRANIZAR,"v.i. K’áaxal bat, batil ja’"
-GRANIZO,sus. Bat
-GRASA,sus. Tsaats
-GRASA QUE LE SALE AL PIPIÁN Y A OTRAS COMIDAS,sus. Yek’
-GRASOSO,adj. Ch’ach’alkij
-GRATIS,"adj. X ma’ bo’oli’, mix bo’oli’."
-GRATUITO,adj . Chéen siibil
-GRAZNIDO,sus. Jolk’olok
-GRILLO,"sus. J máas, máas"
-GRIS,"adj. Éek’ popos, sak boox, sak éek’"
-GRITAR,v.i. Awat
-GRITAR ALOCADAMENTE,v.i.Táataaj awat. GUSTAR
-GRITO,sus. Awat
-GRUESO,adj. Piim
-"GRUESO, MUY GRUESO",adj. Píimpiin.
-GRUPO,sus. Múuch’.
-GRUTA,sus. Áaktun
-GUACAMAYA,sus. Moo
-GUACAMAYO,sus. Xoop
-GUAJOLOTE,"sus. Tso’, úulum"
-GUANÁBANA [ANNONCEAE (ANONA MURICATA L)],"sus. Tak’oop, k’iix pa’ach oop. GUANACASTE [ENTEROLUBIUM CYCLOCARPUM (JACQ)] ."
-GUANO,sus. Xa’an
-GUARAPO,sus. Sa’il moom
-GUARDAR,"v.t. Li’is, ta’ak"
-"GUARDADO, MUY GUARDADO","adj . Báabaalki, táata’ak."
-GUARDAR LAS ESPALDAS,v.t. Mak paach
-GUARDARRAYA,"sus. Bekab, míis jool paach."
-GUARDIA,"sus. Aj ch’a’aj beej, Aj pikit beej, aj kanan beej. K’onchle’ chintok’"
-GUARUMBO (CECROPIA OBTUSIFOLIA (BERT)),sus.
-GUAYABA (PSIDIUM GUAJAVA L),sus. Pichi’
-GUAYACÁN (GUAIACUM SANCTUM L),sus. Chun
-GUERRA,"sus. K’atunyaj, muul ba’ate’el, noj ba’ate’el, nupankil"
-GUERREAR,"v.t. Ba’ate’el, p’iis."
-GUÍA,"sus. Aj bejil, Aj bej, Aj belbesaj."
-GUIAR,"v.t. Belbesaj, joch jaban"
-GUIÑAR EL OJO,v.t. May ich
-GUIÑAR,v.i. Chaak’
-GUIJARRO,sus. Ch’ich’il tuun.
-GUIRNALDA,sus. K’aax jo’ol
-GUITARRA,"sus. X t’in k’áanil páax ,Táabil páax, k’aayun che’."
-GULA,"sus. Bal nak’il, balta’achil"
-GUSANO,"sus. Nook’ol, x nook’ol"
-GUSARAPO,"sus. Bolin, x bube’"
-"GUSTAR, VER CON DELEITE",v.t. Cha’an
-HÁBIL,adj. Péeka’an
-HABILIDAD,sus. Its’atil pool
-HABITANTE,sus. Kaajnáalil
-HABITAR,"v.i. Kaaj, kaajtal, kaajlan."
-HÁBITO,sus. Suukil.
-HABLANTE,sus. Aj t’aan.
-HABLAR,v.i. T’aan
-HABLAR ALBOROTÁNDOSE,v.i. Tsay óoltaj
-HABLAR EN VOZ BAJA,v.i. X muukul t’aan
-HABLAR HISTÉRICAMENTE,v.i. Báabaalt’aan.
-HABLAR PRIMERO,v.i. Paybe
-HABLAR RIÑENDO,v.i. Tsay óoltaj
-HABLAR SOLO,v.i. T’aant’aan
-HABLOTEAR,v.i. Sakacht’aan
-HACE TRES DÍAS,adv. de t. Óoxejeak
-HACE UN AÑO,adv. de t. Jun ja’abake’
-HACER,"v.t. Beet, meent, meen,"
-HACER POR HACER,v.t. Báabaal meenbil.
-HACER ALBARRADA,v.t. Koot
-HACER ARDER LA LUMBRE SOPLANDO,v.t. Jopsaj
-HACER CAMINO,"v.t. Belbesaj, jool ch’áak."
-HACER CAUTIVO,"v.t. Baksaj HACER,"
-CONFECCIONAR,"CONSTRUIR,"
-HACER REALIDAD,v.t. Béeykuntik.
-HACER RODAR,v.t. Balk’esen
-HACER SANGRÍA,v.t. Tok’
-HACERSE MARAVILLOSA Y MILAGROSA,adj. Maktsiljal
-HACIA ABAJO,adj. Chinchin.
-HACIENDA,sus. Ti’yal.
-"HACIENDA, CONJUNTO DE BIENES MUEBLES E IN",
-MUEBLES,sus. Ba’aba.
-HACHA,sus. Báat
-HALO NOCTURNO,sus. Chéelil áak’ab.
-HAMACA,sus. K’áan
-HAMBRE,sus. Wi’ij
-HAMBRUNA,sus. Wi’ijil kiimilo’ob
-HARTO,adj. Na’aj
-HASTA,prep. Tak
-HASTA AHORA,adv. de t. Tak walkila
-HASTA MAÑANA,adv. de t. Tak sáamal
-HASTA MÁS TARDE,adv. de t. Tak ka’akate’
-HASTÍO,sus. Nak óol.
-HAY,v.i. Yaan
-HEBRA TORCIDA O HILADA EN PABILOS,sus. Máak’antik.
-HECHICERO,"sus. Aj kunaj t’aan, aj kunyaj, pul v.t. Ch’ot"
-HACER DE NUEVO UN TRABAJO,v.t. Líik’ meyaj HACER ALGUNA FUERTE
-COSA,v.t. ya’aj Múuk’kankunsik.
-HACER GESTOS O MUECAS,v.i. Eets’
-HACER MONTONES,v.t. Tutukal
-HACER OBRA DE MANO,v.t. K’abtaj
-HACER QUE UNA COSA ABUNDANTE SE AGOTE,v.t.
-HECHICERO QUE ATRAE CON SUS CONJUROS A ALGU,
-NA PERSONA O ANIMAL,sus. Aj pay kun.
-HECHICERO QUE CAUSA DAÑO POR MEDIO DEL AIRE,sus. Aj ch’in iik’.
-HECHIZO,sus. Pul
-HEDOR,"sus. Tu’, tu’ book"
-HELADO,adj. Síis Ch’eejel
-HELECHO,sus. Bebtun.
-HEMBRA,"sus. Ch’úup, ko’olel, x ba’al"
-HENDER ROMPIENDO,v.i. Jet
-HENDIDURA,sus. Jet’
-HENEQUÉN (AGAVE SPP),sus. Kij
-HEREDAD DONDE HAY COSAS PLANTADAS,sus. aale’ paal. Páak’al Loma’an yóok’ol
-HERENCIA,sus. K’aam ba’albail
-HERIDA,"sus. Loob, jatlom."
-HERIDO A LANZADAS O ARPONEADO,adj.
-HERIDO DE MUCHAS HERIDAS,adj. Tulkintan
-HERIR,v.t. Loob
-HERIR CON AGUIJÓN,v.t. Julche’
-HERIR CON ARMA O INSTRUMENTO PUNTIAGUDO,
-HERIR O LASTIMAR EL OJO CON EL DEDO ÍNDICE,v.t. Loom v.t. Ch’oop.
-HERMAFRODITA,"sus. X ch’úupul xiib, síis óol."
-HERMANA,sus. Kiik
-HERMANO MAYOR,sus. Suku’un
-HERMANO MENOR,sus. Iits’in
-HERMOSA,"adj. Jats’uts, ki’ichpam"
-HERMOSO,adj. Ki’ichkelem
-HERRADURA,sus. Xanab tsíimin
-HERRAMIENTA,sus. Nu’ukul
-HERRERO,"sus. Aj meyaj máaskab, J meyaj"
-HERVIR,"v.i. Lóok, om"
-HERVIR DE PERSONAS O ANIMALES,sus. To
-HIELO,Sus. Síis chich ja’.
-HIEL,sus. K’aaj
-HIERBA,sus. Xíiw
-HIERBA QUE CAUSA COMEZÓN,sus. P’óop’oox.
-HÍGADO,"sus. Táaman, tamnel HIGUERA CUYA CORTEZA SERVÍA PARA HACE PAPEL (FICUS COTINIFOLIA H.B. ET K)."
-HIGUERILLA (RICINUS COMMUNIS),sus. K’ooch HIJA O HIJO DE LA MUJER (SÓLO SE APLICA A LA MADRE
-O SÓLO ELLA DESIGNA ASÍ A SUS HIJOS),"sus. Aal, x HOMBRE"
-HIJASTRO,sus. Majan mejen paal.
-HIJO (AL REFERIRSE LA MUJER),sus. A’al.
-HIJO (AL HACER ALUSIÓN EL HOMBRE),"sus. Meejen,"
-HIJO EN GENERAL,"sus. Paal, paalal, mejnil"
-HILAR,"v.t. Jaax, k’uuch"
-HILERA,sus. Tsool
-HILO,sus. K’uuch
-HILVANAR,v.t. Máak’a’an chuuy.
-HIMNO,sus. Noj k’aay.
-HINCADO,adj. Xolokbal
-HINCAR,"v.i. Xolkin, xoltal."
-HINCARSE,"v.i. Xoltol, xoltaj, xoltal."
-HINCHADO,adj. Chuup
-HINCHARSE,"v.i. Chuup, si’ip’il."
-HINCHARSE EL VIENTRE DE COMIDA,v.i. Pemal.
-HIPAR,v.i. Juuyub
-HIPO,sus. Tuk’ub
-HIPÓCRITA,"adj. Ka’ap’éel ak’, x ken k’oj"
-HIPÓTESIS O SUPOSICIÓN,sus. Ch’a’ach’itika’
-HISTORIA,"sus. K’ajlay, siyan"
-HOCICO,sus. Ni’
-HOGAR,"sus. Otoch, naaj, taanaj, naay."
-HOGUERA,sus. Ban k’aák’
-HOGUERA CONSUMIDA,sus. Jabal
-HOJA,sus. Le’
-HOJA DE LIBRO,"sus. Tsil, wáal, wáal ju’un."
-HOJAS SECAS,sus. Sojol
-HOLLEJO,"sus. Saay, saayel."
-HOLLÍN,"sus. Sabak, yebek naaj"
-HOMBRE,"sus. Máak, wíinik, xiib HOMBRE ASTUTO. sus., adj. Aj na’at ach"
-HOMBRE CERTERO EN APUNTAR AL BLANCO,sus. Toj k’ab
-HOMBRE DISCRETO,sus. Aj na’at
-HOMBRE ENTENDIDO,sus. Aj na’at
-HOMBRE FUERTE,"sus. Muuk’a’an wíinik, Aj muuk’náal."
-HOMBRE ILUSTRE,sus. Aj na’at HOMBRE MÍTICO DIMINUTO HECHO DE BARRO QUE
-"COBRA VIDA, CUIDA LOS MONTÍCULOS ARQUEO",
-LÓGICOS Y LAS MILPAS,"sus. Alux, arux."
-HOMBRO,sus. Keléembal
-HOMENAJE,sus. Nojbe’enkant
-HOMICIDA,sus. Kíinsaj wíinik
-HONDA PARA ARROJAR PIEDRAS,sus. Yúuntun
-HONDO,adj. Taam
-HONDONADA,"sus. K’om, k’óom"
-HONGO,"sus. Kuuxum, xuxum che’"
-HONGO DE ÁRBOL,sus. Xikin che’
-HORA,"sus. Tsilk’iin, lat’ab k’iin, jech ti’ k’iin, k’iintsil."
-HORADAR,"v.t. Jool, poot"
-HORIZONTE,"sus. Chuun ka’an, siyan ka’an."
-HORMIGA,sus. Síinik
-HORMIGA CARNICERA,sus. Xuulab HORMIGA NEGRA QUE SE DESPLAZA EN GRANDES
-GRUPOS,sus. Saakal
-"HORMIGA ROJA, DENOMINADA ARRIERA",sus. Saay che’.
-HORNEAR EN LA TIERRA,"v.t. Píibt, píib."
-HORNO HECHO EN LA TIERRA,sus. Píib
-HORNO DE PIEDRAS,sus. Tsuk tun
-HORQUETA,"sus. Ts’opche’, xa’ay che’, táak"
-"HORRIBLE, QUE ESPANTA",adj. Jak’ óoltsil
-HOSPEDAJE,sus. Jula kabil
-HOSPEDAR,v.t. K’aam
-HOSPITAL,"sus. U naajil k’oja’ano’ob, U naajil ts’aak yaaj."
-HOTEL,"sus. K’aam naaj, otoch kabil."
-HOY,"adv. de t. Bejela’e’, bejla’e’, bejele’,bejle’, bejla’ake’."
-HOYA,"sus. K’om, k’óom"
-HOYO,"sus. Jom, jool"
-HOYUELO EN LA MEJILLA O EN LA BARBA,"sus. Tuux HUANO ENANO CUYAS HOJAS SIRVEN PARA TECHAR CONSTRUCCIÓN, HACER ESCOBAS, ETC (SABAL"
-YAPA C (WRIGTH)),sus. Ch’iit
-HUANO (THRINAX RADIATA (LOOD)),sus. Xa’an
-HUANO BLANCO,sus y adj. Sak xa’an.
-HUAYA (TALISIA OLIVAEFORMIS (KUNT) RADLK),sus. Wayum
-HUECO,sus. Jool
-HUELLA DE LOS PIES,"sus. Bilim, chek’, pe’echak’,pe’eche’"
-HUELLA DE LAS MANOS,"sus. Péets’ k’ab, waay."
-HUESO,sus. Baak
-HUESO DE ELOTE,sus. Baakal
-HUESO DE LA MAZORCA,sus. Baakal
-HUESO DE UNA FRUTA,sus. Neek’
-HUEVO,"sus. Je’, e’el, ye’el"
-HUEVO ESTRELLADO,sus. Pa’ ch’iintaj je’
-HUIPIL,sus. Iipil.
-"HUIR, FUGARSE","v.i. Púuts’, púuts’ul"
-"HULE (CASTILLA ELÁSTICA, CERV)",sus. K’i’ik’che’
-HUMANO,"sus.Wíinik, máak."
-HÚMEDO,adj Lolok
-HUMILDAD,"sus. Kaabal óol, suuk óol."
-HUMILDE,"sus. J nuun óol, J suuk óol."
-HUMILLAR,v.t. T’oonkíisaj
-HUMILLACIÓN,sus. T’oonkíinsajil
-HUMO,sus. Buuts’
-HUNDIR,"v.i. Búulul, lam"
-HURGAR CON PALO,v.t. Julche’
-HUSMEAR,v.i. Tsukul iik’taj
-IDEA,sus. Tuukul.
-IDENTIFICAR,v.t. K’ajóol.
-IDIOMA,sus. T’aan
-IDIOMA ESPAÑOL,"sus. Kastilan t’aan, kastran pom. t’aan k’ult naaj."
-IGLESIA,"sus. Naaj K’uj, k’unaj, Yotoch K’uj,"
-IGNORANCIA,sus. X ma’ ojelil.
-IGUAL,"sus. Keet, lajket."
-"IGUALAR, EMPAREJAR","v.t. Keet, keetbesik."
-IGUALDAD,sus. Keetil.
-IGUAL EN FUERZA,sus. Etmuuk’il
-IGUALAR,v.t. Taxkun
-IGUANO,sus. Juuj
-IJADA,sus. Páaknak’
-ILUMINAR,v.t. Sáaskun
-ILUSTRACIÓN,sus. Oochel.
-IMAGEN,sus. Oochel
-IMAGINACIÓN,"sus. Num óol, tuukul"
-IMAGINAR,"v.t. Nen óol, num óol"
-IMAGINARIO,adj. Tuukulbil.
-IMITAR,"v.t. Ch’a ts’ilib, joch, p’a’ast"
-IMPETUOSO,adj. Seeb óol
-IMPLORACIÓN,sus.Yaaj k’áatik.
-IMPORTANCIA,sus. Kananil
-IMPORTANTE,"adj. K’a’anan, k’a’ana’an, k’ojol, jach k’abéet."
-INCESTO,sus. Panpib
-INCIENSO,"sus. Jaak’, pukak’"
-INCLINADO,"adj. T’oonol, chíin"
-INCLINADO SOBRE ALGO,adj. Páapáak.
-INCLINAR,v.t. Chíina’an
-"INCLINAR, LADEAR",v.t. Ch’eeb.
-INCLINARSE,"v.i. T’oon, chíinil"
-INCORDIO,sus. Chu’chum
-INCRUSTADO,adj. Ts’opokbal
-INCRUSTAR,v.t. Tak’aj
-INDAGAR,v.t. K’áat chi’
-"INDICAR, MOSTRAR",v.t. E’esaj.
-INDICAR CON EL DEDO ÍNDICE,v.t. Tuch’ub.
-INDIFERENTE,adj. Ma’bal yóol.
-INDIO,sus. Máasewal
-INDIRECTAS,sus. Ch’iinch’int’aano’ob.
-INDIVIDUAL,adj. Tu juun.
-INERTE,"adj. Ma’ péek óol, muuk’a’an"
-INFANCIA,sus. Paalil
-INFIERNO,"sus. Ak’bal naj, metnal, mitnal."
-INFINITO,"adj. Chaket, cheket, ma’ xulumte’, ma’ xuul."
-INFLAMABLE,adj. Joojóopki.
-INFLAR,"v.t. P’uru’us, p’ulu’ust"
-INFORMAR,"v.t. Num chi’, num chi’tik"
-INFORMACIÓN,"sus. Tsool, Nu’uksaj, num"
-IMPREGNAR,v.t. Ts’am.
-IMPRESO,adj. Ts’ala’an
-IMPRUDENTE,adj. J ma’ kux óol
-IMPUESTO,sus. Patan
-INCENSARIO,"sus. Ch’uyub pukak’, ch’uyub chi’taj"
-INFORME,"sus. Num chi’, tsool ts’íib. INFORTUNIO."
-INFUNDIR,v.t. Oksaj tu pool.
-INGENIOSO,sus. Aj numan
-INGLE,sus. Je’ej
-INHALAR,"v.i. Ch’a’ book, ch’a’ iik’"
-INJURIA,sus. Pooch’.
-INGRATITUD,sus. X ma’ niib pixanil
-INJERTO,sus. K’ubche’.
-INJUSTICIA,"sus. Ma’ tibil, X ma’ tojil."
-INMEDIATAMENTE,"adv. de t. Ma’ muklik, tu séeblankil, jach náapulak. INMINENTE, A PUNTO DE"
-SUCEDER,adv.
-INMÓVIL,"adj. Ma’ péek óol, muuk’a’an, xoxo"
-INQUIETO,adj. Chuklak iik’
-INSCRIBIR,v.t.Ts’íib k’aaba’.
-INSECTO,"sus. Yik’el, yilk’il"
-INSECTO ACUÁTICO,sus. Bubul. INSECTO CON EL CUERPO LUSTROSO DE COLOR AZUL PAVO Y ALAS AMARILLENTAS. SE LE ENCUENTRA
-EN TRONCOS VIEJOS SU PIQUETE OCASIONA DO,
-LOR INTENSO Y TEMPERATURA ELEVADA,sus. Báalamjolom
-INSERVIBLE,"adj. Laab, ma’patali’."
-INSISTENCIA,sus.Tsaantsan t’aane’
-INSÓLITO,adj. Ma’ napaja’an
-INSOMNIO,sus. P’ix ich
-INSTANTE,adv. de t. Súutuk
-INSTITUCIÓN,sus. Molay
-INSTRUCCIÓN,"sus. Nu’ukbesaj , tsool núuk."
-INSTRUMENTO PARA ALGUNA ACTIVIDAD,sus. Nu’ukul
-INSTRUMENTO PARA ESCRIBIR,"sus. Cheeb INSTRUMENTO QUE SIRVE PARA SACAR EL ELOTE DE SU ENVOLTURA EN LA COSECHA. PUEDE SER UN CUERNO DE CIERVO ENANO, UNA MADERA"
-"AGUZADA, UN INSTRUMENTO DE METAL",sus. Bakche’
-INSTRUMENTOS PARA ALGÚN OFICIO,sus. Yeem
-INSTRUMENTO MUSICAL,sus. Páax
-INSULTAR,v.t. Pooch’.
-INSULTO,"sus. Pooch’, pooch’il."
-INSULTAR REPETIDAMENTE,v.t. Póopooch’il
-INTACTO,"adj. Báayli’e’, suju’uy"
-INTANGIBLE,adj. Ma’ takabil.
-ÍNTEGRO,adj. Báayli’e’
-INTELIGENCIA,sus. Na’at
-INTENCIÓN,"sus. Tuukul, tuukulil."
-INTERÉS,sus. Ts’áaj tuukul
-INTERIOR,"adv. de l. Ts’u’, ichil"
-INTERPONER,v.t. Ba’alchaja
-INTERROGACIÓN,sus. K’áat chi’.
-INTERROGANTE,sus. K’áat chi’il.
-INTERRUMPIR,v.t. Nikkabtaj
-INTESTINO,sus. Chooch
-INTRANQUILIDAD,sus. Chi’ichnak
-INTRANQUILIZARSE,v.i. Nich’bal
-INTRODUCCIÓN,"sus. Oksaj t’aanil, káajbal."
-INTRODUCIR,"v.t. Oks, oksaj, ts’ot"
-"INTRODUCIR, METER LA AGUJA",v.t. Juup’
-"INUNDAR, AHOGARSE","v.i. Buul, búulul"
-INVASOR,"sus. Aj okaj kaaj, ch’a kaaj"
-INVENTAR,v.t. Meen.
-INVESTIGACIÓN,sus. Kaxan tsikbal
-INVIERNO,"sus. Ak’ ya’abil, ich ke’el"
-INVISIBLE,adj. Ma’ ilbil.
-INVITAR,"v.t. Payalte’et, payal óol, pay óol, pay t’aan."
-INVOCAR,"v.i. Awat pay, awat paytaj."
-"INVOLUCRAR, PARTICIPAR",v.t. Táakpajal.
-INYECCIÓN,sus. Juup’ ts’aak.
-INYECTAR,v.t. Juup’
-IR,"v.i. Biin, xi’ik."
-IR EN COMPAÑÍA DE OTRO,"v.t. Éetbenel, éet"
-IR TRAS ÉL,v.t. Ch’a ok
-IRA,"sus. K’uuxil, lep’ óolil, p’uujil, ts’íikil."
-ISLA,sus. Petén
-IZQUIERDA,adj. Ts’íik
-JABALÍ (PECARI TAYASSU),sus. Kitam
-JABÍN (PISCIDIA PISCIPULA (L) SARG),sus. Ja’abin
-JACAL,"sus. Naaj, pasel (choza sencilla de un alero o dos, que se hace en la milpa para descanzar o para vigilar.)"
-JADE,"sus. Tuun, ya’ax tuun"
-JADEAR,"v.i. Jéesbal, jéesbaj"
-JAGUAR,"sus. Báalam, chak mo’ol"
-"JALAR, SEPARAR",v.t. Kóol
-JALAR,"v.t. Jáanpaytik, páay."
-JALAR POR BRAZADA PARA SACAR AGUA DEL POZO,v.t. Sáasáap.
-JALAR AGUA DE POZO,v.t. Páay ja’.
-JAMÁS,adv. de t. Mix bik’iin
-JARANA,"sus. Paax k’ool, síit’ óok’ot."
-JARDÍN,sus. Páak’alnikte’
-JARRA,"sus. Buleb, chan p’úul"
-JARRO,sus. Buleb
-JASPEADO,adj. Wewel JÍCAMA (LEGUMINOSAE PACHYRAHIZU EROSUS (L)
-JÚBILO,sus. Ki’imak óolil.
-JUEGO,"sus. Báaxalnen, báaxal"
-JUEGO DE AZAR,sus. Buul
-JUEGO DE PELOTA PREHISPÁNICO,sus. P’okta
-JUGAR,v.t. Báaxal
-JUGAR TROMPO,v.t. T’óoch.
-JUGO,sus. K’aab
-JUICIO,"sus. Kux óol, kuxóolal, na’at, xoot"
-JUNCIA,sus. Semet’
-JUNTAR,"v.t. Múuch’, mool, nup"
-JUNTAR LOS LEÑOS PARA HACER MÁS FUEGO,v.t.
-JUNTAR O LLEVAR EMPUÑADO,v.t. Lóot.
-JUNTARSE,"v.i. Bantak, bantal"
-JUNTO,"adv. de l. Naak’, múul, yiknal, tu"
-JUNTOS,adv. de m. Pa’ate’
-"JUNTOS, MUY APRETADOS",adv. de m. p’ok k’iin Nuuch. tséel
-URBAN),sus. Chi’ikam Pe’epe’ech’ki.
-JÍCARA (CRESCENTIA CUJETE L),sus. Luuch
-JINETE,"sus. Aj naat’, Aj léej wakaxo’"
-JOROBA,sus. P’uus
-JOVEN,"sus, adj. (m) Xi’ipal, táankelem (f)X ch’úupal, X lo’bayan, X lo’bayen."
-JOVEN DE LA NOBLEZA,"sus. (m)J ajauil, (f) X"
-JURISDICCIÓN,sus. Mek’tan kaajil
-JUSTICIA,"sus. Tibil, tojil"
-JUSTO,"adj. Tibil, tojil"
-JUVENTUD FEMENINA,sus. X lóobaymil
-JUVENTUD MASCULINA,sus. J Táankelmil
-JUZGAR,"v.t. Ts’áaj, yaya tse’ ktaj, p’iis óol. ajauil. JUZGAR"
-LABERINTO,sus. Satun sat.
-LABIO,sus. Booxel chi’
-LABORAR,v.i. Meyaj
-LABRAR MADERA,v.t. Póol che’
-LABRAR MADERA SACÁNDOLE PUNTA,v.t. Bits’
-LADEADO,adj. Nixa’an
-LADEADO,Tséetséel.
-LADEAR,"v.t. Nix, tseltal."
-"LADEAR, INCLINAR",v.t. Ch’eeb
-"LADEAR, DESVIAR, TORCER",v.t. K’eech.
-LADO,"adv. de l. Tséel, tséelil, xáax"
-LADO DE LA CAMA O DE LA HAMACA,"sus. Xáax, t’uub."
-LADRAR,v.i. Chi’ibal peek’
-"LADRAR EL PERRO, PERSIGUIENDO A ALGÚN ANI",
-MAL,v.i. Tóojol
-LADRÓN,sus. Ookol
-LAGAÑA,sus. Ch’eem
-LAGARTIJA,"sus. Bebech, meemech."
-LAGARTIJA VERDE CON CRESTA,sus. Tolok
-LAGARTO,"sus. Áayin, áaim, juuj (Hondzonot, municipio de Tulum, Q. Roo.)"
-LÁGRIMA,sus. Ja’il ich
-LAGUNA,sus. Áak’al che’
-LAJA,sus. Chaltun
-LAMA O MOHO VERDE DE LA TIERRA HÚMEDA Y SOM,
-BRÍA,sus. Ya’ax k’oxmal
-LAMENTO,"sus. Akanjal, ok’ol."
-LAMER,v.t. Léets’
-LAMPIÑA,adj. Biirich
-LANA,sus. U tso’otsel taman.
-LANGOSTA DE MAR,sus. Chakay. 
-"LANGOSTA, INSECTO QUE ES PLAGA PARA LA AGRI",
-CULTURA,sus. Sáak
-LANZA,"sus. Tsopche’, julte’, nabte’"
-LANZAR,v.t. Ch’iin
-LANZAR CON ÍMPETU,v.t. Tojlaj
-"LÁPIDA, LOSA, LAJA",sus. Tsal
-LÁPIZ,sus. Ch’ilib ts’íib
-LARGO,adj. Chowak
-LARGO RATO,"adv. de t. Sam, same’, samak."
-LASCA,sus. Xeet’
-LASCAR,v.t. Ts’eej.
-LASCADO,adj. Ts’éets’eej.
-LÁSTIMA,sus. Men óolal
-LASTIMAR,"v.t. K’iil, toop, k’ii"
-"LASTIMARSE, HERIRSE",v.i. Ki’impajal.
-"LASTIMADO, MUY LASTIMADO",adj.Pu’upu’uch
-LÁTEX,sus. Iits
-LATIGAZO,sus. Jaats’
-LATIR,v.i. K’i’inam
-"LATIR EL PULSO, SALTAR COMO LOS NERVIOS",v.i. Titip’ánkil
-LAVANDERA,sus. Ix p’o’
-LAVANDERO,sus. J p’o’.
-LAVADO,sus. P’o’.
-LAVAR,v.t. P’o’
-LAZAR,v.t. Léej
-LAZO,sus. Jook’.
-"LECCIÓN, LECTURA",sus. Xook
-LECTO,ESCRITURA.
-LECHE,sus. K’aab iim
-LECHONA,sus. Ch’úupil k’éek’en
-LECHUZA (GLAUCIDIUM),sus. T’oojka’ x nuuk
-"LEER, ESTUDIAR, CONTAR",v.t. Xook
-LEGUA (MEDIDA DE LONGITUD DE CUATRO KILÓME,
-TROS),sus. Lub
-LEJANO,Adj. Náach.
-LEJOS,adv. de l. Náach
-LENGUA,sus. Aak’
-LENGUAJE,sus. T’aan.
-LENTAMENTE,"adv. de m. Chaanbéelil, cha"
-LEÑA,sus. Si’
-LEÑAR,v.t. Si’intik.
-LEPRA,"sus. Jaway, chachak uay"
-LETRA,sus. Wooj
-LEVADURA,sus. Paj sakan
-LEVANTAR,"v.t. Líik’, li’is LEVANTAR SUSPENDIENDO CON LAS DOS MANOS"
-UNA JÍCARA,v.t. Láat’
-LEVANTAR O ENCENDER LA GUERRA,v.t. Tsay
-LEVANTAR PUEBLOS,"v.t. Líik’saj kaajtal, líik’saj k’atun kaajo’ob."
-LEY,sus. A’almaj t’aan.
-LEY DEL PONTÍFICE,sus. Ya’almaj t’aanil ajaw
-LEY DEL REY,sus. Ya’almaj t’aanil ajaw.
-LIADA APRETADAMENTE,adj. Jep’ LIANAS O BEJUCOS FLEXIBLES Y RESISTENTES QUE SIRVEN PARA AMARRAR LA ESTRUCTURA DE LA
-CASA,sus. Aanikab
-LIBÉLULA,"sus. Xtulix, xturix"
-"LIBERACIÓN, SALVACIÓN",sus. Tóoksajil.
-"LIBERTADOR, SALVADOR",adj. Aj tóoksajil
-"LIBERAR, SOLTAR",v.t. Jáalk’ab
-LIBERTAD,"sus. Síij óol, jalk’abil, jáalk’a’abil"
-LIBRAR ARREBATANDO,v.t. Tóok
-LIBRAR QUITANDO,v.t. Tóok.
-LIBRARSE DE CARGO,"v.i. Sip ik’, mak k’och"
-LIBRARSE DE LO QUE LE IMPUTAN,v.t. Mak k’och
-LIBREMENTE,adv. de m. Síij óolal
-LIBRO,"sus. Ánaltee’, pikju’un, salbiju’un"
-LÍDER,"sus. Jalach, poolil, jo’olil, jo’ol póop."
-LIEBRE,sus. Tsuub
-LIJAR,v.t. Jix LOCO
-LIMA,"sus. Jaab, juux, jóoch."
-LIMADO,"adj. Jii’an,ji’ix kaya’an."
-LIMAR,"v.t. Jaab, jáay."
-LÍMITE,sus. Xuul
-LIMOSNA,"sus. Yatsil, ts’ayatsil."
-LIMPIADA DE SUCIEDAD,adj. Pita’an
-LIMPIAR,v.t. Bili’in.
-"LIMPIAR, ESCOMBRAR",v.t. Ch’óoch’.
-LIMPIAR CON PAPEL O TELA,v.t .Cho’oik.
-LIMPIAR sacudiendo,v.t. Púust.
-LIMPIAR UN PLATO O UNA VASIJA,v.t. Chúul.
-"LIMPIO, SIN HIERBA",adj. Bibilki.
-LIMPIO,adj. Ma’ éek’i’
-"LIMPIO, SIN POLVO",adj. Pu’upu’uski.
-"LIMPIO, VACÍO",adj. Jojochil.
-LIMPIO DEL CUERPO,adj. Kekexkij.
-LIMPIO REFIRIÉNDOSE A CASA,"adj. Míisa’an LIMPIO, MUY LIMPIO. Bíibíilki."
-LINAJE,"sus Ch’i’ibal, olom"
-LINDERO,sus. Ektolol
-LÍNEA,sus. T’o’ol
-LIQUEN,sus. Me’ex cháak.
-LISO,"adj. Táax, babayki"
-"LISO, MUY LISO",adj. Báabayki.
-LISO Y RESBALOSO,adj. Ts’íits’iiki.
-LISONJERO,adj. Aj bay pool
-LISTA,sus. Wewel
-LISTA DE PERSONAS,sus. Tsool k’aaba’ob
-LISTADO DE COLORES,adj. Wewel
-LISTO,adj. Ts’o’ok beyo’
-"LISTO, ATENTO","adj. P’il ich., ts’aaj óol"
-LITERA PARA VIAJAR,sus. Pepem che’
-LITORAL,"sus. Jáal já, chi’ ja’"
-LIVIANO DE PESO,adj. Sáal
-LODAZAL,sus. Ts’oots’oopki.
-LO MÁS FUERTE Y DURO DE LA MADERA DE UN ÁR,
-"BOL, EL CORAZÓN DEL ÁRBOL",sus. Chulul
-LO MÁS IMPORTANTE,sus. Noj lail
-LO QUE HA DE SER PROMOVIDO,sus. Kulkinbil
-LOCALIDAD,sus. Kaaj.
-LOCALIZAR,v.t. Kaxan
-LOCO,"adj. Choko pool, choko jo’ol, saatal"
-LOCOMOTORA,"sus. Tsíimin k’áak’, wakax múuk’."
-LOCUTOR,sus. Aj num chi’
-LODO,sus. Luuk’.
-LOGRAR,"v.t. Náajal, najmat, chuuk."
-LOMA O MÉDANO DE ARENA,"sus. Tséel ka’anil k’áanab, tséel ka’an."
-LOMBRIZ DE TIERRA,sus. Lukum kaan
-LOMO,"sus. Paach, pu’uch"
-"LOMO , ESPINAZO DE CUALQUIER CUADRÚPEDO",bil sus. Sibnel.
-LORO,"sus. T’uut’, x t’uut’"
-LOTE BALDÍO,sus. X tokoy
-LUCERO DE LA MAÑANA,"sus. Aj ajsaj, kab eek’, noj eek’, xuux eek’"
-LUCIÉRNAGA,sus. Kóokay
-LUCHAR CUERPO A CUERPO,"v.t. P’iisba, p’iislam"
-"LUCHAR, DEBATIR, PELEAR","v.t. Paaklam muuk’. P’iislam muuk’,"
-LUEGO,adv. de t. Ka’ tun
-LUEGO QUE,adv. de t. Kitak
-LUGAR,sus. Kúuchil
-"LUGAR DE MALEZA, BREÑAS Y ESPINAS",sus. Lo
-LUJURIA,sus. Ko’il
-LUMBAGO,sus. Kampach
-LUMBRE,sus. K’áak’
-LUNA,sus. Uj
-LUNA LLENA,"sus. Yi’ij uj, túulis uj, ts’aykan uj"
-LUNA NUEVA,"sus. paal uj, yáax uj"
-LUNAR,"sus. Ta’ uj, yuuy"
-LUZ,"sus. Sáas, sáasil."
-LLAMA DEL FUEGO,"sus. Yaak’, k’áak’"
-LLAMADA,sus. K’aaba’maj
-LLAMAR,v.t. T’aan.
-LLAMAR CON LA MANO,v.t. Béech’k’abt
-LLANO,"adj. Táax, táax lu’um."
-LLANTO INTENSO,sus. Banbanok’ol
-LLAVE,"sus. Je’eb, ch’otob, x ch’otobil."
-LLEGAR,"v.i. Taal, k’uchul, u’ul, kóoj, k’óojol."
-LLEGAR,v.i. K’uch.
-"LLEGAR, VENIR",v.i. U’ul.
-LLEGAR AL CORAZÓN,v.t. Najal ti’ol
-LLENAR,v.t. Chuup
-LLENARSE EL VIENTRE DE VIENTO,v.i. T’ibal.
-LLENO,"adj. Chuup, chuka’an."
-LLENO DE AIRE,adj. P’op’oltal
-LLENO DE MALEZA,adj. Loob
-LLENO POR HABER COMIDO SUFICIENTE,adj. Na’aj
-LLEVAR,v.t. Bis
-LLEVAR EN UN PUÑADO,v.t. Lóoch’. LLEVAR CARGADO O APOYADO SOBRE EL HOMBRO
-DETRÁS DEL PESCUEZO,v.t. Lechkaltaj
-LLORAR,v.i. Ok’ol
-LLORIQUEAR,"v.i. Xuxuch ni’, xuxub ni’."
-LLORÓN,"adj. Chéech, chéech keep."
-LLOVER,"v.i. K’áaxal ja’, K’áaxal cháak"
-LLOVIZNA,"sus. Banaja’, tosja’, wíits’ij ja’."
-LLUVIA,sus. Cháak.
-LLUVIA QUE MOJA LEVEMENTE LA TIERRA,sus. Lak may. LLUVIA
-"MACHACAR,TAMULAR EN MOLCAJETE",v.t. K’uut.
-"MACHACADO, TAMULADO",adj. K’uuta’an.
-"MACHACAR, APLASTAR APACHURRAR",v.t. Puu
-MACHETE,"sus. Máaskab, x"
-MACHO,sus. Xiibil ba’alche’
-MADERA,sus. Che’
-MADRASTRA,sus. X
-MADRE,"sus. Na’, na’tsil."
-MADRINA,sus. Ye na’
-MADRUGADA,"sus. Ajal kaab, sáastal"
-MADRUGADOR,sus. Aj jatskaab ajal
-MADURACIÓN,sus. Yiijtalil
-MADURAR,v.i. Tajal
-MADURAR,adj. Síisíip’ki.
-MADUREZ DEL MAÍZ,sus. Yij
-MADURO PARA FRUTAS,"adj. K’an, tak’an,"
-MAESTRA DE ESCUELA,"sus. X ka’ansaj xook, X"
-MAESTRO DE ESCUELA,"sus. Aj ka’ansaj xook, J tak’antak. ka’anbesaj ka’anbesaj"
-MAGIA,sus. K’askunaj ich.
-MÁGICO,v.t. Esaj
-MAGULLADO,adj. Maxal
-"MAGULLAR , MACHACAR, LASTIMAR",v.t. Nuul.
-MAÍZ (ZEA MAYS L),"sus. Ixi’im, xi’im"
-MAÍZ AMARILLO,sus. K’an ixi’im MAÍZ BLANCO (SU CICLO DE PRODUCCIÓN ES DE 
-DÍAS),"sus. Sak ixi’im, x nuuk nal"
-MAÍZ DE GRANOS AZULOSOS,sus. Éek’jub
-MAÍZ DE GRANOS COLOR ROJO OSCURO,sus. Éek’chob
-MAÍZ DE GRANOS ROJOS,"sus. Chakchob MAÍZ DEL GALLO, VARIEDAD DE MAÍZ QUE TARDA  DÍAS EN DESARROLLARSE."
-DÍAS),sus. X mejen nal
-MAÍZ TIERNO,sus. Ak’ ixi’im
-MAJAR,v.t. Pech’ pets’
-"MAJAR, MACHACAR, MAGULLAR",v.t. Maax.
-"MAJAR, APLASTAR",v.t. Yaach’
-MAJESTAD,"sus. Aj tepal, tepalil MAKAL O ÑAME (DIOSCORACEAE (DIOSCOREA ALATA"
-L)),sus. Makal
-MAL,"sus. K’aas, loob"
-MAL DE PINTO,"sus. Wáaway, Paj is."
-MALDECIR,"v.t. Manab chi’, loolobt’aantik."
-MALDICIÓN,"sus. Kóots ak’il, ak’ayil"
-MALDITO,adj. Aj ak’ayil
-MALEZA,"sus. Aban, jaban, loob"
-MALO,"adj. Ma’ patali’, k’aas."
-MALOLIENTE,"adj. P’u’us, tu’"
-MALTRATAR,v.t. Ba’abaj toop.
-MAMA,sus. Chu’uch
-MAMÁ,"sus. Na’, maamatsil, natsil."
-"MAMAR, SUCCIONAR",v.t. Chu’uch. MAMEY DE SANTO DOMINGO (MAMMEA AMERICANA
-L),sus. Chakalja’as.
-MANADA PEQUEÑA DE ANIMALES,sus. Banab.
-MANANTIAL,"sus. Aklin, sayab."
-"MANAR, CHORREAR",v.i. Chooj.
-MANCHADO,adj. Wewel
-MANATÍ,"sus. Téek, chiil."
-MANCHA,sus. Xiijul. MANCHA DE COLOR VIOLETA QUE TIENEN ALGUNOS
-NIÑOS EN LA ESPALDA SOBRE EL COXIS,sus. Waaj
-MANCHADO POR PARTES,adj. Wéeweek’
-MACHACADO,adj. Ya’ach’ta’an
-"MANDAMIENTO, LEY",sus. A’almaj t’aan.
-MANDAR,"v.t. A’alaj, a’almaj"
-"MANDAR, ENVIAR","v.t. Túux, túuxt, tusbeel"
-MANDATO,sus. A’almaj t’aan
-MANDÍBULA,sus. Kama’ach
-MANERA,"sus. Yalul, bixil."
-MANGLAR,sus. Chuk te’
-MANGO DE HERRAMIENTA,sus. Lap’k’abil
-MANIFESTAR,v.t. E’esaj.
-MANIFIESTO,adj. Xech
-"MANIQUÍ, MUÑECO",sus. Wenak
-MANO,sus.K’ab.
-MANOSEAR,v.t. Máamaachik.
-"MASCAR, MASTICAR",v.t. Cha’ach.
-MANOJO O ATADO,adv. de c. K’áax
-MANOJO DE ALGO,adv. de c. Jikipil
-"MANOJO DE CUALQUIER COSA, COMO VARAS, CABE",
-"LLOS, VELAS, ETC",adv. de c. Cháach MANSO.
-MANTA,sus. Nook’
-MANTECA,sus. K’ab tsaats.
-MANTEL,sus.U nook’il mayak che’.
-MANTENER,v.t. Tséent
-MANUAL,sus. Nu’ukul ku tsoolik wáa ba’ax.
-MAÑA EN CUALQUIER COSA,sus. Nonojil
-MAÑANA,adv. de t. Sáamal
-"MAÑANA, EL AMANECER",sus. Ja’atskab k’iin. MAPACHE (PROCYON LOTOR SCHUFELDTI(NELSON Y
-GLODMAN)),sus. K’ulu’
-MAR,"sus. K’áanab, k’áak’náab, k’áanáab"
-MARAÑA,sus. Mamak.
-MARAVILLAR,v.i. Nunuyaktaj
-MARAVILLARSE DE ALGUNA PERSONA COMO DESCO,
-NOCIÉNDOLA,v.t. Makat MEADO
-MARAVILLOSA,adj. Máktsil
-MARIDO,sus. Iicham
-MARIPOSA,sus. Péepen
-MARIPOSA NOCTURNA,sus. Áak’ab ts’unu’um
-MARISMA,sus. Uk’um
-MARRANA,"sus. Ch’úupil k’éek’en, x leech"
-MARRANO,sus. K’éek’en
-MARTILLO,sus. Bajab.
-MÁS,adv. de c. Paymun
-MAS,conj. advers. Jebak
-MÁS TARDE,"adv. de t. Ka’akate’, ma’ sáame."
-MASA DE MAÍZ,sus. Sakan
-MASA ENCEFÁLICA,sus. Ts’o’om.
-MASAJE,"sus, v.t. Páats’, yeet’, yoot’."
-"MASCAR, MASTICAR",v.t. Jaach
-"MASCAR, ROER",v.t. K’uux.
-MÁSCARA,"sus. K’oj, piix ich."
-MASCULINO,adj. Xiib.
-MASTICAR,"v.t. Cha’ach , jaach’."
-MASTICAR VARIAS VECES,v.t. Jáajaach’.
-"MASTICADO POR BOCA GRANDE DE CABALLO, MA",
-"RRANO, PERRO",adj. Cha’acha’an.
-MASTICADO POR BOCA PEQUEÑA DE RATA O TUZA,v.t. Ne’ene’es.
-MASTURBACIÓN,"sus. Kol ach, baxalba."
-MASTURBACIÓN MASCULINA,sus. Kóol keep
-MASTURBARSE,v.i. Baxalba
-MATANZA,sus. Banban kíimsaj
-MATAR,"v.t. Kíins, kíimsaj."
-MATERIA,sus. Ba’alil.
-MATERIA DE UNA HERIDA,"sus. Puj, pu’uj jal."
-MATERNO,adj. Na’itsil.
-MATORRAL,sus. Aban
-MATRIMONIO,"sus. Ts’o’okol beel, k’amnikte’"
-MATRIZ,sus. Sayomal.
-MAXILAR,sus. Kama’ach
-MAYOR,adj. K’ojol.
-MAYOR,adj. U nojochil
-MAYORÍA,adv. U ya’abil.
-MAZORCA DE MAÍZ,sus.Tiijol nal.
-"MEADO, ORÍN",sus. Wíix
-"MEAR, ORINAR",v.i. Wiix.
-MECAPAL,"sus. Táab MECATE, MEDIDA AGRARIA DE  M O DE  M"
-LINEALES,sus. K’aan(Para el singular) Ts’áak (Para el plural)
-MECER,v.t. Úumbal
-MEDIA NOCHE,sus. Chúumuk áak’ab
-MEDIANO,adj. Tuntun
-MEDIBLE,adj. P’iisbe’en
-MEDICINA,sus. Ts’aak
-MÉDICO,sus. Ts’aak yaaj MEDIDA DE LONGITUD ENTRE EL DEDO PULGAR Y EL
-MEÑIQUE CON LA MANO ABIERTA,sus. Náab
-MEDIANTE,adj. Tu yo’olal.
-MEDIDA,"sus. P’iis, p’iisib, betan."
-MEDIDO SIN ORDEN,adv. de m.P’íip’iis
-MEDIO,"sus. Táankuch, táan chúumuk, táan"
-"MEDIO MADURO, A PUNTO DE MADURAR",Adj. K’aas chumuk tak’an
-MECERSE,v.i. Úumbal.
-"MEDIO, MEDIA","adj. Chúumuk, búuj."
-MEDIODÍA,sus. Chúumuk k’iin
-MEDIR,v.t. P’iis
-MEDITAR,"v.t. Nen óol, num óol"
-MÉDULA,sus. Noy
-MEJILLA,sus. P’u’uk
-MEJOR,"adj. Paymun, u ma’alobil"
-MELLIZO,sus. Iich
-MEMORIA,sus. K’aj lay
-MEMORIZAR,v.t. oksaj ti’ pool.
-MENCIONAR,v.t. Ch’a’ chi’.
-"MENDIGAR, PEDIR",v.t. Máat
-MENDIGO,sus. Aj k’áat matan.
-MENEAR,v.t. K’u’uy
-"MENEAR, MOVER ALGÚN LÍQUIDO",v.t.Yúuk
-MENOR,"adj. U chichanil, t’uup."
-MENOS,"adv. de c. Ma’ chuka’an , matla"
-MENOS ENTRE OTROS,adv. de c. Tuntumil
-MENOSPRECIAR,v.t. Kúulpaachkúuns
-MENSAJERO,sus. Aj bisaj t’aanilo’ob
-MENSO,adj. Meelen keep 
-MENSTRUACIÓN,"sus. Ilmaj, jula, k’asal, ulis, uj"
-MENTIR,v.t. Tuus
-MENTIRA,"sus. Tuus, tuusil."
-MENTÓN,sus. No’och
-MEÑIQUE,sus. T’uup
-MEOLLO,sus. Noy
-MERCADO,"sus. Najil koonolo’obi’, u kúuchil koonol."
-MERCANCÍA,sus. Koonol.
-MERMAR,v.i. Jáatspajal
-MES,"sus. Wináal, yuil"
-MESA,sus. Mayak
-MESA DE MADERA,"sus. Mayak che’, táax che’, wi’ileb che’, táas che’."
-MESA DE PIEDRA,sus. Mayak tuunich
-METAMORFOSIS,sus. Wayasbil.
-METATE,sus. Ka’
-METEORO,sus. Túux ka’an
-METER,"v.t. Oks, oksaj, ts’ot"
-METER,v.t. Juup.
-"METER, INTRODUCIR",v.t. Kaap.
-"METER, INSERTAR",v.t. K’aap.
-"METER, EMBUTIR",v.t. Chook’.
-METER POR LA FUERZA EN LUGAR ESTRECHO,v.t. METER DE CUALQUIER
-MANERA,v.t. Chok’la’antaj Chóochook’an.
-METIDO VARIAS VECES,adj.Táatáak.
-MEZCLA,"sus. Xa’ak’, xe’ek’"
-MEZCLADO,adj. Xa’ak’a’an
-MEZCLAR,"v.t. Xa’akit, ta’anbesaj, xa’ak’."
-MI,adj. poses. In.
-MICO DE NOCHE (POTTOS FLAVUS),sus. Áak’ab ma’ax
-MIEDO,"sus. Sajkil, sajak, sajakil"
-MIEDOSO,adj. Sajlu’um
-MIEL,sus. Kaab
-MIEL CUAJADA,sus. Moom
-MIENTRAS,"adv. de t. Kalikil, láakej"
-MIENTRAS,"adv. de t. Kali’ikil, entas."
-"MIERDA, EXCREMENTO",sus. Ta’
-MILAGRO,sus. Maktsil
-MILES,sus. Jun pik
-MILPA,sus. Kool.
-MILPA DEL PRIMER AÑO DE TUMBA,sus. Ch’áakbeen.
-MOLLEJÓN O PIEDRA DE AFILAR,sus. Jux
-MOMENTO,adv. de t. Súutuk
-MOMOTO TURQUÍ,sus. Tooj
-MONDONGO,sus. s’áanchakbil u tsuukel
-MILPERO,"sus. Koolnáal,Aj koolkaab"
-MINOTAURO,sus. Aj wíinik wakax.
-MÍO,pron. poses. Intia’al
-MIRADOR,sus.Ka’anal kisneb naaj.
-MIRAR,"v.i., v.t. Paakat, cha’ant, il."
-MIRAR DE SOSLAYO O CON DISCRECIÓN,v.i. Báa
-"MIRAR DURAMENTE, CON FIEREZA",v.i. Lek’
-NECESITADO,adj. Aj numya
-MISA,Sus. Noj k’ul t’aan.
-MISERIA,sus. Munya
-MISERABLE,"adj. J máan óotsil, J munyaj."
-MISERICORDIA,sus. Yatsil
-MISMO,sus. Batsil
-MISTERIO,sus. Talam
-MITAD,"sus. Táankuch, táan chúumuk, tánkoch, búuj."
-MIXTO,adj.Xa’ak’a’an
-MOCO,sus. Síim.
-MODO,"sus. Yalul, bixil."
-MOFA,sus. P’a’as
-"MOFAR, BURLAR, DESDEÑAR",v.t. P’a’as.
-MOFETA,sus. Pay ooch
-MOHO,sus. Kuuxum
-MOJADO,"adj. Poopoop, ch’uul."
-"MOJAR, HUMEDECER","v.t. Ch’uul, Ch’u’ulul."
-MOJÓN,sus. Multun
-MOJONERA,"sus. Multun, xu’uk’."
-MOLCAJETE,"sus. X k’uutub, k’uut ka’"
-MOLER,v.t. Juuch’.
-"MOLIDO, MASA",sus. Juuch’.
-"MOLER, TRITURAR, REDUCIR A POLVO","v.t. Mux MOLDEAR, MODELAR, FORMAR. V.t. Paat."
-MOLER EL NIXTAMAL,v.t. Juuch’
-MOLESTAR,"v.t. Top, p’u’ujsaj."
-MOLESTAR,v.i. P’úup’u’uj.
-MOLESTO,"adj. Ts’íik, k’uux, p’u’uj, níichbal, k’áax elenche’ ch’úup. wakax."
-MONEDA,sus. Táak’in.
-MONEDA DE ORO,sus. K’an táak’iin
-MONO ARAÑA (ATELES SP),sus. Ma’ax
-MONO AULLADOR (ALOUATTA PALLATA MEXICANA),sus. Ba’ats’
-MONTAÑA,sus. Bolon wits
-MONTAR,v.t. Naat’
-"MONTARÁZ, ARISCO, HURAÑO",adj. K’o’ox.
-MONTE,sus. K’áax
-MONTE ALTO,"sus. Ka’anal k’áax, nukuch"
-MONTE BAJO,"sus. Jubche’, jub che’, ju’che’, ke"
-MONTE DE ALTURA MEDIANA,sus. Ka’a kool
-MONTE DE VENUS,sus.Cho’ono’ob u chíikul x
-MONTÍCULOS,sus. P’óop’ool.
-MONTÓN,adv de cantidad.
-"MAÍZ, TIERRA",sus. Ban
-MONTÓN DE GRANOS O COSAS MENUDAS,sus. Tsuk
-MONTONES,sus.Túutúuk.
-MONTÓN PEQUEÑO DE CUALQUIER COSA,sus. Nik
-MONTURA,sus. Xek
-MOÑO,sus. T’uuch
-MORADO,"adj. sus. Chak ya’ax, ya’ax ch’ooj."
-MORAR,v.i. Kaaj
-MORAR ENTRE MUCHOS,v.i. Molkaajtal
-MORCILLA O MORONGA,sus. Alimento que se prepara rellenando el intestino del ma
-MORDER,"v.t. Chi’b, chi’, níich’."
-"MORDER, LADRAR",v.i. Chi’ibal
-MORDER CON LOS INCISIVOS COMO LA TUZA,v.t. p’uja’an. Néet’.
-MORDIDO VARIAS VECES,adj. Náanaachan.
-MORDISCO,sus. Níich’.
-MORDISQUEADO,adj. Níiniich’.
-MORIR,"v.i. Kíimil, kíim"
-MORRAL DE FIBRA DE HENEQUÉN,sus. Sáa
-MORTAJA,sus. Tep’ kiimén
-MOSCA,sus. Ya’ax kach
-MOSCA GRANDE DE COLOR VERDE,sus. Al ya’ax
-MOSCA VERDE,sus. Tsíintsíin.
-MOSCO,sus. K’oxol
-MOSTRAR LOS DIENTES,v.t. Nich’
-"MOSTRAR, EXHIBIR, ENSEÑAR",v.t. E’es
-MOTAS DE ALGODÓN O HILO,sus. Mamil taman
-MOTÍN,sus. P’ujul
-MOTIVAR,v.t. Ts’a óol
-MOVER,"v.t. Péek, péeks."
-"MOVER, REVOLVER",v.t. Chíik. MOVER UN ALIMENTO LÍQUIDO Y ESPESO DURANTE
-SU COCIMIENTO,v.t. Júuy.
-MUJER,"sus. Ko’olel, x ba’al"
-MUJER NOBLE,sus. X ajauil
-MULTIPLICAR,"sus. Ya’abal, aalan kil."
-"MULTIPLICARSE, AUMENTARSE",v.i. Chaketjal.
-MULTITUD,"sus. Piktanil , múuch’ul"
-MUNDO,sus. Kaab
-MUNICIPIO,sus. Méek’tan kaajil
-MUÑECO,sus. Wenak
-MURALLA,"sus. Pa’, tulum, pa’ tuun."
-MURCIÉLAGO,sus. Soots’
-MURMURAR,v.t. Mukul t’aan
-MÚSCULO,sus. Bak’
-MUSGO,"sus. Tsuk max, me’ex cháak"
-MÚSICA,sus. Páax
-MÚSICO,"sus. Aj páax, j páax, j páaxnáal."
-MUSLO,sus. Muk’ ook
-MUY,adv. Paymun MUY (PREFIJO PARA FORMAR EL SUPERLATIVO DE LOS
-ADJETIVOS CALIFICATIVOS),"Sem, jach, lem, lemkech, seten, semkech, jéet, jeta’an, táaj."
-MUCHACHA,"sus. Ch’úupal, x ch’úupal"
-MUCHACHO,"sus. Xi’ipal, xi’ib pal, xi’ipaj."
-MUCHAS VECES,adv. de c. Junak
-MUCHO,"adv. de c. Ya’ab, ya’abach, ya’abkach,"
-MUY APRETADO,adj. Jíich’il
-MUY ATADO,adj. K’ak’áax
-MUY FRESCO Y LIMPIO,adj. Kekexki.
-"MUY LLENO DE AGUA, O QUE SE INUNDA",adj . tinbantsil.
-"MUCHÍSIMO, DEMASIADO",adv. Séeséen.
-MUDAR,"v.i. Jelep, jeel, jelkunaj"
-MUDAR DE PIEL LA VÍBORA,v.i. Jeleb.
-MUDARSE,v.i. Jelaj
-"MUDARSE, CAMBIARSE DE ROPA",v.t. Jeel.
-MUDARSE DE VIDA,v.i. Jeelbes a kuxtal
-MUDO,adj. Toot
-MUELA,"Cha’an koj, cha’am"
-MUERTE,sus. Chamay baak
-MUERTO,sus. Kimen
-MUESTRA,"sus. Yalul, chíikul Búubuulki."
-MUY CURVEADO,adj. Lo’olo’ochki.
-MUY DERRUMBADO,adj. Níiniik.
-MUY LLENO DE COMIDA,adj. Na’aj
-MUY MAGULLADO,adj. Nunulaja’an
-MUY MANCHADO O SUCIO,adj. K’ook’ool.
-MUY METIDO,adj. Láalaanki.
-MUY MOJADO,adj.Susulki.
-MUY MOLESTO (A),adj. P’úup’u’uja’an.
-MUY MOLIDO,adj. Múumuuxki.
-MUY MOJADO,adj. Poopoopki.
-MUY ODIADO,adj. P’éep’eeka’an.
-NÁCAR,sus. Mak.
-NACER,"v.i. Síijil, síij, yaantal"
-NACIMIENTO,sus. Síijil.
-NADA,adv. de n. Mixba’al
-NADAR,"v.i. Báab, báaxal ja’"
-NADAR DEBAJO DEL AGUA,v.i. Muuk ja’
-NADIE,adv. de n. Mix máak
-NALGA,sus. P’u’uk iit
-NANA,sus. X kanan paal.
-NARANJA AGRIA (CITRUS AURANTIUM L),sus.
-NERVIO,sus. Xich’
-NI,adv. de n. Mix
-NI HABLAR,adv. de n. Mix t’aan
-"NI MODO, NI REMEDIO",adv. de n. Ja’alibe’.
-NIDO,sus. K’u’
-NIETO,"sus. Áabil, wáabil, áabitsil."
-NIGROMÁNTICO,sus. Wáay xibalbailo’
-NIGUA (DERMATOPSYLLA PENETRANS),sus. Al ch’ik
-NINGUNO (PERSONA),pron ind. Mixmáak.
-NINGUNO (PERSONA O ANIMAL),pron ind.Mix
-"NARANJA DULCE ( CITRUS SINENSIS, OSB)",sus. Suuts’ pak’áal Ch’ujuk pak’áal.
-NARIZ,sus. Ni’
-NARRADOR DE HISTORIAS,"sus. Aj kansiyaan, Aj tsikbal k’ajlay."
-NARRAR,v.t. Tsikbal.
-NATA,sus. Oots’
-NAUFRAGAR,"v.i. Nokop, sat, búulul"
-NAUFRAGIO,sus. Nokopa’il
-NAÚFRAGO,adj. Aj nokop.
-NAVEGAR,"v.i. Báab, bubil, cheemul, xot ja’"
-NAVEGANTE,sus. J cheemnáal.
-NEBLINA,sus. Ye’eb
-NECESARIO,"adj. K’a’anan, k’a’ana’an, k’abéet, k’abeet, kenlik, najbe’en."
-NECESIDAD,sus. Najbe’entsil
-NECRÓPOLIS,sus. Suju’uy lu’um
-NEGLIGENCIA,sus. Náay óolal
-NEGRO,"adj. Boox, éek’"
-NEGRURA,"adj. Éek’ popos, éek’i"
-NEGRUZCO,adj. Éek’tile’en. juntúul.
-NINGUNO (COSA),adv. Mix junp’éel.
-NIÑA,sus. Chan x ch’úupal.
-NIÑA DEL OJO,sus. Néenil ich
-NIÑO,"sus. Paal, chanbal, chanpaal, chan"
-NIVEL,sus. Ka’analil
-NIVELADO O EMPAREJADO CON AGUA,adj.Yuyul
-NO,"adv. de n. Ma’, ma’ach, ma’atan, mix"
-CAL),"sus. K’u’um. taan, mun, ma’ab."
-NO ES CIERTO,"adv. de n. Ma’tech, ma’ jaajil, ma’ jaaji’, mix jaaji’"
-NO HABLAR,v.i. Ch’iikil
-NOCHE,sus. Áak’ab
-NOMBRAMIENTO,sus. Wakunaj
-NOMBRE,sus. K’aaba’
-NOMBRE PROPIO,sus. Noj k’aaba’
-NOPAL,sus. Páak’am.
-NORMAL,"adj. Ma’alob yaanil, tu beel yaanil."
-NORTE,sus. Xaman.
-NOSOTROS,pron. pers. To’on
-NOTICIA,"sus. K’aj óolal, k’ajóolo, ojelil, k’uben t’aan, péeksilo’, ts’áaj ojeltbil."
-NOVENTA,sus. Lajun p’éel ti’ jo’o k’áal
-NOVIA,sus. X ba’al
-NUBE,sus. Múuyal
-NUBLADO,adj. Nookoy
-NUBLAR,"v.i. Nookoytal, nookoychajal."
-NUCA,sus. Pachkab
-NUDO,sus. Jook’
-NUDO EN LA SOGA,sus. Mok.
-NUERA,sus. Ilib
-NUERA,"sus. X ilibtsil, x ilibtsile’"
-NUESTRO,pron. poses. K
-NUESTRO,adj. poses. K tia’al
-NUEVAMENTE,"adv. Tu ka’atéen, túunbenil."
-NUEVE,sus. Bolon
-NUEVO,adj. Túunben
-NUMERAR,v.t. Ts’áaj xookul.
-NÚMERO,sus. P’éelel
-NUMEROSO,adj. Jach táaj ya’ab.
-NUNCA,adv. de n. Mixbik’iin
-O,conj. disyunt. Wáa
-OBEDIENCIA,"sus. Ch’a t’aan, u’uy t’aan."
-OBEDIENTE,adj. U’baj t’aan
-OBJETO,sus . Ba’al.
-OBJETIVO,sus. Ba’al unaj u beeta’al.
-OBLIGACIÓN,sus. K’ochbesajul.
-OBLIGAR Y CULPAR,v.t. K’uchbesaj
-OBLIGAR A HACER O NO HACER ALGO,v.t. Taataak
-OBLIGAR,v.t. Ts’alpaachtik.
-OBRA QUE UNO HA HECHO,sus. Kelemal.
-OBSCURECER,"v.i. Eéjoch’e’ental , e’same’en."
-OBSCURO,"adj. Ee’joch’e’en, e’same’en."
-OBSEQUIO,sus. Siibal.
-OBSERVAR,"v.t. Cha’ant, cha’an, il."
-OBSIDIANA,sus. Sim tun
-OBTENER,v.t. Aantal.
-OBSTINACIÓN,sus. Nolmail
-OBSTINADO,adj. Nonolki
-OCASO,"sus. Éemel kaab, t’úubul k’iine’"
-OCIO,sus Mak’ óolal.
-OCIOSO,adj. J mak’ óolal.
-OCTAVO,adj. U waxakp’éel.
-OCULTAR,v.t. Ta’ak
-"OCULTAR, ESCONDER, ENCUBRIR",v.t. Baal.
-OCUPACIÓN,"sus. Al sawa’nil, meyaj."
-"OCURRIR, SUCEDER",v.t.Úuchul.
-OCHAVARIO (OCHO DÍAS DESPUÉS DE FINADOS O CELE,
-BRACIÓN DE LOS SANTOS DIFUNTOS),sus. Biix
-OCHO MIL,sus. Jun pik
-OCHO,sus. Waxak
-ODIAR,v.t. P’eek.
-ODIO,sus. P’eek.
-OESTE,sus. Chik’iin
-"OFENDER, INJURIAR",v.t. Pooch’
-OFENSA,sus. K’aas pooch’
-"OFENSA, INSULTO",sus. Pooch’il.
-OFICIO,sus. Yits’atil
-OFRECER,"v.t. Chaybesaj, ts’áabilaj"
-OFRECER AYUDA,v.t. Kóoybaj áantaj
-OFRECER O DONAR LO OFRECIDO,v.t. Ts’áabilaj.
-OFRENDA,"sus. Jo’oche’, tiich’, loojil, ti’ibil óo"
-OÍDO,sus. Xikin
-"OÍR, ESCUCHAR",v.i. U’uy
-OIR CON MUCHA ATENCIÓN,v.i.Ch’éenxikintik.
-OJAL,sus. U joolil nook’. ¡OJALÁ!.
-OJIZARCO,sus. Saak buye’en ich
-OJO,sus. Ich
-OJO DE AGUA,"sus. Aklin, sayab, sayabil."
-OLA,sus. Kukul
-OLA DE AGUA,sus. Ts’ikit ja’
-OLAS DEL MAR,sus. Yaam
-OLER,"v.i. Utsben, u’ts’ben"
-OLFATEAR,"v.t. Tsukul iik’taj, úuts’bentik, ch’a’"
-OLFATEAR PARA SACAR POR EL RASTRO,v.t. book. Bobokni’ktik
-OLFATO,sus.Uts’banaj.
-OLOR,sus. Book
-OLOROSO,adj. Ki’ibook
-OLVIDAR,"v.t. Tu’ubs, tu’ub, tubul."
-OLVIDO,sus. Manak’óol
-OLLA,sus. Kuum
-OMBLIGO,sus. Tuuch
-OMNIPOTENTE,adj. Uchuk tuméen sinil.
-ONCE,sus. Buluk
-ONDEAR,v.i. Wilta’al
-ONDULAR,v.i. Wilta’al
-OPACIDAD DEL CRISTALINO DEL OJO,sus. Sak
-OPORTUNIDAD,sus. U k’iinil
-"OPRIMIR, PRENSAR, APLASTAR",v.t. Peets’
-ORACIÓN,sus. Payalchi’
-ORADOR,"sus. Aj ku’chlu’um t’aan, Aj tse’ek t’aj t’aan."
-ORDEN,sus. Tsool.
-"ORDEN, DISPOSICIÓN",sus. A’almaj t’aan
-ORDENADO,adj. Tsoola’an
-ORDENAR,"v.t. A’almaj, ts’áaj u tumutil, tsool, tun t’aan."
-ORGULLO,"sus. Nojbail, tsikbail"
-ORGULLOSO,adj. J nojbail.
-ORIENTAR,v.t. Nu’uk bej.
-ORIENTE,sus. Lak’iin
-ORIGEN,"sus. Chuun, chúunuk"
-ORILLA,"sus. Jáal, chi’"
-ORINA,sus. Wíix’
-ORINADO,"adj. Wíixbil, wíixa’an."
-ORINAR,v.i. Wíix
-ORO,sus. K’an táak’iin
-OROPÉNDOLA,sus. Yúuyum
-ORTIGA (URERA SPP),sus. Laal
-ORUGA,sus. Balnak’ péepen.
-OSAR,v.i. Xet’ óolal
-OSO HORMIGUERO,sus. J chab
-OSO COLMENERO,sus. Sam jo’ol
-OTRA PARTE,adv. de l. Tanxel
-OTRA VEZ,adv. de
-ORDENAR Y CONCERTAR LO QUE UNO VA A HACER,"ka’ajtéeno’, tu ka’atéen v.t. Mamak t’aan"
-ORDEÑAR,"v.t. Poots’, puts’"
-OREJA,sus. Xikin
-"OREJÓN, PAROTA,GUANACASTLE",sus. Piich
-ORGANIZADOR,sus. Aj nu’ukbesaj
-ORGANIZAR,v.t. Tsool
-ORGASMO,"sus. Xexbail. t. Tu ka’ajtéen, tu"
-OTRO,sus. Uláak’
-"OTRO, OTRA, COSA DIFERENTE","Pron.Yaanal, u yaanal, jela’an."
-OVALADO,"adj. Túuts’, k’ak’atak.’"
-OVAR,"v.t. E’elankil, e’elankal, e’el, ye’el, je’eankil."
-PALO MULATO (BURSERA SIMARUBA (L) SARG),
-PACIENCIA,"sus. Taj muk’óolal, muk’ óolal."
-PACIENTE,"adj. K’uchpaja’an yóol, aj muk’"
-PACIFICAR,v.t. Toj jal óol
-PACTO,"sus. Ts’áaj t’aantanba, k’aax t’aan."
-PADECER,v.i. Muk’yaj.
-PADRASTRO,"sus. Sak yuum, majan taata."
-PADRE,"sus. Taata, taat, yuum."
-"PADRE, SACERDOTE","sus. K’iin, Yuum K’iin."
-PADRES,sus. Taatatsilo’ob
-PADRINO,sus. Ye yuum
-PAGAR,"v.t. Bo’ol, bo’ot."
-"PAGO, SALARIO","sus. Bo’ol, bo’ot."
-PAILA,sus. Máaskab kuum
-PAÍS,sus. Noj lu’um.
-"PAJA, ZACATE",sus. Su’uk.
-PÁJARO,sus. Ch’íich’
-PÁJARO CARPINTERO,"sus. Ch’ejob, ch’ejum,"
-PÁJARO NEGRO DE OJOS COMO BRASAS,sus.
-PALABRA,sus. T’aan
-PALACIO DE GOBIERNO,sus. Noj najil jala’ach
-PALADAR,"sus. Mábka’an, mab ka’an, náab ch’ojom. Ts’iiw ka’an."
-"PALEAR, CUCHAREAR",v.t. Jo’op.
-PALENQUE,sus. Jil che’
-PÁLIDO,adj. Sakpile’en
-PALILLO,sus. Ch’ilib
-PALIZADA,"sus. Jil che’, pa’, suup’."
-PALMA ( REINHARDTIA SP),"sus. Xa’an, ch’iit"
-PALMEAR,v.t. Pak’laj PALO DE TINTE (HAEMATOXYLON CAMPECHIANUM
-L),sus. Éek’ sus. Chakaj.
-PALOMA AZUL,sus. Ch’ooj tsúutsuy
-PALOMA DE PICO NEGRO,sus. Úukum
-PALOMA SILVESTRE (LEPTOLILA VERREAUXI FULVIVEN,
-TRIS) (Lawrence),sus. Tsúutsuy .
-PALOMA SILVESTRE DE PICO ROJO,sus. X chúu
-PALOMA TORCAZA DE ALAS BLANCAS (ZENAIDA ASIÁ,
-TICA),sus. Sakpakal.
-PALPAR,v.t. Tatal k’abtik.
-PALPITAR,"v.i. Kil, kil kil."
-PALUDISMO,sus. Yax ke’el
-PAN,sus. Waaj
-PANADERO,sus. Aj meen waaj.
-PÁNCREAS,sus. Pék
-PAN DE TRIGO,sus. Kastlan waaj
-PANAL,sus. Chúujil kaab.
-PAN TOSTADO,sus. Oop’
-PANELA,sus. Monkaab
-PANTALÓN,"sus. Eex, chowak eex."
-PANTALETAS,sus. Eex
-PANTORRILLA,"sus. P’ul ook, P’ul t’óon"
-"PANZA, BUCHE",sus. Tsuukel
-PAÑO,sus. Nook’
-PAÑUELO,"sus. Cho’ob, k’axab ich, tanjay, x tanja’il, cho’obol ni’."
-PAPADA,sus. K’o’
-PAPAYA (CARICA PAPAYA L),sus. Puut
-PAPEL,sus. Ju’un
-PARA,"prep. Yook’lal, yo’osal, yook’sal. PARA."
-PARAGUAS,sus. Balab ja’.
-PARA QUE,conj. fin. Utia’al.
-PARA QUE,conj. Yo’sal. ¿PARA QUÉ?.
-PARA SIEMPRE,adv. de t. K’atun
-PARÁBOLA,"sus. Etjun t’aan, keet t’aan."
-PARADO,"adj. Kuma’an, wa’alaja’an, wa’akbal"
-PARAR,v.i. Wa’atal
-PARCELA,sus. U kúuchil ichankil che’ob
-PARECIDO,"adj. Chika’an, bayjal, kéet."
-PARED,sus. Pak’
-PAREJA,"sus. Nuup, nuupul"
-"PAREJO, IDÉNTICO, IGUAL",sus. Kéet
-PARENTESCO,"sus. Makil, láak’tsilil."
-PARIENTE,"sus. Láak’, láak’tsil."
-"PARIR, DAR A LUZ",v.i. Alankil
-PAROTA (ENTEROLOBIUM CYCLOCARPUM (JACQ),sus. Piich
-PARPADEO,sus. Múumuts’
-PÁRPADO,"sus. Paach ich, boxel ich."
-PARQUE,sus. K’íiwik
-PARTE,sus. Tsúkul
-"PARTE, PÁRRAFO, CAPÍTULO",sus. Tsúuk
-PARTE DE ALGO,"sus. Jaatsul, jaatsil."
-PARTE DE UNA LECTURA,"sus. Jaats, jaatsul, ja"
-PARTE DEL CUERPO O DE CUALQUIER ANIMAL,sus.
-"PARTICIPAR EN ALGO, INVOLUCRARSE EN ALGO","v.t. Etpaljal, táakpajal"
-PARTIR,"v.t. Buuj, tej"
-"PARTIRSE, QUEBRARSE",v.i. Xíikil.
-"PARTO, ALUMBRAMIENTO","sus. K’ojol , aalankil, atsil. Bayel síijil."
-PASADO,"sus. Máanlil, máaja’an."
-PASADO MAÑANA,adv. de t. Ka’abej
-PASAR,v.i. Máan
-"PASAR LA LENGUA A ALGO, LAMER",v.t. Ma’ats’ 
-PASAR GENERALMENTE POR UN LUGAR,v.i. Mal
-PASAR SOBRE ALGO,v.t. Xáak’a’at
-PASATIEMPO,sus. Máansaj k’iin.
-PASEAR,v.i. Xíinbal
-PASO,sus. Chek ok
-PASOS LARGOS,sus. Xáak’ab
-PATA DE AVE,"sus. Mooch’, xaaw."
-PATA HENDIDA EN DOS PARTES,sus. Maay
-PATEAR,"v.t. Koko’chaak, kóochak’"
-PATEAR ALOCADAMENTE,v.t. T’íint’íinkóochak’.
-PATEAR VARIAS VECES,v.t. Jáajaancha’ata.
-PATILLA,sus. Me’ex p’u’uk.
-PATIO,sus. Táankab
-PATO,sus. Kúuts ja’
-PATRÓN,"sus. Yuum. yuumil, ts’uul, ts’uulil."
-PAUSA,sus. Junp’éel xanlil.
-PAUSADA,adj.Chaanbéelil.
-PAVA,sus. X tuux
-PAVITO,sus. Mejen úulum
-PAVO DOMÉSTICO,"sus. Tso’, úulum"
-PAVO SILVESTRE,sus. Kúuts
-PAZ,"sus. Ts’akin, jets’ óolil."
-PECADO,"sus. K’eban, si’ipil"
-PECADOR,adj. J k’eeban wíinik.
-PECADORA,adj. X k’eeban ko’olel.
-PECHO,sus. Tseem
-PEDAZO,"sus. Xeet’,xóot’"
-PEDERNAL,"sus. Tok’, tok’ tuunich"
-PEDIR,v.t. K’áat.
-PEDIR PRESTADO,v.t. Majan
-PEDO,sus. Kiis
-PEDREGOSO,"adj. Mulu’uch, k’o’lemak, tsek’el."
-PEGADA A OTRA,adv. de l. Naak’
-PEGADO,adj. Taak’al
-"PEGAR CON GOMA, ENGRUDO, ETC",v.t.Taak’ PEGAR O GOLPEAR VARIAS VECES CON LA PALMA DE
-LA MANO,v.t. Láalaaja. PEINADO.
-PEINE,"sus. Xáache’,xáacheb."
-PEINAR,"v.t. Xáache’, xáacheb, ts’íik pool, xáache’ pool."
-PELADO,"adj. Ts’i’its’i’ip, ts’íila’an, súusa’an,"
-PERDERSE,v.i. Sa’atal
-PERDERSE U OCULTARSE EN VARIAS OCASIONES,
-PELADO EN VARIAS PARTES,adj. Ts’íits’íip.
-"PELAR CON LOS DIENTES, DESCORTEZAR",v.t. v.i. Sa’asaat. k’oosa’an. Nóot’ PERTINAZ
-PELAR A UN ANIMAL CAZADO,"v.t. Ts’íil, jo’och."
-PELAR O CORTAR EL CABELLO,v.t. K’oos
-PELAR UNA FRUTA,v.t. Súus
-PELAR O CEPILLAR MADERA,v.t. Súus.
-PELDAÑO,sus. Tem
-PELEA,sus. Ba’ate’el
-PELEAR,v.t. Ba’ate’el
-PELEAR CUERPO A CUERPO,v.t. P’is
-PELÍCANO MORENO,"sus. P’oto’, p’onto’"
-PELIGRO,sus. Sajbe’enile’
-PELO,sus. Tso’ots
-PELOTA,"sus. P’ok, wóolis báaxal."
-"PELUQUEAR, CORTAR EL PELO, RAPAR",v.t. K’oos
-PELUQUERO,sus. J k’oos.
-"PELUQUERA, ESTILISTA",sus. X k’oos.
-PELLEJO,sus. Oot’
-PELLIZCAR,v.t. Xe’ep’
-PENA,"sus. Loob, munya, nat’ tseemil, ok’om óolal"
-PENAS,sus. Numyail
-PENDEJO,adj. Nun keep.
-PENDÓN,"sus. Láakam, pan."
-PENE,"sus. Keep, toon"
-PENITENCIA,"sus. Xoot óol, yaayatulul, ch’abtanil."
-PENSADOR,sus. Aj tuukul.
-PENSAR,"v.t. Nen óol, num óol, ts’áaj, tuukul."
-PENUMBRA,sus. K’aas bo’oy
-PEÓN DE HACIENDA,sus. Palitsil
-PEÓN QUE DA MEZCLA AL MAESTRO ALBAÑIL,sus.
-PEOR,adj. Paynum lobil
-"PEPITA, O SEMILLA DE CUALQUIER FRUTA",sus. Ts’áaj luuk’ Neek’.
-PEPITA DE CALABAZA,sus. Sikil
-PEQUEÑO,"adj. Chichan, chan, mejen."
-PERDER,v.t. Saat. PERDERSE EN ALGÚN OFICIO v.i. Ch’ejel
-PERDICIÓN,sus. Saatal
-PERDIDO,adj. Saata’an
-PERDIZ,sus. Noom
-PERDÓN,"sus. Sa’as si’ipil, sa’as k’eeban."
-PERDONAR,"v.t. Sa’as si’ipil, satal k’eeban"
-PERDURABLE,adj. Mina’an u xuul.
-PERFIDIA,sus. K’eeban t’aan
-PERFORADO,adj. Jom
-PERFORAR,"v.t. Poot, jool"
-PERFUME,sus. Yelma
-PERICO DE OJOS ROJOS,sus. K’ili’
-"PERIÓDICO, DIARIO","sus. Xookbil ju’un , xook"
-PERLA,sus. Yaxil tun.
-PERMANECER,"v.i. Baili’, t’ilil, t’íilit"
-PERMITIR,"v.t. Cha’, silk’a"
-PERO,"conj. advers. Jebak, kúum, kux, ba’ale’, chéen ba’axe’."
-PERONÉ,sus. Lák’ bak ook
-PERPETUAMENTE,adv. de t. Junk’uli’
-PERPETUAR,v.i. Baili’
-PERRO,sus. Peek’
-PERSEGUIR,"v.t. Áalkab paach, áalkabtaj , ch’a paach , ts’ay tu paach."
-PERSEGUIR EL PERRO A SU PRESA,"v.t. Toojol,ch’a’ paach, tsáayalpaach."
-PERSIGNARSE,v.i. Ts’íibil ich
-PERSONA,sus. Máak
-"PERSONA ALTA Y MUY DELGADA, GIGANTE MITOLÓ",
-GICO,sus. Wa paach
-PERSONA CON LA QUE SE HABLA,sus. Éet máa
-PERSONA QUE SUPERA TODO OBSTÁCULO PARA LLE,
-GAR AL FIN PROPUESTO,adj. Aj k’uchpaja’an yóol
-PERTENECER,"v.t. Yaantal ichil, táakpajal kil ichil."
-PERTINAZ,adj. K’uchpaja’an yóol
-PESADO,adj. Aal
-PESAR,v.t. P’iis aalil.
-"PESAR, TRISTEZA","sus. Muuk’ yaaj, yaaj óolal."
-PESCADO,sus. Kay
-PESCADOR,sus. Aj chuk kay
-PESTAÑA,sus. Máatsab
-PETATE,sus. Poop
-PETO,sus. U piix tseem.
-PETRÓLEO,sus. Boox yiits lu’um
-PEZÓN,"sus. Chu’uch, chúuch"
-PEZUÑA,sus. Maay
-PICADA,sus. T’oja’antak
-PICANTE,adj. Páap
-PICAR,"v.t. T’óoch, t’óoj"
-PICAR EL AVE O LA CULEBRA,v.t. T’óoch
-PICAR LAS AVES,v.t. T’ooj
-PICAR LAS PIEDRAS,v.t. T’ooj
-PICO,sus. Koj
-PIE,sus. Ook
-PIEDAD,sus.Ok’ol ich.
-PIEDRA,sus. Tuunich
-PIEDRA ADIVINATORIA,sus. Sáastun
-PIEDRA DE LA CLARIDAD,sus. Sáastun
-PIEDRA PLANA SUPERFICIAL,sus. Chaltun
-PIEDRA PLANA Y GRANDE,sus. Chaltun
-PIEL,sus. Oot’
-PIERNA,sus. Muk’ook
-"PILAR, COLUMNA, POSTE",sus. Okom
-PILETA,sus. Panab
-PIMIENTA (COLUBRINA FERRUGINOSA BRONGN),sus. Ts’ulubmay
-PINCEL,sus. Cheeb
-PINCHAR,"v.t. Loom, juup’."
-"PINCHAR VARIAS VECES, APUÑALAR",v.t. Lóo
-PINOLE (BEBIDA HECHA CON MAÍZ TOSTADO Y MOLIDO),loom. sus. K’aj
-PINTADO,adj. Boona’an
-PINTAR,"v.t. Boonik, boon."
-PINTURA,"sus. Boon, wooj"
-PIÑATA,sus. Pa’ p’úul
-PIÑUELA (BROMELIA PINGUIN L),"sus. Ch’om,  ch’am"
-PIOJO,sus. Uk’
-PIRÁMIDE,sus. K’u
-PISAR,v.t. Pe’echak’
-PISAR,"v.t. Jakche’etaj, ts’anchak’"
-PISAR ALGO SUAVE,v.t. Júupchak’.
-"PISOTEAR, PISAR ALGO VARIAS VECES",v.t. Ts’áats’áanchak’
-PISO,"sus. Lu’um,"
-PISO FIRME Y PLANO,sus. Báabáaxki.
-PITAHAYA (CEREUS UNDATUS (HAW),sus. Woob
-PITAYA ROJA (CACTACEAE (HYLACEREUS UNDATUS)),
-PIZOTE O TEJÓN (NASUA NARICA YUCATANICA ALLEN),sus. Chak woob sus. Chi’ik
-PLACENTA,"sus. Yibnel paal, ibnel, ibnil."
-PLANCHAR,"v.t. Báay, ji’ik, ji’b, tats’, ji’ nook’."
-PLANCHAR ROPA,v.t. Ji’ik nook’.
-PLANICIE,sus. Táax lu’um.
-PLANO,adj. Táax
-PLANTA,sus. Che’ PLANTA CUYAS RAMAS SON UTILIZADAS POR LOS
-YERBATEROS PARA SANTIGUAR A LOS ENFER,
-MOS,sus. Sip che’
-PLANTA DE LA MANO,sus. Táan k’ab
-PLANTA DEL PIE,"sus. Táan ook PLANTA PERENNE, ERECTA (NYCTAGINACEAE (PISONIA"
-ACULEATA L),"sus. Beeb PLANTA PERENNE, TREPADORA (EUPHORBIACEAE)"
-QUE PRODUCE COMEZÓN,sus. P’op’ox
-PLANO,adj. Táax.
-PLANTA TREPADORA,sus. Aak’il
-PLANTÍO,"sus. Pak’áal, pok’al."
-PLÁTANO (MUSA PARADIASÍACA L),sus. Ja’as
-PLATICAR,v.t. Tsikbal.
-PLATO,"sus. Lak, chób,"
-PLAYA,"sus. Jáal ja´, chi’ja’, páay."
-PLAZA,"sus. K’íiwik, chúumuk ti’ kaaj."
-PLEGAR,v.t. Paak
-"PLEGAR, DOBLAR",v.t. Wuuts’.
-PLÉYADES,sus. Tsáab
-PLOMADA,"sus. Ch’uyub máaskab, ch’uyub"
-PLOMO,sus. Ta’ uj
-PLUMA,sus. K’u’uk’um
-PLUMAJE,sus. K’u’uk’umel
-PLURAL,sus. Ya’ab
-POBLADO,"sus. Kaaj, kaajal"
-POBLADOR,sus. Kaajnáalil
-POBRE,"adj. Aj numya, óotsil"
-POBREZA,sus. Óotsilil
-POCO,"adv. de c. P’íit, jun p’íit"
-POCO A POCO,adv. de m. Jujunp’íitile’
-PODER,"sus. Kal, lox t’aan, páajtal, páajtalil."
-PODRIDO,adj. Jojok’ki.
-POEMA,"sus. Iik’ t’aan, yóolil tsikbal"
-POETA,sus. Aj iik’t’aan
-POLEM,sus. Jujuy lu’um lool
-POLICÍA,sus. Túupil
-POLILLA,"sus. Ik’el, sajkay"
-POLÍTICA,"sus. Almejen wíinikil, chuk ku’uk yo’olal. prep. Yail"
-"POR CAUSA GRANDE, GRAVE Y DE IMPORTANCIA",
-"PORCIÓN, PARTE","sus. Jaatsul, jaatsil."
-POR ÉL,prep. Tu yo’olal
-POR ESO,"prep. La’aten, lebetik, le óolal, le o’olale’, tuméen, tu yo’olal"
-POR LA MAÑANA,"adv. de t. Ja’atskab k’iin, jatskaab"
-POR PEDAZOS O ÁREAS,adv. T’óot’ool.
-POR POCO,adv. de c. Óolak
-PORQUE,Conj. Tuméen. ¿POR QUÉ?.
-POR SÍ SOLO,adv. Tu ba
-PORTAL,"sus. Noj joonaj, nojoch joonaj."
-POR TERCERA VEZ,adv. de t. Tu yóoxpáake’.
-POR CUARTA VEZ,adv de t. Tu kanpáake’.
-POR QUINTA VEZ,adv de t. Tu jo’opáake’.
-PORQUE,"conj. caus. Meentun, tuméen, yo"
-POLUCIÓN,sus. Xexbail
-POLVO,"sus. Ma’ay lu’um, jujuy lu’um"
-PÓLVORA,sus. Sabak
-POLLITO,sus. Mejen káax
-PÓMULO,"sus. P’u’uk bakel, p’u’uk ich."
-PONER,"v.t. Ts’aa, ts’áaj, ts’ik."
-PONER CUESTA ABAJO,v.t. Nix
-"PONER DISCORDIA, RENCILLA O CIZAÑA",v.t. Tak t’aan
-PONER EN FILA U ORDEN,"v.t. T’is, t’isaj, t’isbi PONER EN POSICIÓN AL BEBÉ PARA QUE ORINE O DEFEQUE, ACOMPAÑANDO LA ACCIÓN CON UN"
-BISBISEO PECULIAR,v.t. Kéex.
-PONER FIJA UNA COSA,v.t. Aktal.
-PONER O VOLVER BOCA ABAJO,v.t. Nok
-PONERSE DE CUATRO PATAS,v.i. Xak
-"PONERSE DE PUNTILLAS, O DE PUNTITAS",v.i. Liit’ib
-PONERSE LA ROPA,v.t. Búuk
-"PONIENTE, OESTE",sus. Chik’iin
-PONZOÑA,"sus. K’inam, ts’akil"
-POR,"prep. Óok’lal, o’olal, tio’olal, tu yo’olal, ¿POR QUÉ?."
-POSARSE EL AVE,"v.i. T’úuch, t’úuchul."
-POSIBILIDAD,sus. Lox t’aan
-POSIBLE,"adj. Úuchak, beychajak, jop’bentil, páajtal."
-POSICIÓN DE ALERTA,adj. Béejbeechki.
-POSTE,sus. Okom
-POSTEMA,sus. Chu’chum
-POZO,sus. Ch’e’en
-POZO QUE SE FORMA EN LOS SUELOS PANTANOSOS,sus. Xuuch
-POZOLE,sus. K’eyem
-PRACTICAR,"v.t. Túumtaj, túuntaj."
-PRECAUCIÓN,sus. Kananil
-PRECAVIDO,adj. Aj na’at ach
-PRECIO,sus. Tojol
-PRECIOSA Y DE RICA ESTIMA,adj. Koj
-PRECISIÓN,sus. Najbe’ntsil
-PRECISO,adj. Najbe’en.
-PRÉDICA,sus. Tse’ek
-PREDICAR,v.t. Tsé’ekt
-PREDICAR CON VOZ CLARA Y RECIA,v.t. Salkaltal
-PREDICCIÓN,"sus. Tomoxchi’, tamaxchi’"
-PREFERIR,v.i. Pay num.
-PREGONAR,"v.t. K’a’ayt, k’a’ay."
-PREGUNTA,"sus. K’áat t’aan, k’áat chi’"
-PREGUNTAR,"v.t. K’áat, k’áat chi’"
-PREMIO,sus. Makul
-PREMONICIÓN,"sus. Tomoj chi’, tomox chi’"
-PRENDIDO,adj. Ch’iika’an.
-PRENDER,v.t. Ch’iik.
-PRENDIDO CON FUERZA,adj. Ch’íich’iiknak.
-PREOCUPAR,v.i. Tuukul.
-PREPARACIÓN,sus. Ch’alba
-PREPARAR ALGUN OBJETO O ALIMENTO,v.t. Ma’ak’antik.
-PREPOTENCIA,sus. Paynumil
-PRESENTAR,v.t. E’esaj
-"PRESENTE, A LA VISTA",sus.Tak’kabal ich
-PRESENTIR,v.i. Kóojol
-PRESO,"sus. K’ala’an, j k’ala’an"
-PRÉSTAMO DE DINERO,sus. Páay
-PRESTAR ALGUNA COSA,"v.t. Majáant, páay PRESUMIR"
-ENVANECERSE,O v.i. Nojba’alkuntikubáa.
-PRESUNCIÓN,sus. Nonojbail
-PRESUMIDO,sus. Aj nonojbail.
-PRETÉRITO,"sus. K úuchi, máanlil."
-PREVENIR,"v.t. Ch’aba, paybe"
-PRIMAVERA,sus. Yáax k’iin
-PRIMERAMENTE,"adv. de t. Bat’an, paybe’en"
-PRIMERO,"adj. Yáax, yáax táanil"
-PRIMERO,adv. de l. o t. Bat’an
-PRIMICIA,sus. K’aam.
-PRIMA,sus. Ka’a kiik.
-PRIMO,sus. Ka’a suku’un.
-PRINCIPAL,"adj. K’ojol, noj lail"
-PRINCIPIO,"sus. Chuun, chúunuk"
-PRINGAR O SALPICAR,v.t. Wíiwíits’.
-PRISIÓN,"sus. che’,núup’. K’alab máaskab, k’aal"
-"PROBAR, EXPERIMENTAR","v.t. Túumtaj, túum, túuntaj. "
-PROBLEMA,sus. Toop
-PRODIGABILIDAD,sus. Síij óol.
-PRÓDIGO,adj. Aj síij óol.
-PRODUCIR,"v.t. Beete, meent."
-PROFETA,"sus. Aj bobat, aj chilam"
-PRÓFUGO,sus. Aj puuts’ul
-PROFUNDO,adj. Taam
-"PROHIBIDO, VEDADO",adj. Weet’a’an
-"PROHIBIR, IMPEDIR, VEDAR",v.t. Weet’
-PRÓJIMO,sus. Éetwíinikil
-"PRÓLOGO, INTRODUCCIÓN","sus. Pay bet’aan, oksaj t’aan."
-PROMESA,"sus. Jóok’ chi’, pa chi’"
-PROMETER,"v.t. Chi’isaj, jok’ chi, sebchi’tik."
-PROMOVER A OFICIO,v.t. Kumbinaj
-PRONÓSTICO,sus. K’iinyaj t’aan
-PRONTO,"adv. de t. Téek, séeba’an, séebik"
-PRONUNCIACIÓN,sus. Sutupak
-PRONUNCIAR,v.t. A’al.
-PROPORCIONAR,"v.t. Tich’, ts’a."
-PROPÓSITO,sus. Tuukul
-PROTECCIÓN,sus. Mak bo’oy
-PROTEGER,"v.t. Bo’oybesaj, mak paach,"
-PROTEGERSE DEL SOL O DE LA LLUVIA,v.t. Bo’oy
-PROVERBIO,sus. Ts’áaj tuukul
-PROVISIONALMENTE,adj.Chéen ts’e’ets’ek chajal k’iin
-PROVINCIA,sus. Kuchkabal
-PROVOCAR LA GUERRA,v.t. Tsay k’atun
-PRUDENCIA,"sus. Kux óol, tumut óolal"
-PRUDENTE,adj. Aj kux óol.
-PRUEBA,sus. Tumut
-PUBLICADO,"adj. Jok’a’an, ts’áaj ojeltan."
-PUDRIRSE,v.i. Tu’tak
-PUEBLO,sus. Kaaj
-PUEDE SER,"adv. de d. Bey wale’, uchak"
-PUENTE,sus. Péepen che’.
-"PUERCA, MARRANA",sus. X leech.
-PUERCO,sus. K’éek’en
-PUERCO ESPÍN,sus. K’ixpachoch
-PUERTA,"sus. Joonaj, jool naaj"
-PUES,"conj. Kuun, Bakáan."
-"PUESTO, LUGAR",sus. Kúuchil.
-PUJAR INFLÁNDOSE,v.i. P’uru’us
-PULGA,sus. Ch’ik
-"PULIDO, DEMASIADO LISO",adj. Ts’íits’íiki.
-PULIR,v.t. Jalbakunsik.
-PULMÓN,sus. Soorot’
-PULPA,sus. Nooy.
-PULSERA,sus. K’aap
-"PULSO, LATIDO, PULSACIÓN","sus.Kil, kilbail, kikil."
-"PULVERIZAR, ASTILLAR",v.t. P’uuy
-PUMA,sus. Koj
-PUNTA DEL ESTERNÓN,sus. Puytanil.
-PUNTAPIÉ,sus. Kóochak
-PUNTIAGUDA,"adj.Ts’ut, pu’upuuts’ki’"
-PUNTO,sus. Tak’ sabak
-PUNTO DE ESCRIBIR,sus. T’unil ts’íib
-PUNTO DE ESCRITURA,"sus. T’un, t’unil ts’íib"
-PUNTO SOBRE LA I,sus. X t’un
-PUNZAR,"v.t. Tok’, ch’iik,loom."
-PUNZAR CON ARMA O INSTRUMENTO PUNTIAGU,
-DO,v.t. Loom
-PUNZÓN,"sus. Yokob, bajab"
-PUÑADO DE COSAS,adv. de c. Láap’
-PUÑAL,sus. Lomob máaskab
-PUÑETAZO,sus. Loox
-PUÑETAZOS DADOS VARIAS VECES,v.t. Lóoloox.
-PUPILA,sus. Neek’ ich
-PUREZA,adj. Suju’uyil
-PURO,adj. Suju’uy
-QUE,adv. Ok’ol
-QUE,conj. cop. Ka
-QUÉ,pron. rel. Ba’ax
-QUE,"adv. de d. Mia, mi"
-QUE ARDE Y BRILLA,adj. Léemléemki.
-QUE CAMINA RÁPIDO EN PUNTILLAS,adv.de m. Tsa’atsa’ap. Sa’asa’ak’ol. Sáansaanki.
-QUE TIENE MUCHA SALUD O VITALIDAD,adj.
-QUE CORRE MUCHO O QUE NO SE DETIENE,adj.
-QUE CAUSA COMEZÓN,adj. Sa’asa’apki.
-QUE CAUSA COMEZÓN,adj. Tsa’atsa’apki.
-QUE SE DESPRENDE CON FACILIDAD,adj.
-QUE ESTÁ EMPONZOÑADO,sus. Ts’aka’n
-QUE ESTÁ LEJANA O HUNDIDA EN EL HORIZONTE,Joojoots’ki. Líiliit’ki. adj. Lamal
-QUE NO SE PUEDE ERGUIR,adj. Jóojooch’ki.
-"QUE TITILA, SE ENCIENDE Y SE APAGA",adj.Jóojo
-QUEBRADIZO,"adj. Kakachki QUEBRADO EN VARIAS PARTES, APLÍCASE A LOS"
-GAJOS DE LOS ÁRBOLES Y ARBUSTOS,adj. P’íip’iik.
-QUEBRAR,v.i. Káach
-QUEBRAR,v.t. Káach.
-"QUEBRAR, ROMPER",v.t. Jaat.
-QUEDAR,v.i. P’áatal
-QUE ES CIERTO Y POSITIVO,adv. De afir. Jáajbin
-QUEJARSE POR EL DOLOR,v.i. Áakan
-QUEJIDO,sus. Áakam
-QUEMA,sus. Tóok
-QUEMADO,sus. Ela’an
-QUEMADURA,v.t. Chuuj
-QUEMAR,"v.t. Elel, chuuj, tóok."
-QUE SE ESCONDE MUCHO,adj.Babalki
-QUE TIENE COMEZÓN,adj.Níiniich’ki.
-QUE TIENE MUCHAS AMPOLLAS,adj.P’óop’oolki.
-QUE TIENE PEQUEÑAS PROTUBERANCIAS,"adj. P’óop’ootki. panki. T’íit’iilki. Yu’umyu’um. óol, oltaj."
-QUE SE PARTE MUY FÁCIL,adj.Yo’oyo’op’ki.
-QUE NO SE QUEDA EN UN SOLO LUGAR,adj.
-QUE SE MUEVE O MECE MUCHAS VECES,adj.
-QUERER,"v.t. Táan óoltik, k’áat, óoltik, táak"
-"QUERER, AMAR","v.t. Yaakunaj, yaabilaj."
-QUIÉN,"pron. rel. Jensen, je máax ¿QUIÉN?."
-QUIETO,adj. Xoxolki’
-QUIETUD,sus. Ets’a’an óolal
-QUINCE,sus. Jo’olajun
-QUINQUÉ,"sus.Tsuub, sáasil, ch’úuy sáasil."
-QUINTO,adj. U jo’op’éel.
-QUITAR,"v.t. Luk’s, Piit."
-QUITAR UNA PRENDA,v.t. Piit.
-QUIZÁ,"adv. de d. Wale’, úuchak"
-QUIZÁS,"adv. de d. Bey wale’, binakí, mia’,"
-QUE TIENE MUCHOS ORIFICIOS,adj. Chaachaab.
-COMEZÓN,adj. QUE TIENE PELUSA Y DA muki.
-RABADILLA,"sus. Bobox, k’ul"
-RABIA,sus. Ko’il
-RABIHORCADO,sus. Jiich’ kaal nej
-RABO,sus. Nej
-RACIMO DE FRUTOS,"sus. Bab, ch’úu"
-RACIMO,sus. P’och
-RADICAR,"v.i. Kaajnáal, kaajakbal, kaajlan."
-RAÍZ,sus. Moots
-RAJAR,"v.t. Buuj, tej, xik"
-"RALO, MUY RALO",adj. T’áach máan t’aach.
-RAMA DE ÁRBOL O ARBUSTO,"sus. K’ab che’, xa’ay che’, jéek’ che’."
-RAMADA DE LA IGLESIA,sus. Makan
-RAMITA SECA,sus. Ch’ilib
-RAMO,sus. Chach
-RAMÓN (BROCIMUM ALICASTRUM SW),sus. Óox
-RANA,sus. X muuch
-RANCHERÍA,sus. Chan kaaj
-RÁPIDAMENTE,"adv. de m. Séebankil, séebik"
-RÁPIDAMENTE,adj. Jáanjaan.
-RÁPIDO,"adj. Séeb, séeba’an"
-RÁPIDO O MUY VELOZ,adj. Lilich’ki.
-"RÁPIDO, MUY RÁPIDO",adj. K’íik’i’itki.
-"RAQUIS , HUESO DE LA MAZORCA",sus. Bakal
-RAQUÍTICO,adj. Ts’uuts’
-RARO,adj. Ma’ napaja’an
-RASAR,"v.t. Jux k’ab, Tax"
-"RASCAR, RASGUÑAR , ARAÑAR","v.t. La’ach RASPAR, RASURAR."
-"RASPOSO, QUE RASPA FINAMENTE",adj. Líiliichki.
-"RASPOSO, MUY RASPOSO",adj. K’óok’ooxki.
-RASTRO,sus. Bilim
-RATO,adv. de t. Súutuk. Junsúut : un rato. Jun súutuk : un rato.
-RATÓN,sus. Ch’o’
-RAYAR,"v.t. Ja’at, jarat’ ts’íibtik, pay ts’íib, jó’ot’"
-RAYO,sus. Jaats’ cháak
-RAYOS DEL SOL,"sus. Matsab k’iin , jul k’iin"
-RAYO O HAZ LUMINOSO,sus. Jul
-RAZA O LINAJE,sus. Ch’i’ibal
-RAZÓN,"sus. Kux óol, na’at, tumut, uchbal."
-REATA,sus. Suum
-REBANAR,v.t. K’uup.
-REBELDE,adj. J ma’ tsíik
-REBELDÍA,sus. Ma’ tsíikil
-REBELIÓN,sus. Líik’saj kaajo’ob.
-REBOSANTE,adj. Yalbanak.
-REBOSAR LO LLENO,"v.i. Man tuljal, mantul."
-REBOZO,sus. Bóoch’
-REBUSCAR,"v.t. Meents’ul, balul, xa’ak’al"
-REBUZNAR,"v.i. Xuxub ni’, jink’i kaal, jenk’aal."
-RECAUDOS,sus. Xa’ak’
-RECIBIR,v.t. K’aam
-"RECIBIR, ATRAPAR CON LAS MANOS",v.t. K’aam.
-RECIEDUMBRE,sus. K’inam
-RECIO,"adj. Chich, k’a’am, ts’u’uy"
-RECÍPROCAMENTE,"adv. de m. Paaklan, pa"
-RECLAMO,sus.Ikin chi’
-RECOGER,"v.t. Ch’íich’, mool"
-RECOMPENSA,sus. K’exul
-RECONOCER UN BENEFICIO,v.t. K’ajsaj ts’aya’.
-RECORDAR,"v.i. K’a’ajs, k’a’ajsik, ch’a’chi’ib."
-RECTO,"adj. Toj, tojil"
-RECUERDO,"sus. K’a’ajsajul, k’aj lay"
-RED QUE SIRVE DE SACO PARA LLEVAR COSAS FRÁGI,
-LES,sus. Baay
-"REDIMIR, DESAGRAVIAR, RESCATAR",v.t. Loj
-REDONDEAR,v.t. Wóol
-REDONDO,adj. Wóolis
-REDUCIR A POLVO O PEDAZOS,v.t. P’uuy
-"REFLEJA, QUE REFLEJA MUCHO",adj. Jáajaats’ki. REFLEJO U OLEAJE PRODUCIDO POR EFECTO DE LA
-LUZ SOLAR,sus. Wóowóoch’.
-REFLUJO DE MAR,sus. Toch’il.
-REFRÁN,"sus. Ts’áaj tuukul REFRIGERIO VIRGEN, OFRENDA DE BEBIDA FRESCA"
-VIRGEN,sus. Sujuy síis óola’.
-REFUGIO,sus. Mak bo’oy
-REFUNFUÑAR,v.i. Tutukchi’
-REGALAR,v.t. Síij
-REGALO,sus. Siibal
-"REGAÑAR, AMONESTAR, REPRENDER",v.t. K’eey
-REGAÑAR MUCHAS VECES,v.t. K’éek’eey.
-REGAR,"v.t. Jóoya’, jóoyab"
-REGIA,adj. Ajawiil
-REGIDOR,"sus. Aj beelmal, aj nat be"
-REGIÓN,"sus. Kuchkabal, petén"
-RELOJ,sus. P’iisib k’iin.
-"REGLA, MENSTRUACIÓN","sus. Ula, ilmaj"
-REGRESAR,v.i. Suut
-REÍR,v.i. Che’ej
-REIR A CARCAJADAS,v.i. Jáajaabche’ej.
-RELACIONAR UNA COSA CON OTRA,v.t. Taj ok’oltaj
-RELÁMPAGO,sus. Jats’ yuum cháak
-RELAMPAGUEAR,v.i. Léets’bal
-RELATO,sus. Tsikbalile’
-RELATOR,sus. Aj tsool t’aan 
-RELIGIÓN,sus. Okol k’uj
-RELINCHAR,v.i. P’iit
-"RELLENAR, EMBUTIR",v.t. Buut’
-"RELLENO, EMBUTIDO",adj. Buut’
-REMAR,v.t. Ch’uy
-REMEDAR,v.t. P’a’as
-REMENDAR,v.t. Pak’akok
-REMO,sus. U báabil cheem
-REMOJAR,"v.t. Ts’am, suul."
-"REMOJAR, SUMIR",v.t.T’uub
-"REMOJARSE , ASENTARSE",v.t. Ts’áamal.
-REMOLINO,sus. Moson iik’
-REMOLINO DE LA CABEZA,sus. Su’uy
-RENACUAJO,sus. J bube’
-RENCILLA,"sus. Ok yail, xab óolal"
-RENDIR A OTRO,v.t. Ts’oyesaj
-RENDIRSE,v.t.Oyol óol
-RENEGAR,v.i . Xet’ óolal
-RENUEVO,sus. Alamil
-REÑIR CON RABIA,v.i. Mak’ tanan
-REPARAR,v.t. Utskíinsaj
-REPARTIR,"v.t. Jaats, t’oox"
-REPETIDAMENTE,adv. de m. Ban ban
-REPETIR,v.t. Ka’a púut t’aan
-REPIQUE DE CAMPANAS,v.t. Ban péeks
-"REPLETARSE, HARTARSE",v.i. Balankil kukut
-REPOSO,sus. Ts’akin
-REPRIMIR LA IRA,v.t. Taj muk’
-RESBALAR,"v.i. Jalchajal, jalk’ajal, pitk’ajal, pots’kajal, pots’che’ej"
-RESBALAR ALGO MAL COLOCADO,v.i. Nixk’ajal.
-RESBALOSO,"adj. Popots’ki, jojolki"
-RESBALOSO,"adj. Jáajaalki, jóojoolki."
-RESCATAR,v.t. Loj
-RESCOLDO,sus. Chikix ta’an
-RESECO,"adj. Ts’uuts’, k’ak’al."
-RESECA,adj. Chuchul.
-RESEMBRAR,v.t. Julbe’en.
-RESIDENTE,sus. Kula’an
-RESINA DE LOS ÁRBOLES,sus. Iits
-RESISTIR,v.t. Nup’intaj
-"RESISTENTE, MUY RESISTENTE",adj.T’oot’oochki.
-RESOLVER ALGÚN NEGOCIO,v.t. Jepajal óol
-RESPETAR,"v.t. Tsíikik, tsíik, chíinpool."
-RESPETO,sus. Tsíikbe’enil
-"RESPETUOSO,","adj. Aj tibil be, Aj tibil wíinik"
-RESPIRAR,v.i. Ch’a’iik’
-RESPIRAR TOMANDO EL AIRE CON FUERZA,v.i. Bo
-RESPIRAR POR LA BOCA A CAUSA DE UN ARDOR,
-RESPLANDOR DEL FUEGO,sus. Léets’
-RESPONSABILIDAD,sus. K’ooch.
-RESTA,sus. Lúusbil.
-RESTO,"sus. Xiix, yala’"
-RESUMIR,v.i.Ts’um
-RETENER,v.t. Balinaj
-RETENER EL AGUA,v.t. Jalinaj ja’
-RETENER EL RESUELLO,v.t. Kupaj
-RETENTADO DE ATAQUE O PASIÓN,adj. Leka’an
-RETIRARSE LOS QUE PELEAN,v.i. P’alba.
-RETOÑAR,"v.i. K’uk’ankil , k’u’uk’ankil"
-RETOÑO,"sus. K’uuk’che’, k’uk’, top’ che’"
-RETRATO,"sus. Jochol, etpatkunaj"
-RETROCEDER,"v.i. Kukul iit, kukulpaach."
-RETUMBAR,"v.i. Anal, kulun"
-REUMA,sus. Ch’onoj óol.
-REUNIÓN,"sus. Múuch’tal, múuch’kinaj, mul"
-REUNIR TODO,v.t. Junmooltaj
-REVELAR SECRETOS,v.t. Múukul ya’alabil
-"REVENTAR,ESTALLAR, DETONAR",v.i. Wáak’
-"REVENTAR, ROMPER",v.t. Teep’
-"REVENTAR, ROMPER",v.t. T’ook.
-REVOLCADERO DE ANIMALES,sus. Bilim
-REVOLCAR,"v.i. Bobal, babal"
-REVOLTILLO,sus. Xe’ek’
-REVOLVER,"v.t. Bak’, xa’akit, xa’ak’lal, ta’anbesaj."
-REVOLVER,v.t. Xa’ak’al
-"REVOLVER, MEZCLAR","v.t. Buuk’, xa’ak’, xe’ek’"
-"REVUELTA, ALBOROTO",sus. X wookin.
-REZO,"sus. Kama’t’aan, payalchi’"
-REZONGAR,v.i. Tutukchi’
-RIBERA,"sus. Jáal ja’, chi’, jáal."
-RICO,adj. Ayik’al
-RIENDA,sus. Jok’ ni’
-RINCÓN,"sus. Tu’uk’, xu’uk’il, ti’itsil."
-RINCÓN DE LA CASA,sus.Tuuk’ naaj.
-RIÑA ENTRE MUCHOS,"sus. Buuj, pa’al a bu’uj"
-RIÑÓN,"sus. Is, yis."
-RÍO,"sus. Uk’um, bel ja’, áalkab ja’."
-RIQUEZA,sus. Ayik’alil
-RISA,sus. Che’ej
-RITUAL,sus.Tsolante.
-RIVALIDAD,"sus.Tsa, tsaul."
-"RIZADO, MUY RIZADO",adj. Múumuuch.
-ROBAR,v.t. Óokol
-ROBLE (EHRETIA TINIFOLIA L),sus. Béek
-ROBUSTO,adj. Noj ach
-ROCIAR,v.t. Líil.
-"ROCIAR, ESCURRIR",v.t.Tsíits.
-ROCÍO,sus. P’uja’
-RODAJA,sus. Me’et
-RODAR,"v.i. Balak’, balk’ajal, bak’al."
-RODEAR,"v.t. Bak’ paach, ba’apaachmil."
-RODILLA,sus. Píix.
-ROER,"v.t. K’úux, néet’, nées."
-ROGAR,"v.i. Pay chi’, payalchi’"
-ROJO,adj. Chak
-ROJOS,sus. Chaktak.
-ROLLO,sus. Koots’
-ROMPER CUERDA O BEJUCO,v.t. T’aak.
-ROMPER PAPEL,"v.t. Jaat, xeet’."
-"ROMPER PLATO, CAJETE, CÁNTARO",v.t. Pa’
-ROMPER VIDRIO,v.t. Kaach.
-ROMPER EL VIENTO,v.t. Pa’ iik’
-RONCAR,v.i. Nóok’
-RONQUIDO,sus. Nóok’
-ROPA,"sus. Nook’, búukina’"
-ROPA EN GENERAL,sus. Nook’
-ROSADO,"adj. Chaksak, sakpile’en chak."
-ROSTRO,sus. Ich .
-ROTO,"adj. Jaatal, pa’al, xeet’el"
-RÓTULA,sus. Lakil píix.
-ROZA,sus. Ch’akbeen
-RUBIO,adj. Ch’eel
-RUECA,sus. Tunul pechéch.
-RUEGO,sus. Ok’otba.
-RUFIÁN QUE VENDE MUJERES,sus. Aj konkooil
-RUGIR,v.i. Áakan
-RUIDO,sus. Juum
-RUIDO QUE HACE LA SERPIENTE DE CASCABEL,sus. Tirix
-RUISEÑOR,sus. X k’ook’
-RUMBO,"sus. Jel, belil"
-SABANA,sus. Chak’an
-SÁBANA,"sus. Táas, teep’, buklis"
-SABER,sus. Its’atil pool
-SABER,"v.i. Ojelt, ojel, ojéel."
-SABIDURÍA,"sus. Ojelil, yits’atil."
-SÁBILA (ALOE VERA L),sus. Petk’inki
-SABIO,"sus. Aj miats, aj baal kajil miats"
-SABOR,"sus. Ki’il, kii’"
-"SABROSO, MUY SABROSO",adj. Kíiki’iki.
-SACAR,"v.t. Jíil, jo’osik, jó’os, jóok’s."
-"SACAR,DESENTERRAR",v.t. Jáal
-SACAR CON LOS DEDOS UN POCO DE ALGO MASOSO,v.t. Jo’ots’
-SACAR CON VIOLENCIA,v.t.Tojoch’iin.
-SACAR DE LA FUNDA,v.t. Jiilt SACAR DE LA OLLA Y SACAR LO QUE SE CUECE BAJO tik
-LA TIERRA,v.t. Jáal
-SACAR PUNTA,v.t.Ts’uts’utkin.
-SACERDOTE,"sus. J k’iin, yuum k’iin"
-SACERDOTE AGRARIO,sus. J men
-SACO,sus. Mukuk
-SACRIFICIO,"sus. Kukuleb, suy k’up"
-SACUDIR,"v.t. Púust, púusk, tíit , líil."
-SAGACIDAD,sus. Noj ach óolal
-SAGRADO,adj. K’uyen
-SALTAR,"v.i. Síit’, p’iit"
-SAL,sus. Ta’ab
-SAL MUY GRUESA,sus. Sim tuun ta’ab
-SALADO,adj. Ch’óoch’
-SALAR,v.t. Ta’abt
-SALARIO,sus. Náajal
-SALCOCHAR,v.t. Chaak
-SALINA,sus. Chi’ib
-SALIR,"v.i. Jóok’ol, tíip’il"
-SALIR EL MAÍZ,v.i. Jóok’ol
-SALIR LA YERBA,v.i. Jóok’ol
-SALITRE,sus.Sak ta’ab.
-SALIVA,sus. Túub
-SALPICAR,v.t. Wits’
-SALPULLIDO,sus. Uusáan
-"SALTAR, BRINCAR","v.i. P’iitik, síit’, p’íit."
-SALTAR LAS GOTAS DE UN LÍQUIDO QUE SE DERRA,
-MA,"v.i. Tits’, tiis."
-SALUD,sus. Toj óol.
-SALUDABLE,adj. Tojóolal
-SALUDAR INCLINANDO LA CABEZA,v.t. Chíinpool
-"SALUDO, TRAER Y SALUDAR",v.t.Julesaj.
-"SALVADOR, REDENTOR, LIBERTADOR",sus. aj Tóoksaj.
-"SALVAR, DAR AUXILIO, REDIMIR",v.t. Tóoksaj
-SANAR,v.i. Utstal
-SANAR,v.t. Mal
-SANDÍA,sus. Chak bojonja’
-SANGRE,sus. K’i’ik’
-SANGRE CUAJADA,sus. Olom
-SANGRÍA,"sus. Kokan SANGRIENTO, buk’e’en."
-ENCARNIZADO,adj. Chak
-SANTIFICADO,adj. Kili’ichkuntabak
-SANTIGUARSE,"v.i. Chikilbesaj ich,"
-SANTO,sus. Kili’ich
-SAPO,sus. Muuch
-SARAGUATO (ALOUATTA PALLATA MEXICANA),sus.
-SARAMUYO (ANNONACEA ( ANNONA RETICULATA)),sus. Ts’almuy
-SARGAZO,sus. Ta’il k’áanab
-SARNA,"sus. Jaway, chachak uay"
-SARTENEJA (OQUEDAD EN LA PIEDRA EN QUE SE ACUMU,
-LA EL AGUA DE LLUVIA),sus. Jaltun
-SASTRE,"sus. J chuuy, j chuuy nook’"
-SATISFECHO,adj. Tuup óol.
-SAÚCO AMARILLO (TECOMA STANS (L)H B ET K),sus. X k’anlol
-SAZÓN DEL MAÍZ,sus. Yij
-"SAZÓN, MUY SAZÓN",adj. K’aank’aanki.
-SECARSE,v.i. Tijil.
-SECARSE,v.i. Sap
-SECARSE UN POZO O AGUADA,v.i. Sa’ap’ak
-SECO,adj. Tikin
-"SECO, MUY SECO",adj. Wóowooki.
-"SECO, DESHIDRATADO",adj. Síisiiki
-"SECO, MUY SECO",adj. K’áak’áalki.
-SECRETO,sus. Ta’ak tsikbal
-SECUESTRAR,v.t.Chuk ba’alba.
-SED,sus. Uk’aj
-SEDIMENTO,sus. Xiix
-SEGUIR A OTRO,"v.t. Ch’a’ ook, ch’a’ ookil."
-"SEGUIR, CONTINUAR",v.i.Baykunaj.
-SEGUIR EL RASTRO,"v.t. T’ul, t’u’ulpachto’ob"
-SEGÚN,"prep. Je’ebik, je’ebix"
-SEGURIDAD,sus. Toj óolal
-SEGURO,adj. Muuk’a’an
-SEIS,sus. Wáak
-SELECCIONAR,"v.t. Téet, yéey"
-SELVA,"sus. Jub che’, k’áax, ka’anal k’áax"
-SELLADO,adj. Ts’ala’an
-SELLAR,v.t. Ts’al
-SELLO,sus. Ts’al
-"SEMBRADO, SIEMBRO",sus. Pak’áal.
-SEMBRAR,v.t. Páak’al.
-SEMBRAR MAÍZ,"v.t. Oksaj, páak’al."
-SEMEJANTE,"adj. Ket, bayjal"
-SEMEJANTE,"sus. Éetwíinikil, yéet, wéet, bat"
-SEMEN,"sus. Sa’il keep, k’oy, lel,lal, xex."
-SEMILLA,sus. Neek’
-SEMILLA DE CALABAZA,sus. Sikil
-SEMILLA DE MAÍZ,sus. I’inaj
-SENCILLO,adj. Joya’n
-SENDERO,"sus. T’ulbe, éek’bej"
-SENO,sus. Im
-SENSIBILIDAD,sus.Chajil.
-SENSITIVA,sus. X mumuts’
-SENTAR,v.i. Kutáal.
-SENTARSE,"v.i. Kutal, pek’, kultal"
-SENTENCIA,"sus. Ts’áaj tuukul, xoot k’iin, xoot"
-SENTIR CON EL TACTO O CON EL GUSTO,"v.i. U’ub, k’iin t’aan. u’ubaj, u’uy"
-SENTIR MUCHO UNA COSA,v.t. Najal ti’ol
-SEÑAL,"sus. Bilim, chíikul"
-SEÑALAR,"v.t. Tuch’ub, joch kintaj"
-SEÑOR,"sus. Yuum, taat, yuumtsil"
-SEÑORA,"sus. Ko’olel, xunáan."
-SEÑORITA,sus. X nin.
-SEPARAR,v.t. Jaats.
-"SEPARAR, DISPERSAR",v.t. Jaab.
-"SEPULTAR, ENTERRAR",v.t. Muuk
-SEPULTURA,sus. Múuknal SEPULTURERO. sus. Aj muuk kimen.
-SEQUÍA,"sus. Yáax k’iin, noj k’iin"
-SER MALIGNO,"sus. Baba’al SER SOBRENATURAL QUE SE PRESENTA EN LA NOCHE BAJO LA SOMBRA DE UNA CEIBA, ADOPTANDO LA FORMA DE UNA MUJER MUY BELLA VESTIDA DE HIPIL PEINANDO SU LARGA CABELLERA PARA"
-SEDUCIR A LOS HOMBRES,sus. X táabay
-SER TRABAJADOR,sus. J meyjil
-SERENATA,"sus. Ye’eblan k’aay, tunar"
-SERMÓN,sus. Tse’ek
-SERMONEAR,v.t. Tse’ekt
-SERPENTEAR,v.i. Bik’chalák. SERPIENTE CORALILLO (MICRURUS).
-"SERVIR, UTILIZAR",v.i. Biilal
-"SERVIR, ATENDER","v.t. Táanlaj, táan óol. sus."
-SERVIR DE ALGO,v.i. Ch’alik
-SESENTA,sus. Óox k’aal
-SESEO,sus. Ses
-SESO,sus. Ts’o’om
-SETENTA,sus. Lajun p’eel ti kan k’áal
-SETO,sus. Jil che’
-SEXO SERVIDORA,"adj., sus. Káakbach"
-SI,"adv. de a. Ajaaj, bey, beyo’, jaaj"
-SI,conj. cond. Wáa
-SIEMPRE,"adv. de t. Bayjal, bayli’, bayli, binili’, jun k’uli’, mantats’, juntiich’."
-SIEMPRE,"conj. cond. Layli’,bayli’, binili’."
-PERMANECER,"v.i. Bayjal, bayli’"
-SIETE,sus. Úuk
-SIGNO,"sus. Chíikul, wooj"
-SILBAR,"v.i. Xóobt, xúuxub, xóob."
-SILBIDO,"sus. Xóob, xúuxub"
-SILENCIO,"sus. Ch’ench’enki, ch’il"
-SILVESTRE,adj. K’áaxil
-SILLA,"sus. Kulxekil, xek, x kulupche’"
-SÍMBOLO,sus. Wooj
-"SIMPLE, SIN AZÚCAR, SIN RECADO",adj. Piits’.
-SIMULTÁNEO,"adv. Éetk’iin, éetk’iinil."
-SIN,"prep. Achak, x ma’"
-SIN CUENTA,"adj. Chaket, cheket, ma’ xulum"
-SIN EMBARGO,Bakakix
-SIN QUE,prep. Achak
-SINO,prep. Achak
-SINVERGÜENZA,adj. J ma’ su’tal
-SIRVIENTA,"sus. Ix k’oos, x k’oos."
-SIRVIENTE,"sus. Aj k’oos, j k’oos"
-"SOBADOR, HUESERO, QUIROPRÁCTICO",sus. Aj
-"SOBAR, MASAJEAR, MANOSEAR","v.t. Páats’, yeet’, páats’, aj yeet’. yoot’. SOPLAR"
-SOBRE,"prep. Yóok’ol, yóok’"
-SOBRESALIENTE,adj. Atpuj.
-SOBRINO,"sus. Sob, achak, ach’ak"
-SOBRIO,adj. Núuk
-SODOMITA,"sus. Aj top it, Aj top lom chun, síis óol."
-"SOSIEGO, PAZ","sus. Ets’a’an óolal, ets’ óol."
-SOGA,sus. Suum
-SOGA DE POZO,sus. Suumil ch’e’en
-SOGUILLA,sus. Léech kaal
-SOJUZGAR,"v.t. Kulkinaj yaalan ook, kukinaj yaalan k’ab, kula’an"
-SOL,sus. K’iin
-SOLDADO,"sus. Jolkan, aj k’a’tun wíinik."
-SOLEDAD,"sus. Ch’eneknakil, chiltal"
-SOLEMNIDAD,sus. Tsiktsilil
-SOLO,"adj. Tu ba, ti’ junal, chéen tu jun."
-SOLTAR DE LA MANO,v.t. Sipit
-SOLLOZO,"sus. Jaja’ok’ol, múukul ok’ol"
-SOMBRA,sus. Bo’oy SOMBRA DE ALGÚN CUERPO PROYECTADA A CAUSA
-DE LA LUZ,sus. Woochel
-SOMBRA DEL CUERPO,sus. Oochel
-SOMBRA Y AMPARO,sus. Boch’
-SOMBRERO,sus. P’óok
-SOMBRILLA,sus.Balab k’iin
-SONAJA,"sus. X tuuch’, so’ot"
-SONÁMBULO,sus.Chukut kibil
-SONAR,v.i. Juum.
-SONAR LA BARRIGA,v.i. Bubulaankil nak’.
-SONAR LA NARIZ EL CABALLO SACUDIÉNDOLA,Po
-SONDEAR,"v.t. Bobojtej, túuntaj, túunt"
-SONIDO MUY HUECO,adj. Jóojoonki.
-SONIDO FUERTE QUE LASTIMA LOS OÍDOS,adj. Ch’e’ej
-SOBERBIA,"sus. Nojbail, nonojbail, tsikbail."
-SOBERBIA,"sus. Ka’anal óol, ka’anan óol."
-SOBERBIO,"sus. Aj nojbail, j nojbail."
-SOBERBIO EN HABLAR,sus. Aj bobok’ t’aanil
-SOBRA,sus. Yala’
-SOBRE,sus. Paymun
-"SONORO, QUE SUENA FUERTE",adj. Chéecheej
-SONREÍR,"v.i. Sakche’ej, che’ej."
-SONRISA,sus. Sak che’ej
-SOÑAR,"v.i. Náayt, wayak’, náay."
-SOPA,"sus. Ya’ach’, chok’ob"
-SOPLAR CON LA BOCA,"v.i. Uust, uustik"
-SOPLAR CON REPETICIÓN,v.t. Jojopsa
-SOPOR,sus. Nikib
-"SORBER, BEBER A SORBOS",v.t. Xúuch
-SORBER ALGÚN LÍQUIDO ESPESO,v.t. Jáap
-SORBO,sus. Xúuch.
-SORDO,sus. Kóok
-SORONGO O CHONGO,sus. T’uuch
-SORPRENDER,v.t. Jak’aj óol
-SOSEGAR,v.i. Toj jal óol
-SOSPECHAR,v.i. Ch’ajal óol
-SOSTENER CON LA PALMA DE LA MANO,v.t. Láat’.
-SOSTENER ALGO EN LA PLANTA DE LA MANO,v.t. Pe’
-SU,adj. poses. U
-SUAVE,"adj. Mamayki, mamaykil, o’olki, ts’u’uts’ukil, ts’u’uts’uki."
-"SUAVE, MUY SUAVE",adj. Biibiiki.
-"SUAVE, MUY SUAVE ( PARA LA ARENA , TIERRA, POL",
-VO),adj. Júujuupki.
-SUBIR,v.i. Na’akal
-SÚBITAMENTE,adv. de m. Chetun
-SUBSTITUIR,"v.t. Jeel, k’eex"
-SUCEDER,"v.t. Úuch chajal, úuchul"
-SUCEDIDO,sus. Máanlil
-SUCESOR,sus. K’exulan
-SUCIO,"adj. Éek’, k’óok’ol, kiirits’"
-"SUCIO, MUY SUCIO",adj. Cha’acha’aki.
-SUDADERO,sus. Taats’ paach.
-SUDARIO,"sus. Cho’ob, k’axab ich"
-SUDAR,"v.i. K’íilkab, k’íilkabankil."
-SUDOR,sus. K’íilkab.
-SUEGRA,"sus. Jawan, x noj na’e’, x jaachil."
-SUEGRA DE LA MUJER,"sus. Noj ko’, x nij ko’"
-SUEGRO,"sus. Jachil, noj yuum, aj jawan, j ja"
-SUELA,"sus. K’éewel, táan xanab."
-SUELDO,sus. Náajal
-SUELO,sus. Biltum
-SUELO AMARILLENTO,sus. Ak’alche’
-SUELO ARCILLOSO,sus. Ak’alche’
-SUELO ARTIFICIAL,sus. Pak’ bitun
-SUELO PEDREGOSO,sus. Tsek’el 
-"SUMIR, HUNDIR",v.i. Laam.
-"SUMIR, REMOJAR, EMPAPAR",v.t. Ts’aam.
-SUEÑO,"sus. Wayak’, náay."
-SUERTE,sus. K’intaj
-SUFICIENTE,adv. Chaan.
-SUFIJO CLASIFICADOR PARA CONTAR AZOTES,Puul SUFIJO CLASIFICADOR PARA CONTAR ANIMALES O
-PERSONAS,Túul
-SUFIJO CLASIFICADOR PARA CONTAR ÁRBOLES,
-SUFIJO CLASIFICADOR PARA CONTAR HOJAS Y DO,
-BLECES,Wáal
-SUFIJO CLASIFICADOR PARA CONTAR OBJETOS,
-SUFIJO CLASIFICADOR PARA CONTAR OBJETOS ALAR,
-"GADOS COMO VELAS, DEDOS, CAÑAS",Ts’iit
-SUFIJO CLASIFICADOR PARA CONTAR PUÑADOS,
-SUFRIMIENTO,"sus. Muk’ óolal, yaayaj kuxtal."
-SUFRIR,v.i. Muk’yaj
-SUICIDARSE,v.i. Kíimsikba
-SUJETAR,"v.t. Kulkinaj yaalan ook, kukinaj Kúul P’éel Lap’ yaalan k’ab, kula’an"
-SUMA,sus. Buk’xookil
-SUMAR,v.t. Bak’ xook
-SUMERGIR,"v.i. Ts’aam, ts’am, buul, ts’oom"
-SUMERGIDO,adj. T’úubent’úub.
-SUMIR,v.t. Lam
-SUPERCHERÍAS,sus. Babal t’aano’ob.
-SUPLENTE,sus. Jeel
-SÚPLICA,"sus. Yaanyan, k’áat, yaayan."
-SUPONER,v.i. Nak’kuktik.
-SUPOSICIÓN,sus. Ch’a
-SUR,sus. Nojol
-SURCO,sus. T’o’ol.
-SUREÑO,adj. J nojolil.
-SUSPENDER,v.t. Jáaw
-"SUSPENDER, ALZAR, LEVANTAR",v.t. Ch’úuy.
-SUSPENSO,sus. Ch’ena’an.
-"SUSTENTAR, ALIMENTAR",v.t. Tséent
-SUSTO,sus. Jak’ óol
-"SUYO, DE ÉL",pron. poses. Utia’al
-"SUYO, DE ELLOS",pron. poses. Utia’alo’ob
-TABACO (NICOTINA TABACUM L),sus. K’úuts
-TÁBANO,sus. Áakach
-TACAÑO,adj. Ts’u’ut
-"TAJAR, PELAR","v.t. Súus, p’e’es."
-TAL VEZ,"adv. de d. Wale’, uale’, úuchak"
-TALA EN GENERAL,sus. Sakal
-TALAR,v.t. Ch’akbe’ent
-TALEGA,sus. Mukuk
-TALENTO,sus. Chich óolal
-TALISMÁN,sus. Yut.
-TALLAR,v.t. Póol
-TALLO,"sus. Che’el, kanil"
-TAMBALEAR,v.i. Takchalaankil.
-TAMBALEO,sus. Takchalaankil.
-TAMBIÉN,"adv. de a. Bey, bey xan, láaylie’, léeyli, xan"
-TAMO O POLVO DEL MAÍZ,sus. May ixi’im
-TAMPOCO,"adv. de n. Mix, mix xan."
-"TAMULADOR, MOLCAJETE",sus. K’utub
-TAPA,"sus. Maak TAPACAMINO (AVE ,CAPRIMULGUS SERICOCAUDATIS"
-SALVINI (HARTER)),sus. Pu’ujuy
-TAPAR,"v.t. Bal, pix, maak."
-TAPIR,sus. Ts’iimin k’áax
-TAQUIGRAFÍA,sus. Taj ts’íibtaj
-TARÁNTULA,"sus. Chíiwoj, x ch’íil tun, x"
-TARDAR,v.i. Xáantal
-TARDE,"sus. Chúunk’iin, oknajk’iin, chíinik k’iin, chíinil k’iin."
-TARTAMUDEAR,"v.i. Altal yaak’, k’alk’alak chiwol t’aan"
-TARTAMUDEZ,sus. Ses
-TARTAMUDO,"adj. Aj al yaak’, aj ses, nuntal"
-TATUAR,v.t. Jots.
-"TECOLOTE, BÚHO (BUBO VIRGINIANUS MAYENSIS)",sus. Tunkuluchuj
-"TEJER, TRENZAR","v.t. Jiit’ TEJÓN,PIZOTE, COATÍ (NASUA NARICA YUCATANICA (ALLEN))."
-TELARAÑA,sus. Mak maktaj k’áan.
-TELÉFONO,sus. Sutuchiilt’aan
-TELÉGRAFO,sus. Jultuchiilt’aan
-TELEVISIÓN,"sus. Náachil e’esaj oochel, máa"
-TEMA,sus. Chich
-TEMBLAR,"v.i. Kikiláankal, kikiláankil"
-TEMBLAR DE MIEDO Y ESPANTO,v.i. Papalankil
-TEMBLAR LA TIERRA,"v.i. Kíilbal, temba, yuk"
-TEMBLOR,sus. Kíilbal
-TEMBLOR DE TIERRA,sus. Yanba lu’um
-TEMER,v.i. Sajaktal
-TEMIBLE,"adj. Sajbe’en, sajbe’entsil"
-TEMOR,"sus. Sajkil, sajak"
-TEMPERAMENTO,sus. K’íinal óol.
-TEMPLADO,adj. Núuk.
-TEMPLANZA,sus. P’iis bail
-TEMPORAL,adj. Xululte
-TEMPRANO,adv. de t. Ja’atskab
-TENAZAS,sus. Nat’ab
-TENDER,"v.t. Jayba, jaybaj."
-TENDER LA ROPA,v.t Le’
-TENDER POR EL SUELO,v.t. jayaj
-TENDIDO,"adj. Síin, te’a, ja’aya, ja’ayan"
-TENDÓN,"sus. Xiich’, t’in xich’"
-TENER,v.t. Yaan.
-"TENSAR, TENDER",v.t. T’iin
-"TENSO, A PUNTO DE REVENTAR",adj. T’íint’iinki.
-TENSAR VARIAS VECES CON FUERZA UNA CUERDA,
-TENTACIÓN,"sus. Túuntabail, tutajuli’"
-TEPEZCUINTLE,(CUNICULUS PACA NELSONI).
-TERCIAR,v.t. Ch’aal t’aan
-TERCO,adj. Nonolki
-TERMINADO,adj. Ts’o’ok beyo’
-TERMINAR,"v.t. Jaw, ts’o’okol, xuul"
-TÉRMINO,"sus. Cheel, ts’o’ok, xuul"
-TÉRMINO DE PLAZO SEÑALADO,sus. P’elk’iin
-TÉRMINO DE TIEMPO,sus. P’elk’iin
-TERNURA,sus. Muun óol
-TERQUEDAD,sus. Nonojbail
-TERCO,sus. Aj nonojbail.
-TERCA,sus. Ix nonojbail.
-TERRENO ABANDONADO,sus. X tokoy
-TERRENO BAJO,sus. Ak’alche’
-TERRENO CON MATORRALES,sus. Ak’alche’
-TERRENO CON SUELO DE RENDZINA NEGRA,sus. Ak’alche’
-TERRENO INUNDABLE,sus. Ak’alche’
-TESTIGO,"sus. Ts’áaj jaajil, aj jaajkuns t’aan."
-TESTIMONIO,"sus. Kunaj t’aan, tojol t’aan"
-TÍA,sus. Ix kit
-TIBIO,"adj. K’inal, pa’a síis, síis chokoj"
-TIBURÓN,sus. K’an xok
-TIEMPO,sus. K’iin
-TIEMPO DE FRÍO,sus. Ke’elil.
-TIEMPO DE LLUVIA,"sus. Ja’ja’lil, ja’aja’al"
-TIEMPO DE SEQUÍA,"sus. Noj k’iinil, yáax k’iin"
-TIEMPO EN QUE ABUNDA UNA COSA,sus. K’iinbe’n
-TIEMPO PARA CAPTURAR ANIMALES,sus. Pets’
-TIERNO,"adj. Áak’, muum"
-TIERNA,sus. Ix muun óol.
-TIERNO,sus. Aj muun óol. 
-TIERRA,"sus. Kaab, lu’um"
-TIERRA BLANCA,sus. Saskab
-TIERRA BUENA Y FÉRTIL,Tul lu’um.
-TIERRA MUY PEDREGOSA,sus. Tsek’el
-"TIERRAS QUE DESORIENTAN, QUE NUBLAN EL EN",TENDIMIENTO. EL REMEDIO ES ENCENDERLES
-UNA VELA O VELADORA,sus. Ts’íik lu’um
-TIESO,"adj. To’och, to’otokil."
-"TIESO, MUY TIESO",adj. Tojtojki.
-TIGRILLO,sus. Sak xikin
-TÍMIDO,adj. J nuum
-TÍMPANO,sus. Papatal.
-TINTA NEGRA,sus. Sabak
-TINTINEO,sus. Tsan.
-TINTURA,sus. Boon
-TÍO,"sus. Akan, ts’éyuum"
-TIRA,sus. Wewel
-TIRAR,"v.t. Ch’iin, puul."
-"TIRAR, AVALANZAR, ARROJAR",v.i. Puul DERRIBAR TIRAR VARIAS O Lúulu’usik.
-VECES,v.t.
-TIRAR PARA ASUSTAR,v.t.To’onto’onch’íin. TIRAR Y REVOLVER ALGUNAS
-COSAS,v.t. Xéexeek’.
-TIRAR POR TIRAR,v.t. Ch’íinch’iin.
-TIRAR SIN PUNTERÍA CON ARMA DE FUEGO,v.t.
-TIRAR CON ARMA DE FUEGO VARIAS VECES,v.t. Báabaalts’oon. Ts’oonts’oon.
-TITILAR,"v.i. Jojopaankil, léembal"
-TIZNE,sus. Sabak
-TIZÓN,sus. Naxche’ TLACUACHE Ooch (DIDELPHYS MESOAMERICANA).
-TOALLA,"sus. Cho’ob, k’axab ich"
-TOBILLO,sus. Kuy
-TOCAR UN INSTRUMENTO,v.t. Páax
-TODA,"adv. de c. Mal, tuláakal."
-TODA LA NOCHE,adv. de t. Buláak’ab
-TODAVÍA,adv. de t. Asab
-TODO,"adv. de c. Láaj, mal, tuláakal, tusinil"
-TODO EL DÍA,adv. de t. Bulk’iin
-TODO ENTERO,adv. de c. Petel
-TODO JUNTO,adv. de m. Wol
-TODOS NOSOTROS,pron. indef. Tuláaklo’on.
-TOLERANCIA,sus. Máansaj óolal.
-TOMAR,v.t. Ch’a’b
-TOMAR POSESIÓN,v.t. Pach
-TOMAR PRESTADO,v.t. Majan
-TOMATE (LYCOPERSICUM ESCULENTUN),sus. P’aak
-TONTERA,sus. Netsil.
-TONTO,"adj. Nets, nuun, nóol (Hondzonot,"
-"TOSCO, RÚSTICO",adj. To’och.
-TOSER,"v.i. Se’enak, se’en."
-TOSER PARA ACLARAR LA VOZ,v.i. Babkaltaj
-TOSER POR COMEZÓN EN LA GARGANTA,v.i. Sáasaak’kaal.
-TOSFERINA,"sus. T’uju’, x t’ujub"
-TOSTAR,"v.t. K’éel , póok, k’áak’t."
-TRABAJADOR,sus. Sa’ak’ol
-TRABAJAR,v.i. Meyaj
-TRABAJO COLECTIVO,"sus. Múul meyaj, múu"
-TORCER,"v.t. Bil, juk’, ch’eet."
-"TORCER, EXPRIMIR, DARLE VUELTAS A ALGO",v.t.
-"TRABAJOS, PESARES, DIFICULTADES",sus. Num
-TRABALENGUAS,"sus. K’alk’alak t’aan, t’iit’il"
-"TORCERSE, CERRAR UN CANDADO",v.t. Ch’óotol
-TORDILLO,adj. Chukim
-"TORDO, GRAJO O ZANATE DE YUCATÁN (MEGAQUIS",
-CALUS MAJOR MACROURUS (SWANSON),"sus. K’a’au, k’a’aw."
-TOREAR,"v.t. Paay, páayal"
-TOSTAR,"v.t. K’éel, póok."
-TOSTADA,sus. Oop’.
-TORCERSE,v.i. Ch’ettal.
-TORERO,sus. J paay wakax
-TORMENTOS,sus. Numyail
-TORNAR,v.i. Walk’ajal
-TORNO DE ALFARERO,"sus.K’abal, K’aba’al."
-TORO,sus. Xiibil wakax
-TORRE,sus. Julbil naaj.
-TORTEAR (HACER TORTILLAS CON LAS MANOS),v.t. Pak’ach
-TORTILLA DE MAIZ,sus. Waaj
-TORTILLA DE MAIZ NUEVO,sus. Iis waaj
-TORTILLA DURA,sus. Chuchul waaj TORTILLA GRUESA QUE SE CUECE DIRECTAMENTE
-SOBRE LA BRASA,sus. Péenkuch
-TORTILLA RESECA,sus. Chuchul waaj
-TORTILLA TOSTADA,"sus. Oop’ TÓRTOLA, (COLUMBIGALLINA PASSERINA PALLESCENS (BAIRD)) ."
-TORTUGA,sus. Áak
-TOS,"sus. Sa’asak, sasa’kaal yail aak’ luuk’."
-TRABAR,v.t. Léech
-TRAER,"v.t. Taas, taasik, púut."
-"TRAFICADO, MUY TRAFICADO",adj. K’áak’aatki.
-TRAGAR,v.t. Luuk’
-TRAGAR CON PRESTEZA,"v.t. Pot luuk’, totop"
-TRAGADO RÁPIDO,adv. de m.Lúuluuk’bil
-TRAIDOR,sus. Aj k’uubilaj.
-TRAICIÓN,"sus. K’uubilaj, k’uuba’an paach."
-TRAJE DE LAS MUJERES INDÍGENAS DE YUCATÁN,
-TRAJE NEGRO,sus. Sabak nook’.
-TRAMPA DE LAZO,sus. Léech
-TRANCA DE LA PUERTA,"sus. No’ox che’, k’aal sus. Iipil che’"
-TRANQUILIDAD,"sus. Ets’a’an óolal, ts’akin"
-TRASCENDER,"v.t. Balk’ajal, buyul."
-TRANSFIGURARSE,v.i. Jeelpaji’ u yich
-TRANSPORTAR OBJETOS O FRUTAS,v.t. Púut
-TRAQUEA,sus. Yúul
-TRASPARENTE,"adj. Sáapik’en, saask’alen, saast’en"
-TRASPLANTAR,v.t. Xaab.
-TRATO,"sus. Nuupt’aan, k’aax t’aan."
-TRAVIESO,"adj.(m) J ko’ , (f) Ix ko’."
-TRÉBOL,sus. Xchiople’
-TRECE,sus. Óox lajun p’éel.
-TREINTA,sus. Lajun p’éel ti ka’a k’aal
-"TRENZADO, MUY ENREDADO",adj. Jíijiit’.
-TREPAR,v.t. Na’akal
-TRES,sus. Óoxp’éel.
-TRIBULACIÓN,sus. Numya
-"TRILLADO, MUY TRILLADO","v.t. T’uut’uulki, t’áat’aalki."
-TRINCHERA,"sus. Pa’, tulum."
-TRISTE,"adj. J k’om óol ich, J yaaj óol ich."
-TRISTEZA,"sus. Yaaj óolal, ok’om óolal."
-TRITURAR,"v.t. Juch’, mux"
-TROCAR,v.t. Jelkunaj
-TROJE DE MAÍZ,"sus. Ch’iil, kumche’"
-TROMPETA,sus. Jom
-TRONAR,v.i. Kíilbal
-TRONCO,sus. Chuun
-TRONERA,sus. Kisneb
-TRONO,"sus. Nak, ts’am, k’áanche’ ajau."
-TROPEZAR,"v.i. T’óochpajal, t’óochpaj"
-"TROZAR, DESPEDAZAR",v.t. Koots
-TRUENO,"sus. Kíilbal cháak, péek cháak"
-TRUEQUE,"sus. Jeel, k’ex, k’exul"
-TU,adj. poses. A
-TUBÉRCULO,sus. K’uk’ut
-TUBERCULOSO,sus. Aj bakil
-TUCÁN,sus. Pan ch’eel
-TUERTO,adj. Ch’óop
-TUMBA DE LA SELVA,sus. Kool.
-"TUMBA, SEPULTUA",sus. Múuknal
-TUMBAR,"v.t. Kool, nix"
-TUMOR,"sus. Chu’chum, chu’uchum"
-TUMULTO,sus. P’ujul TUNA (OPUNTIA DILLENII (KER
-TURBADO,adj. Kilba óol
-TURBIO,adj. Puuk’
-TUYO,pron. poses. Atia’al.
-"TUZA (HETEROGEOMYS, HÍSPIDUS (SAY))",sus. Baj sus.
-UBRE,"sus. Chu’uch ba’alche’, yiim ba’alche’"
-ÚLTIMO,sus. Ts’o’ok
-UN INSTANTE,adv. de t. Jun súutuk
-UN POCO,"adv. de c. Ts’e’ets’ek, jun p’íit, jun"
-UNA VEZ,"adv. de t. Jun jets’ake’, junténajkij, p’íitil juntéenekij"
-"ÚNICO, COSA SOLITARIA",sus. Junab.
-UNIDO,adj. Nuupan
-UNIDOS POR GRUPOS,adv. de c. Lo’olo’ot.
-UNIÓN,sus. Jun óolal
-UNIR,"v.t. Nup, nup’, nuupik."
-"UNIR, PEGAR, EMBONAR",v.t. Tak’
-"UNIR, JUNTAR, PEGAR",v.t. Loot.
-UNTAR,v.t. Ku’ul.
-"UNTAR, PEGAR","v.t Paak’ UNTAR EL BOCADO EN LA COMIDA,PRESIONAR LA CARNE GUISADA .v.t. Ts’aal"
-UNTAR,"v.t. Ji’, ji’i, ji’ik"
-UÑA,sus. Iich’ak
-UÑA DE GATO (PISONIA AULEATA),sus. Beeb
-URDIMBRE,sus. Mamak
-URDIR,v.t. Waak’
-URDIR HAMACA,v.t. Waak’k’áan
-URGENTE,adv. de m. Séeb
-URRACA,sus. Ch’eel
-USTEDES,pron. pers. Te’ex
-UTENSILIO,sus. Nu’ukul UTENSILIO DE LA COCINA MAYA QUE CONSISTE EN
-UNA CIRCUNFERENCIA DE BEJUCO CUYO INTE,
-RIOR ESTÁ TEJIDO CON HILOS DE HENEQUÉN,sus. Peten aak’
-ÚTERO,"sus. Sayomal, soyem."
-ÚTIL,adj. K’abéet
-UVA DE LA COSTA,sus. Mixche’
-UVA DE MAR (COCCOLOBA UVÍFERA (L) JACQ),sus.
-UNIVERSIDAD,"sus. U molay kanbal, noj na"
-UNO,sus. Jun
-UVAS,sus. Sak tabka’an
-UVERO,sus. Mixche’ UVERO
-VACA,sus. Ch’úupul wakax
-VACIAR,v.t. Láal
-"VACIAR, TRASEGAR",v.t. Báab
-VACIAR ALGÚN LÍQUIDO EN EMBASE DE BOCA AN,
-GOSTA O CUELLO DELGADO,v.t. T’ooj.
-"VACILAR, BROMEAR",v.i. Tuuskeep
-VACÍO,adj. Joch.
-VACUNA,sus. Jup’lants’aako’
-VAGABUNDO,sus. Aj nunum
-VAGINA,sus. Peel
-VAHÍDO,sus. Tupul ich
-VAHO,sus. Owox
-VAINA,sus. Piix
-VALENTÍA,"sus. Chichil óolal, jolkanil"
-VALIENTE,adj. Aj koo
-"VALIOSO, NECESARIO","adj. K’a’anan, k’a’ana’an"
-"VALOR, PRECIO","sus. Tojol, tojoj."
-"VALOR, VALENTÍA","sus. Xet’ óolal, yail, j ma’ sajkil, x ma’ sajkil."
-VALLE,sus. Jem
-VANAGLORIA,sus. Nonojbail
-VANIDAD,sus. Ma’ba’lil
-VANIDOSA,adj. X ka’amal
-VANIDOSO,adj. J ka’amal.
-VAPOR,"sus. Ooxol, owox"
-VAQUERO,sus. J kanan wakax VARA PARA MEDIR QUE TIENE LA SEXTA PARTE DE
-"UN MECATE, ES DECIR 333 m",sus. P’iisiche’
-VARIEDAD DE AVISPA DE GRAN TAMAÑO CUYA PICA,
-DURA PROVOCA FIEBRE,sus. Bobo’te’ 
-VARIEDAD DE FRIJOL NEGRO,sus. Tsama’
-VARIEDAD DE MOSCA PEQUEÑA,sus. Us
-VECINO,sus. Et chi’ na
-VEINTE,sus. Jun k’aal
-VEINTIUNO,sus. Jun p’éel ti ka’a k’aal
-VEJEZ,sus. Ch’íijil
-VEJIGA,"sus. Chim, chimix"
-VELA,sus. Kib
-VELAR,"v.t. Kanankimén, kalankimén"
-VELO DE NOVIA,sus. K’asab nook’
-VELORIO,sus. Kanankimén.
-VELOZ,"adj. Séeb, séeba’an"
-VELLOS,sus. Ts’ukuti
-VENA,sus. Beel k’i’ik’
-VENADO COLA BLANCA,sus. Kéej
-VENADO ENANO (MAZAMA PANDORA (MERRIAM)),
-VENADO CON CUERNO DE UNA PUNTA,sus.
-VENADO CON CUERNOS RAMIFICADOS,sus. Nikte’ sus. Yuuk. Púuts’nab. baak.
-VENCER,"v.t. Baksaj, pa’ muuk’"
-VENCER A OTRO,v.t. Ts’oyesaj
-VENCIDO,"sus. Baksaj, kuch chimal"
-VENDER,v.t. Kóonol
-VENENO,"sus. Ts’akil, yek’el."
-VENENO DE ANIMALES,sus. K’inam.
-VENERAR,v.t. K’ul.
-VENGANZA,"sus. Ch’atoj, ch’atojil"
-VENIR,"v.i. Taal , taalel."
-VENTA,sus. Koonol
-VENTAJA,sus. Paynumil
-VENTANA,"sus. Kalom k’iin, kisneb naaj"
-VENTERA DE AGUA,sus. X koon ja’
-VENTOSA,"sus. Ch’ut, nup’ luuch"
-VENTOSA INTESTINAL,sus. Kiis.
-VENTOSEAR,v.i. Kiis.
-VENUS,sus. Noj eek’
-VER,v.i. Il
-VER CON DELEITE,v.t. Cha’ant
-VERA,adv. de l. Tséel
-VERA,sus. Jáal
-VERBO AUXILIAR CON QUE SE CONJUGA EL PRESEN,
-TE DE INDICATIVO DE TODOS LOS VERBOS NEU,TROS Y SIGNIFICA ESTARSE VERIFICANDO EL
-VERBO,Ka’aj
-VERDAD,"sus. Jaaj, jaajil, máasa, máasima’"
-VERDADERO,adj. Ajajbil
-"VERDE, COLOR VERDE",adj. Ya’ax.
-"VERDE, INMADURO","adj., sus. áak’, ya’ax."
-VERDE ESMERALDA,adj. Ya’aya’ax
-VERDÍN,sus. Kuuxum
-VERDUGO,sus.Aj ch’uy tab.
-VERDUZCO,adj Ya’axele’en.
-VEREDA,"sus. T’ulbe’, éek’bej"
-VER FANTASMAS O ALGÚN MAL AGÜERO,v.i. Ma
-VERGA,"sus. Keep, toon"
-VERGÜENZA,"sus. Subtal, su’tal"
-VERRACO,sus. Beel
-VERRUGA,sus. Aax
-VERTER,"v.t. Bab, láal, piich."
-VERTER COMO SEA,v.t. Chóochooblaalbil.
-VESÍCULA BILIAR,sus. K’aj
-VESTIDO,"sus. Búuko’, nook’"
-"VESTIDO CON ELEGANCIA, BIEN VESTIDO",adj. P’íip’iiki
-VESTIR,"v.t. Búuk, búukinaj."
-VIAJERO,"sus. Aj xíinbal, j xíinbal VOLAR"
-VÍA LÁCTEA,"sus. Tamakas, tamkas."
-VÍBORA,sus. Kaan
-VÍBORA CORALILLO,sus. Kalam
-VÍBORA DE CASCABEL,"sus. Ajau kaan, tsáab kaan"
-VIBRAR,v.i. Bik’chalák
-VICTORIA,sus. Ts’oysaj
-VICTORIOSO,adj. Aj ts’oye saj
-VIDA,"sus. Iik’, kuxtal"
-VIEJO,"adj. Ch’iija’an, laab, nuxib, nuxiib, úu"
-VIENTO,sus. Iik’
-VIENTO CON LLUVIA,sus. Ak’ ya’abil iik’
-VIENTO MANSO Y BLANDO,sus. Juyuknak iik’
-VIENTO QUE VIENE ANTES DEL AGUACERO,sus. Yiik’al ja’
-VIENTRE,sus. Jobnel
-VIGILANTE,"adj. P’ix ich, Aj kanan bej."
-VIGILAR,v.t. Kanan
-VIGILIA,sus. P’ix ich
-VIGOR,"sus. K’inam, muuk’"
-VINAGRE,sus. Suuts’ki
-VIOLACIÓN,sus. Sat suju’uyil
-VIOLÍN,sus. Jichoch
-VIRGEN,"adj. Suju’uy, sujuy"
-VIRILIDAD,sus. Toonil
-VIRTUD,"sus. Chich óolal, tumut óolal, utsil, xiuil, tibilil."
-VIRUELA,"sus. K’áak’, usam k’áak’"
-VÍSCERAS,sus. Jobnel
-VISIBLE,adj. Chika’an
-VISIÓN,sus. Waya’as.
-VISIÓN ENTRE SUEÑOS,sus. Nayal
-VISITA,sus. Yu’ulab.
-VISTO,adj. Ila’an
-VIVIR,"v.i. Kaajnáal, kaajakbal, kuxtal, kuxtaj"
-VOCABULARIO,"sus. Tsoola’an t’aan, molay t’aano’ob."
-VOLAR,"v.i. Xik’nal, popok xik’"
-VOLCADO,adj. Noka’an.
-VOLTEARSE O HACER RODAR,v.t. Balak’taj
-VOLUNTAD,"sus. Óol, óolaj, yot óol."
-"VOLVER, GIRAR",v.i. Suut
-VOMITAR,v.t. Xeej
-VÓMITO,sus. Xeej.
-VORAZ,adj. Aj balnak
-VUELTA,sus. Suut
-VUELTA QUE HACE EL CAMINO,sus. Wats’ bej
-VUELTA Y COMBA QUE HACE EL MADERO,sus. Loch
-VUESTRO,pron. poses. Atia’ale’ex
-"VULVA, VAGINA",sus. Peel Y Yerba Z Zopilote
-Y,conj. cop. que sólo se usa para numera
-Y,"conj. cop. Kux, i’ix"
-Y,conj. cop. Yéetel
-YERBA,sus. Xíiw
-YERNO,sus. Ja’an
-YO,pron. pers. Teen
-YUCA (MANIHOT ESCULENTA (CRANTZ)),sus. Ts’íim
-YUGO PARA UNIR UNA BESTIA CON OTRA,sus. Yukache’
-ZACATE,sus. Su’uk
-"ZAFAR, SACAR, DESCLAVAR, DESENCAJAR","v.t. Joots’, jook"
-ZAFAR,v.t. Jíits’
-ZAFRA,"sus. Ch’ot, ch’óot."
-ZANJA,sus. Jom
-ZAPATO,sus. Xanab
-ZAPATEADO,"adj. Janchalak’ óok’ot. ,ZAPOTE (MANILKARA ZAPOTA (L) VAN ROYEN)."
-ZAPOTE AMARILLO,sus. K’anisté
-ZAPOTE NEGRO (DIESPYRUS DIGYNA (JACQ),sus.
-ZARIGÜEYA,sus. Ooch
-ZOPILOTE,sus. Ch’oom
-ZOPILOTE DE CABEZA ROJA (CATHARTES AURA AURA),sus. K’uch
-ZORRA,"sus. Ch’omak, ch’amak"
-ZORRILLO,sus. Pay ooch
-ZOZOBRA,sus. Ik’il iik’.
+word_id,words,definitions
+1,A,prep. ti’. Dícelo a Juana : A’al ti’ X
+2,A (para interrogar),prep. Tu ba
+3,ABAJO,"adv. de l. Kaabal, yáanal. Mi zapato está debajo de mi hamaca: Yáanal in k’áan ti’aan in xanab."
+4,ABANDONAR,v.t. P’aat
+5,ABANICAR,"v.t. X pikit, pik’it iik’e’. Píipik."
+6,ABANICO,sus. Pikit
+7,ABARATAR,v.t. Yéemel u tojol.
+8,"ABARCAR, RODEAR",v.t. Bak’ paach
+9,ABDOMEN,sus. Nak’
+10,ABEJA (APIS MELLIFICA Y MELIPONA SSP),"sus. Ko’olel kaab, kaab , xunáan kaab, yik’el kaab."
+11,ABEJORRO,sus. Báalam kaab.
+12,ABERTURA,"sus. Jool, jaatalil, teejelil, buu"
+13,ABERTURA HONDA,sus. Jet’
+14,ABIERTO EN FORMA DE BOCA,adv. Jáajaapan
+15,ABISMO,sus. Julek’
+16,ABOFETEAR,"v.t. Láaj, p’aak’láaj."
+17,ABOFETEAR REPETIDAS VECES,"v.t. Máamaaláaj,"
+18,ABOGADO,Sus. Aj k’ulel
+19,ABOMINABLE,adj. P’etayenjal
+20,ABORRECER,v.t. P’eek
+21,ABORTO,sus. Éemel al
+22,ABRAZAR,v.t. Méek’
+23,ABRAZAR UNO AL CUELLO O DE LA CERVIS,v.t. Lóoch
+24,ABRAZAR REPETIDAMENTE,v.t. Lóolóochbil.
+25,ABRAZAR A CADA RATO,v.t. Méemek’ik.
+26,ABRIGAR,"v.t. Teep’, to’owe, piixe’."
+27,ABRIGO,sus. Chuk bo’oy.
+28,ABRIR LOS OJOS,v.i. P’iil a wich
+29,ABRIRSE,v.i. Xit’k’ajal.
+30,ABRILLANTAR,v.t. Lelekuntal
+31,ABRIR LA PUERTA,v.t. Je’.
+32,ABRIR LAS PIERNAS,v.i. Jeech.
+33,ABRIR VAINAS,v.t. P’eel.
+34,ABRIR LA BOCA,v.i. Jaap
+35,ABRIR UNA BOLSA,v.t. Xiit’.
+36,ABRIR LOS PIES,v.i. Xaach.
+37,ABRIR CAMINO,v.t. Jool.
+38,ABRIR,v.i. Jet
+39,ABRIR,v.t. Je’
+40,ABRIRSE,v.i. Xíit’il
+41,ABSORBER,"v.t. Xuuch, chu’uch"
+42,ABSORBER CON FUERZA,v.t. Xúuxuuch.
+43,ABUELA,sus. Chiich
+44,ABUELO,"sus. Nool, taaten, nojoch taata."
+45,A BUEN TIEMPO,"adv. de t. Tii’, tibilak"
+46,ABUNDANCIA DE FRUTA EN EL ÁRBOL,adv. de c. Jíijiichki. chinki. ABUNDANTE. Adv. de c. Ch’éech’eeki.
+47,ABUNDAR,v.i. Ya’abtal
+48,ABURRIMIENTO,sus. Náak óol
+49,ABURRIR,v.i. Náakal óol
+50,ACÁ,"adv. de l. Waye’, weye’, way"
+51,ACABA,adv. de t. Jach táant
+52,ACABA DE SER,adv. de t. Je’lakito.
+53,ACABAR,"v.t. Xu’ul, ts’o’ok, náak. báabaaláaj."
+54,ABUNDANCIA DE FRUTA EN EL ÁRBOL,adj.Chin
+55,ACABARSE,v.i. Xu’upul.
+56,ACABARSE DEL TODO,v.i. Nak’al.
+57,ACABARSE EL AIRE,v.i. Ku’upul u wiik’.
+58,A CADA MOMENTO,adv. de t. Junak
+59,A CADA RATO,adv. de t. Chich muuk’
+60,ACAECER,v.i. Úuchul
+61,ACAECER DE REPENTE,v.i. Wasut jal
+62,ACALORARSE,v.i. Kal k’iin
+63,ACALLAR,"v.i. Chiltaj, chilkunaj"
+64,"ACARICIAR, ALISAR","v.t. Báay, baytaj."
+65,"ACARREAR, TRANSPORTAR",v.t. Púut
+66,"ACASO, QUIZÁS","adv de d. Binakí, balakix."
+67,ACAUDALADO,adj. Ayik’al. Aj táak’in máak.
+68,ACAUDILLAR,v.t. Méek’tantaj
+69,ACCIDENTE,sus. Loob
+70,ACCIÓN DE GRACIAS,sus. Ts’aa yaatsil.
+71,ACECHAR,v.i. Ch’eeneb
+72,ACEDO,adj. Paj
+73,ACEITOSO O MANTECOSO,adj.Ch’ach’apki.
+74,ACEPTAR UNA PROPOSICIÓN,v.t. Ket
+75,ACEPTAR,v.i. Chíintaj.
+76,ACEQUIA O CANAL,sus. Bebek
+77,ACERCAR,v.i. Naats’
+78,ACERCARSE,v.i. Naats’al
+79,ACERCARSE REPETIDAMENTE,v.t. Naanaats’
+80,ACERTAR,v.t. Utsál
+81,ACERTAR EL TIRO,v.t. Toj k’ab.
+82,"ACESIDO, DISNEA (RESPIRAR CON DIFICULTAD)",sus. Jéesbal se’en.
+83,ACEZAR,v.i. Jéesbal
+84,ACLARAR,"v.i. Sáastal, píik"
+85,ACOBARDARSE O SER VENCIDO,adj. Kumtantaj
+86,ACOMETER,"v.t. Kopulba, ts’am k’ab"
+87,ACOMODAR,v.t. Tsool
+88,ACOMPAÑAR,"v.t. Tabantaj, láak’intal, láak’intik."
+89,ACONSEJAR,v.t. Tsool xikin
+90,ACONTECER,v.t. Úuchchajal
+91,ACORDADO,adj. Tumaja’an
+92,ACORDEÓN,sus. Sats’alsats’.
+93,ACORRALAR,"v.t. K’aal, k’aansaj"
+94,ACOSTADO,adj. Chilikbal 
+95,ACOSTAR,"v.i. Chital, chiltal."
+96,ACOSTAR A ALGUIEN,v.t. Chilkuns.
+97,ACOSTADO BOCA ARRIBA,adv. de m. Jawtal.
+98,ACOSTADO BOCA ARRIBA,adv. de m. Jawakbal
+99,ACOSTARSE BOCA ABAJO,"v.i. Nok, nokakbaj ,chelik"
+100,ACOSTUMBRADO,adj. Suuk
+101,ACOSTUMBRADO,adj. Suukbe’en
+102,ACOSTUMBRAR,v.i. Na’antal
+103,ACOSTUMBRARSE,v.i. Suuktal
+104,ACRECENTADA,adj. Chaybesabal
+105,ACRIBILLAR,v.t. Ts’ots’op loom
+106,ACTIVIDAD,sus. Sa’ak óolal.
+107,ACTIVO,adj. T’a’aj
+108,ACTOR O COMEDIANTE,sus. Balts’am
+109,ACTOS SEXUALES,"sus.Tal, ts’íis, top."
+110,ACTUALMENTE,"adv de t. Bejela’e’,beje’ele’, bejla’e’, bejle’, bela’e’, bele’."
+111,ACUÁTICO,adj. Ja’il
+112,ACUCHILLAR,v.t. Loom
+113,ACUERDO,sus. Éejenil.
+114,ACUERDO O RESOLUCIÓN TOMADA,"sus. Xot óol, multumut, k’aax t’aan."
+115,ACUÑAR,v.t. Cheej.
+116,ACURRUCARSE,"v.i. Mochtal, kop, moch"
+117,ACUSAR,v.t. Takpool
+118,ACUSACIÓN,sus. Takpoolil
+119,ACHIOTE,"sus. Kiwi’, k’uxub"
+120,ADEMÁN,"sus. Béech’ k’ab, t’aan k’ab"
+121,ADEMÁS,adv. de c. Bey xan
+122,ADENTRO,"adv. de l. Ich, ichil"
+123,ADEUDAR,v.t. P’aax
+124,"ADHERIR, PEGAR",v.t. Tak’
+125,ADICIONAR,"v.t. Ts’a yóok’ol, ya’abkuns."
+126,ADINERADO,"adj. Ayik’al, táak’iin máak."
+127,ADIVINANZAS,sus. Na’ato’ob
+128,"ADIVINAR, ENTENDER",v.t. Na’at
+129,"ADMINISTRAR, REGIR, GOBERNAR",v.t. Belankil.
+130,"ADMITIR, CONCEDER",v.t. Oksaj t’aan
+131,ADOLESCENCIA,sus. gen. m. Táankelemil; gen. f. x
+132,ADORAR,v.t. K’ult
+133,ADORATORIO,sus. Chan naajil k’ultaj
+134,ADULADOR,adj. Aj bay pool
+135,ADULAR,v.t. Baytaj
+136,ADÚLTERO,sus. Aj kalpach
+137,ADULTERIO DE MUJER,"sus. Kal paach, joy ts’om"
+138,ADULTO,sus. Nojoch máak.
+139,ADVERSIDAD,sus. Numya
+140,A ESTA HORA,adv. de t. Ualkila’
+141,A EMPELLONES,adv. de m. Ts’alk’abtantaj
+142,AFECTO,sus. Ts’a óolal
+143,"AFEITAR, TRASQUILAR","v.t. Ts’iik, jo’och."
+144,AFEMINADO,"adj. Ch’úupil xiib, síis óol."
+145,AFERRAR,"v.i. Ch’ik, maach."
+146,AFIANZADO EN ALGO CON MUCHA FUERZA,adj. Xáaxaachki.
+147,AFILAR,"v.t. Jáak, ja’i, jóojsaj yeej, juux."
+148,"AFILAR, DESBASTAR, LIJAR, FROTAR",v.t. Ja’.
+149,A FIN DE QUE,conj. fin. Utia’al
+150,AFIRMACIÓN,sus. Jailkunaj t’aan
+151,"AFIRMAR, ASEGURAR, ASENTAR CON FIRMEZA",v.i. Jeets’
+152,AFLIGIDO,adj. Naak’al ti’
+153,AFLOJAR LAS AMARRAS,"v.t. Sáal , waach’."
+154,"AFLOJAR, DESATAR, SOLTAR",v.t. Cha’
+155,AFLOJAR ALGO TENSO,v.t. Ch’uuk.
+156,AFUERA,adv. de l. Táankab
+157,AGACHADO,"adj. Mot’okbal, p’oka’an,"
+158,AGACHARSE,"v.i. Mot’al, p’oktal, t’uchtal,"
+159,AGARRAR,"v.t. Ch’a’an, maach, cháach, laap’, p’okokbal. mot’. ch’a’aj."
+160,"AGARRAR, ASIR, SUJETAR",v.t. Maach.
+161,AGAZAPAR,v.i. Mot’kin
+162,AGAZAPARSE,v.i. Mot’tal.
+163,AGAZAPADO,adj. Mot’baj.
+164,ÁGIL,adj. T’a’aj
+165,AGILIDAD,sus. T’a’ajil.
+166,ÁGIL DE PENSAMIENTO,adj. Léeleep’ki.
+167,"AGITARSE, COBRAR FUERZA",v.i. T’a’ajtal
+168,AGLOMERAR,"v.i. Múuch’kiin, mulkiin, múu"
+169,AGONÍA,sus. Pa’ muuk’.
+170,AGORAR,"v.t. Tamaxchi’, tomoxchi’"
+171,AGOTAR,"v.t. Xuup, sóop’."
+172,AGRADECIMIENTO,"sus. Nibpixan, nibpixanil,"
+173,AGRAVIO,sus. K’aas poch’
+174,AGREGAR,"v.t.Ts’a yóok’ol, ya’abkuns."
+175,AGRICULTOR,"sus. Koolnáal, j meyji k’áax, niib óolal koolkaab"
+176,AGRICULTURA,sus.Meyjul k’áax.
+177,AGRIDULCE,adj. Ch’ujuksu’uts’
+178,AGRIETAR,v.i. Jet
+179,AGRIO,adj. Su’uts’
+180,AGUA,sus. Ja’
+181,AGUA CALIENTE,sus. Chokoj ja’
+182,AGUA LLUVIA,"sus. Ka’anil ja’, ch’ulub ja’"
+183,AGUACATE (PERSEA AMERICANA MILLER),sus. Oon
+184,AGUACERO,sus. K’a’amkach ja’.
+185,AGUACERO PEQUEÑO,sus. Luuchil ja’
+186,AGUADA,"sus. Áak’al, áak’al che’"
+187,AGUADOR,sus. J koonja’
+188,AGUADORA,sus. X koonja’.
+189,AGUARDAR,"v.i. Páak’t, páa’t"
+190,AGUARDIENTE,"sus. Uk’aj, wiix kisin, k’áaj ja’, ja’i’ káaltal."
+191,AGUIJÓN,"sus. Aach, k’i’ix"
+192,ÁGUILA ROJA,sus. Kóot.
+193,AGUILILLA,sus. Koos
+194,AGUILILLA NEGRA,sus. Éek’ píip
+195,AGUJA,sus. Púuts’
+196,AGUJEREADO,"adj. Jola’an, pota’an"
+197,AGUJEREAR,v.t. Jo’ol
+198,"AGUJERAR, PERFORAR, BARRENAR",v.t. Poot.
+199,AGUJERO,sus. Jool
+200,AGUTÍ,sus. Tsuub
+201,AGÜERO,"sus. Tomoj chi’, tomox chi’,tamaxchi’."
+202,AHÍ,adv. de l. Te’elo’. ¿Qué haces ahí? ¿Ba’ax ka beetik te’elo’?
+203,AHIJADO,sus. Mejenilan
+204,AHOGAR,v.t. Kupaj
+205,AHOGAR APRETANDO LA GARGANTA,v.t. Bits’ nak paach.
+206,ALCANZAR,"v.t. Chuk, chukik, chukpaachtik,"
+207,AHORA,"adv. de t. Bejela’e’, teak, teaki’, Chuuk."
+208,AHORA MISMO,adv. de t. Táan
+209,AHORCAR,v.t. Jich’kaal
+210,AHORRAR DINERO,v.t.Líik’esaj táak’iin.
+211,AHORRO,sus. T’áal k’u’
+212,"AHUECADO, CON MUCHOS HUECOS",adj. Jóonjo
+213,AHUYENTAR,v.t. Tóojol
+214,AIRE,sus. Iik’
+215,AIRE FUERTE,sus. K’aam iik’
+216,"AJADAS, ESTROPEADAS",adj. T’u’t’u’uy
+217,AJENO,adj. Junpayil
+218,AJONJOLÍ,sus. Sikli’ p’uus
+219,AJUSTAR,"v.t.P’iiskunaj, p’elkunaj."
+220,AJUSTICIADO,adj. Malel táankab
+221,AL,prep.Ti’. Le di ramón al borrego.Tin ts’aj óox ti’ taman
+222,ALBARRADA,sus. Koot.
+223,"ALBARRADEAR, HACER ALBARRADA",v.t. Koot.
+224,ALBOROTO,sus. X wookin.
+225,AL CONTRARIO,adv. de m. Kuchpaach.
+226,ALEGRÍA,"sus. Ki’imak óol, ki’ óolal, ki’imak"
+227,ALFABETIZADOR,"sus. Aj ka’ansaj xook, Aj óolajil. ka’ambesaj."
+228,AL INSTANTE,adv. de m. Jan
+229,AL RATO,"adv. de t. Ka’akate’, ma’ sáame"
+230,ALA,sus. Xiik’
+231,ALACENA,sus. Balab.
+232,ALACRÁN,"sus. Síina’an, sina’an"
+233,ÁLAMO (FICUS COTINIFOLIA HB ET K),sus.
+234,ALBAHACA (OCIMUM MICRANTHUM WILLD),"sus. Kóopo’, ju’un Kakaltun"
+235,ALBAÑIL,"sus.J pak’ bal, j meen pak’."
+236,ALBOROTAR,v.t. P’uj
+237,ALBOROTAR PUEBLOS,v.t. Liik’saj kaajtal
+238,ALCALDE,"sus. Aj beelmal, aj nat be "
+239,"ALCANZAR, ATRAPAR, CAPTURAR PESCAR",v.t.
+240,ALCANZAR LO DESEADO,v.t. Chuuk sits’il
+241,ALDABA DE HIERRO,sus. K’aalab máaskab
+242,ALDEA,sus. Chan kaaj
+243,ALEGRÍA,"sus. Ki’ ki’ óolal, ki’imak óolal, ki’imal óolajil."
+244,ALEJADAS,adj. Náachja’antak
+245,ALEJAR,v.t. Náachkun
+246,ALEJARSE,v.i. Náachtal.
+247,ALENTAR,"v.t. Kuxkintaj óol, ch’a’b óol."
+248,ALEPUSA (ÁCARO QUE VIVE EN GALLINAS CLUECAS),sus. P’aj
+249,ALETA,sus. Mejen ot’ xiik’o’ob
+250,ALETEAR,"v.i. Popokxiik’o’ob, poklankil, popokankil."
+251,ALEVOSÍA,sus. K’eban t’aan
+252,ALFARERA,sus. X paat k’at.
+253,ALFARERO,sus. J paat k’at
+254,ALFORJA,sus. Mukuk
+255,ALGARABÍA,"sus. Tataj awatil, k’amach awatil"
+256,ALGO,adv. de c.Ts’e’ets’ek .
+257,ALGODÓN (GOSSYPIUM HIRRSUTUM L),sus. Jinta
+258,ALGÚN,adv de c. Babajun.
+259,ALGUNOS,adv de c. Ts’éets’ek.
+260,ALGUNA COSA,sus. Ba’abal
+261,ALGUIEN,sus. Yaan máax.
+262,"ALHAJA, JOYA",sus. Mejen ba’abal ko’oj.
+263,ALIANZA,"sus. Jax t’aanil, k’aax t’aan, múuch’ t’aani, mok t’aani."
+264,ALIENTO,"sus. Iik’, múusik’"
+265,ALIMENTAR,"v.t. Tséem, téentik."
+266,ALIMENTO,"sus. Janal, o’och, janalbe’en"
+267,ALIMENTADO,adj. Tséenta’
+268,ALISAR,"v.t. Tats’, báay, ji’ik"
+269,ALIVIAR,v.t. Táan u yutstal.
+270,ALIVIO,sus. Ch’éensáal
+271,ALJIBE,sus. Chultun
+272,AL LADO,adv de l. Tu tséel
+273,ALMA,"sus. Pixan, óol."
+274,ALMIZCLE,sus. P’u’us
+275,ALMORRANA,sus. X mumus
+276,ALMUD (MEDIDA DE PESO DE 3600 KGS),sus. Muut
+277,ALMUERZO,"sus. Janal, o’och"
+278,ALPARGATA,sus. Xaanab k’éewel. ALPARGATAS QUE SE AMARRAN AL TOBILLO CON UN
+279,CORDEL,sus. X bak’al óoko’ob.
+280,ALREDEDOR,"adv. de l. Bak’ paach, ba’apach, nak’lik,bak’lam paach."
+281,ALTAR,"sus. K’atal che’, K’uyen temil"
+282,ALTAR RÚSTICO DE MADERA,sus. Ka’anche’
+283,ALTERADO DE LOS NERVIOS,adj. Na’aka’an u
+284,ALTERAR EL ÁNIMO LIGERAMENTE,v.i. Lep’ óol
+285,ALTERARSE MUCHO COMO DE ESPANTO,v.i. ch’íich’il. Chaketjal
+286,ALTIVEZ,"sus. Tsikbail, ka’anal óolil."
+287,ALTIVO,adj. Ka’anal óol
+288,ALTO,adj. Ka’anal bak
+289,ALTURA,sus. Ka’analil
+290,"ALUMBRAR, AFOCAR",v.t. Juul.
+291,ALUMNO,"sus. Aj kambal, j káanbal."
+292,ALUMNA,"sus. Ix kambal, x káanbal"
+293,ALZAR,"v.t. Li’is, ch’úuy."
+294,ALZAR O ESTIRAR LAS MANOS O LOS PIES,v.i. Tiich’
+295,"ALZAR, ASIR CON LOS DEDOS",v.t. T’úuy.
+296,ALLÁ,adv. de l. Tolo’
+297,ALLANAR,"v.t. Tax, taxkun"
+298,ALLANAR CON LA MANO,v.t. Jux k’ab
+299,"ALLEGAR, ACERCAR",v.i. Taak.
+300,ALLÍ,"adv. de l. Ti’i, te’elo’, tolo’. Ponlo ahí: Ts’a te’elo’"
+301,AMABLE,adj. Uts.
+302,AMABILIDAD,sus. Utsil.
+303,AMAMANTAR,v.t. Ts’áa chu’uch
+304,AMANECER,"sus.,v.i. Sáastal, sáastaj, jáatskab k’iin, píik, píik’il."
+305,AMANECER,"adv. de t.Píik’ij, sáaschajake’."
+306,AMANSADOR,sus. J suuk kinnáal
+307,AMANTE,"sus. gen. m. J yaakunaj, gen. f. X AMPARAR ba’al, Ix yaakunaj , weey."
+308,AMAPOLA,"(PACHIRA AGUATICA. AUBL.) sus. K’uyche’, k’uux che’."
+309,AMAR,"v.t. Yáakunaj, yaabilaj, yáajkunaj"
+310,AMARANTO (AMATANTHUS),sus. X tes.
+311,AMARGO,adj. K’áaj.
+312,AMARGUÍSIMO,adj. K’áak’áaj.
+313,AMARGURA,sus. K’áajil.
+314,AMARGURA,sus. Ok’om óolal.
+315,AMARILLO,adj. K’an.
+316,AMARILLÍSIMO,adj. K’ank’an.
+317,AMARRAR,v.t. K’aax
+318,AMARRAR FUERTEMENTE,v.t. Jiich’ k’aax.
+319,AMARRAR FUERTEMENTE,v.t. Móomooch.
+320,AMARRADO MUY FUERTE VARIAS VECES,adj.
+321,"AMARRADO CON FUERZA, DIFÍCIL DE DESATAR",adv K’aak’aax. de m. Jíijiich’.
+322,AMBICIÓN,"sus. Sawin achil, ts’íibol, po"
+323,AMBICIÓN,sus. Sits’ óol.
+324,AMBICIONAR,v.i. Sits’
+325,A MI MISMO,Baatsile’
+326,AMENAZAR,"v.t. Sajakkun, ts’áa sajak"
+327,AMIGO,"sus. Et ook, etail, éet bisbail, etchi’ili’, etchi’il."
+328,AMNISTÍA,sus. Sajtsajil
+329,AMONESTACIÓN,sus. Pay óolal.
+330,AMONESTAR,v.t. K’eey.
+331,AMONTONADO,"adj. Túujkab. AMONTONADO EN EXCESO, MUY ESPONJADO. adj."
+332,AMONTONAR,"v.t. Mulkin, múuch’kin, nik."
+333,"AMONTONADO, AGLOMERADO",adj.
+334,"AMONTONAR, HACER MONTONES",v.t. Túutuu
+335,"AMONTONAR, TUPIR",v.t. Cheej.
+336,AMONTONARSE,"v.t. Múuch’ul, múuch’tal."
+337,AMOR,"sus. Yaakun, yaakunajil, yaabilaj."
+338,AMOTINAR,v.i. P’ujla’ajal
+339,AMPARAR,v.t. Bo’oybesaj
+340,AMPARO,sus. Anat
+341,AMPLIAR,"v.t. Nojochkinsaj, kóochkinsaj"
+342,AMPOLLA,"sus. Kum ja’, xaakal, xáakal."
+343,AMPOLLAR,"v.i. Xaak, xáak, p’ool."
+344,ÁMPULAS O PROTUBERANCIAS,sus. P’oolen p’óol.
+345,AMULETO,sus. Pay okil.
+346,AMURALLAR,"v.t. K’aal, bak’ paach"
+347,ANARANJADO,adj. Chak k’ank’an
+348,ANATEMA,sus. Aj tsakom
+349,ANCIANO,"adj. Nuxib, ch’iija’an"
+350,ANCLA,"sus. Ch’uuy tuun, Ch’uuy máaskab."
+351,ANCHO,adj. Kóoch
+352,ANCHURA,sus. Kóochil.
+353,ANDAR,v.i. Xíinbal
+354,ANDAR A LA REDONDA COMO CABALLO DE NORIA,v.i. Kots’ xíinbal
+355,ANDAR DANDO TRASPIÉS,v.i. Takchalak ANDRAJO. sus. T’u’ut’uy
+356,ANEGAR,v.i. Búulul
+357,"ANEGAR, AHOGAR",v.i. Buul
+358,ANÉMICO,adj. Sakpak’e’en
+359,ANEMIA,sus. Sakpak’e’enil.
+360,ÁNGULO,"sus. Ti’its, tu’uk’."
+361,ANGUSTIA,sus. Ok’om óolal .
+362,ANGUSTIA DE ÁNIMO Y DE CORAZÓN,sus. Jat’ tsemil
+363,ANIDAR,v.t. K’u’ankil
+364,ANILLO,sus. Ts’ipit k’ab
+365,ANIMAL,sus. Ba’alche’
+366,ANIMAL DOMÉSTICO,sus. Aalak’
+367,ANIMAL MITOLÓGICO,"sus. Bob, bobil, boboch"
+368,ANIMAL MONTARAZ,sus. Ba’alche’
+369,ANIMAL QUE HA SIDO AMANSADO O DOMESTICA,
+370,DO,sus. Aalak’bil
+371,ANIMAR,"v.t. Ts’a óol, líik’esaj óol."
+372,ÁNIMO,"sus. Chichil óolal, lep’óolal, óol,"
+373,ANIMOSO,"adj. Chich óol, t’a’aj."
+374,ANIQUILARSE,v.i. Ch’ejel
+375,ANO,"sus. Iit, moolo, moolol, mooloj, óolaj chuun. "
+376,ANOCHE,"adv. de t. Ok’najak, áak’ab, áak’abejak"
+377,ANOCHECER,"v.i. Áak’abtal, oknaj k’iin ANOLAR (DESGASTAR UN DULCE EN LA BOCA MOVIÉNDOLO DE"
+378,LADO A LADO),v.t. Nóol .
+379,ANSIEDAD,"sus.Sowjal, chukul iik’, okom óolil, pochil."
+380,ANSIOSO,adj. Aj chukul iik’
+381,"ANSIOSO, MUY DESESPERADO",adj. Paapaach’.
+382,ANZUELO,sus. Lúuts.
+383,ANTEPASADOS,sus. Máanja’an ch’i’ibalo’ob.
+384,ANOCHE,adv. de t. O’niak.
+385,ANONA (ANNONA CHERIMOLA MILLER),sus. Óop
+386,ANONA MORADA,sus. Polbox
+387,ANOTAR,v.t. Ts’íib
+388,ANTE,adv. de l. Aktáan
+389,ANTENOCHE,adv. de t. Áak’ab ka’oje
+390,ANTEPASADO,sus.Úuchben ch’i’ibal.
+391,ANTES,"adv. de t. Ma’aili’, paybe’en, táanil, táanij, yáax, yáax táanil, payanbe’, tanta"
+392,ANTERIORMENTE,"adv de t. Úuch, ka’ach."
+393,ANTIER,"adv. de t. Ka’ojej, kaujeak"
+394,ANTIGUAMENTE,adv. de t. Ka’ach úuchij.
+395,ANTIGÜEDAD,sus. Úuchbenil
+396,ANTIGUO,adj. Úuchben
+397,ANTORCHA,sus. Tajche’
+398,ANUDADO,adj. Jiich’il
+399,ANUDAR,v.t. Mook.
+400,ANUDAR APRETANDO FUERTE,v.t. Jeep’.
+401,ANULAR,"v.t. Cháajal, xu’uls"
+402,ANUNCIAR,v.t. Nub chi’
+403,AÑADIDA,adj. Chaybesabal
+404,AÑADIR,v.t. Chaybesaj
+405,AÑEJAR,"v.i.Úuchbe’enchajal, úuchbe’enjal"
+406,AÑIL (INDIGOFERA SUFFRUTICOSA MILLER),sus. Ch’ooj.
+407,AÑO,sus. Ja’ab.
+408,AÑO PASADO,"sus., adj. Ja’abake’."
+409,APACIGUAR,v.t. Jets’tal
+410,APAGADO,adj. Tuupul.
+411,APAGAR EL FUEGO,v.t. Tuup.
+412,APAGARSE EL FOGÓN,v.i. Jaab.
+413,APARATO,sus. Nu’ukul
+414,APARECER,"v.i. Chíikpajal, tip’"
+415,APARTAR,v.t. Jaats.
+416,APARTE,adv. Junpay
+417,APARTARSE CON ARROGANCIA,v.i. Kusba
+418,APATÍA,sus. Ma’óolal
+419,APEDREADO,adj. Ch’íinch’iinabil.
+420,APENADO,adj. Naak’al ti’
+421,APENAS,adv. de m. Chéen p’eel APESGAR (TOCAR UN OBJETO PRESIONÁNDOLO CON
+422,LA MANO ABIERTA O CON UN DEDO),"v.t. Peets’, ts’aal"
+423,APESTAR,v.i. Tu’
+424,APESTOSO,adj. Tu’
+425,APETITO,"sus. Wi’óolal, wi’ij, táak janal."
+426,APICULTOR,sus. Aj kaabnáal
+427,APICULTURA,"sus. Meyajil kaab, meyjul kaab."
+428,APILADO DESORDENADAMENTE,adj. Ts’áats’aap.
+429,APISONAR,v.t. Bajpéek
+430,APLANAR,"v.t. Táaxkun, táaxkuntik."
+431,APLASTADO,adj. Maxal
+432,"APLASTAR,MAJAR, PRENSAR","v.t. Pech’, pets’, peech’, puuch’."
+433,"APLASTAR, ARRUGAR",v.t. Yuuch’.
+434,APLAUDIR,"v.i. Papax k’ab, lalaaj k’ab."
+435,APLOMO,sus. Toj óolal
+436,APODO,"sus. P’aat k’aaba’, ko’ko’k’aaba’"
+437,APORREAR,v.t. P’uuch
+438,APOSENTO,sus. Tunk’as
+439,APOYAR,"v.i. Jets’kun, nakkun."
+440,APOYO,sus. Jets’il
+441,APRECIO,sus. Tumut
+442,"APRECIAR, VALUAR, JUSTIFICAR","v.t. Xoot chimil APRECIAR, ESTIMAR, AMAR, v.t. Yaakunaj"
+443,APREHENDER,"v.t. Chuk, chuuk, maach"
+444,APREMIO,sus. Yail
+445,APRENDER,"v.i. Káanbal, kaambal."
+446,APRENDER,v.t. Kanik.
+447,APRENDIZAJE,sus. Káanbesajul.
+448,APRESURADO,adj. Seeb óol ARBUSTO yaach’ Chek’mal. sus. Yeet’
+449,APRETADO,"adj. K’ak’ax, nu’ut’"
+450,APRETADO,"adj. Jejep’ki, kankanki."
+451,APRETADO MUY FUERTE,adv. Jéejeep’ki.
+452,APRETAR,"v.t. Jep’, p’e’es."
+453,"APRETAR, CEÑIR",v.t. jiich’.
+454,"APRETAR, DEFORMAR, ARRUGAR","v.t. Yuuch’,"
+455,APRETAR ENTRE DOS COSAS,v.t. Jaap.
+456,APRETARSE COMO LA BALA EN EL ARCABUZ,v.t.
+457,APRETAR FUERTE,v.t. Káamjep’.
+458,APRETÓN QUE SE DA CON LA PUNTA DE LOS DEDOS,
+459,APRISA,"adv. de m. Séebal, seba’an"
+460,APROBACIÓN,"sus. Éejenil, éejenta’al."
+461,APROBAR,v.t. Ketbesaj
+462,APROPIAR,v.t. Pach
+463,"APROPIAR, AGARRAR, TOMAR, COGER",v.t. Ch’a’
+464,APROVECHAR,"v.i. Ch’alik, makenjal"
+465,APROVECHARSE POR SER BASTANTE,v.t. Chanbil
+466,APROXIMARSE,v.i. Naats’al
+467,"APROXIMAR MUCHO LAS COSAS, ANIMALES O PER",
+468,SONAS,v.t. Naanaak’. APROXIMARSE MUCHO A ALGO O ALGUIEN. v.t.Náanaak’.
+469,APUNTAR PARA TIRAR,v.t. Joltan.
+470,A PUNTO,adv. de t. Ol
+471,A PUNTO DE SUCEDER,adv. de t. Ta’aitak
+472,"APUÑALAR, PUNZAR, HERIR",v.t. Loom
+473,"APUÑETAR, DAR DE PUÑETAZOS, BOX, BOXEAR",v.t. Loox.
+474,APÚRATE,"Expresión léxica verbal. Bajaba, péeksaba, lep’ a wóol, chook’aba, chok’ ti’, péenen."
+475,AQUEL,"adj. Lelo’, le je’elo’."
+476,AQUÍ,"adv. de l. Te’ela’, waye’, weye’, way."
+477,AQUIETARSE,v.i. Toj jal óol
+478,ARAÑA,"sus. Am, le’um"
+479,ARAÑA NEGRA,sus. X boox le’um
+480,ÁRBOL,sus. Che’ ARBUSTO CUYOS FRUTOS SE UTILIZAN PARA PROVOCAR EL HABLA EN LOS INFANTES QUE NO
+481,APRENDEN A HABLAR PRONTO,sus. Sutup
+482,ARBUSTO MELÍFICO DE FLORES AMARILLAS,sus.
+483,ARCO IRIS,sus. Cheel
+484,"ARCO DE EDIFICIO, BÓVEDA","sus. P’um, p’un"
+485,ARCO FALSO,sus. Tuusil p’un.X ma’ jaajil
+486,ARCO DE FLECHA,"sus. Tip’ix, tip’ix che’"
+487,ARCO PARA TIRAR,"sus. Tip’ix, tip’ix che’"
+488,ARCO DE RAMAS,sus. Ts’ulum
+489,ARDER,"v.i. Elel, el"
+490,ARDER ECHANDO LLAMAS,v.i. Jopankil
+491,ARDIENDO CON CALENTURA,"v.i. T’at’abki, táan u jáabal yéetel chokwil. Está ardiendo con calentura, está consumiéndose con calentura."
+492,ARDILLA,"sus. Ku’uk, kunab"
+493,ARENA,"sus. Sam, u lu’umil k’áanab, sinsin."
+494,ARENGADO,adj. P’ujbesaj
+495,ARENGAR,v.t. Awat t’aanil
+496,ARETE,sus. Tuup
+497,ARGAMASA,sus. Pak’ bitun
+498,ARISCO,adj. K’o’ox
+499,ARMADILLO,sus. Weech
+500,ARMADURA DEL CUERPO,sus. Chej baakel
+501,ARMAS,sus. Yeemba.
+502,ARMONÍA DE CANTO,sus. Siinan k’aay
+503,ARMONÍA DE VIDA,sus. Siinan kuxtal
+504,ÁRNICA (TILHONIA DIVERSIFOLIA (HEMSLEY A GRAY),sus. Chak su
+505,AROMA,sus. Ki’ibok
+506,AROMÁTICO,adj. Ki’ibook
+507,ARQUEAR,v.t. P’unik.
+508,"ARRAIGAR, ENRRAIZAR",v.i. Táabal
+509,ARRANCAR,"v.t. Jok, t’ook"
+510,"ARRANCAR, BAJAR FRUTOS Y FLORES",v.t. T’ook.
+511,"ARRANCAR, DESRAIZAR",v.t. Jook
+512,ARRASAR MEDIDA,v.t. Laj ts’ak
+513,ARRASTRAR,"v.t. Jiilt, jíil."
+514,ARRASTRAR ALGO POR EL SUELO,v.t. Bilyaj
+515,ARREAR,"v.t. Aktantaj, jáalbil ch’apaach."
+516,ARREBATAR,"v.t. Jáan páay, took. "
+517,ARREBATAR ALGO,v.t. Tóotóokabi.
+518,ARRECIAR,v.i. K’a’am
+519,ARRECIFE,sus. Chaway
+520,"ARREMANGAR LA FALDA, EL VESTIDO, ETC","v.t. Siil , wol."
+521,ARREMETER,v.t. Kiblaj
+522,ARREMETER CON FURIA,v.t. Pul
+523,ARRIBA,adv. de l. Ka’anal
+524,ARRIERO,sus. J ts’ik tsíimin
+525,ARRIMAR,v.t. Juuts’.
+526,ARRINCONAR,"v.i. Nakkun, ts’aa nak’lik, naak."
+527,"ARRINCONARSE, APOYARSE EN ALGO",v.t. Naktal.
+528,"ARRIMAR, JUNTAR, ACERCAR",v.t. Naak’.
+529,ARROBAMIENTO,sus. Sa’at óol
+530,ARRODILLADO,"adj. Xóolokbal, xóol k’a’taj"
+531,ARRODILLAR,"v.i. Xóolkin, xóol píix"
+532,ARROJADO,adj. Jalanch’inta’ab
+533,"ARROJAR, APEDREAR, ARROJAR, LANZAR, TIRAR","v.t. Ch’iin, puul"
+534,ARROJO,sus. Xet’ óolal
+535,ARROLLAR,"v.t. Kots’, wol."
+536,ARROYO,sus. Beel ja’
+537,ARRUGAR,"v.t. Yuuch’, yaach’ ARRUGADO (PARA ROPA O TELAS) adj. Yáayaach’. ARRUGADO (PARA METALES) adj.Yúuyuuch’"
+538,ARTE,"sus. Its’atil pool, yits’atil"
+539,ASADO,"adj. Póoka’an, k’áak’bil."
+540,ASALTAR,v.t. Ts’am k’ab
+541,ASAMBLEA,sus. Múuch’tsikbalo’
+542,ASADO A FUEGO LENTO,adv. K’aánk’aanchetaj.
+543,ASAR,"v.t. Póok, k’áak’tik, k’áak’."
+544,ASCENDER,v.i. Líik’
+545,ASCETA,sus. Aj ch’abtan
+546,ASEGURAR,v.t. Tem kunaj óol
+547,ASENTADO,"adj. Aka’an, ets’a’an, kuma’an."
+548,ASENTAR,"v.t. Ak kunaj, ets’kúunsaj, t’uchkíinsaj, xéekt"
+549,ASENTARSE,v.i. Ets’tal.
+550,"ASENTARSE, REMOJARSE",v.i. Ts’áamal
+551,ASENTIMIENTO,sus. Éejenil
+552,"ASERRAR, MARCAR, SEÑALAR",v.t. Weel.
+553,ASFIXIAR,v.i. Kupaj.
+554,"ASFIXIA, AHOGO",sus. Ku’upul yiik’.
+555,ASÍ,"adv. de m. Bey, beya’, beyo’"
+556,ASÍ COMO,"conj. comp. Je’ebix, je’ex, je’ebik"
+557,ASÍ ES,adv. de a. Beyistako’
+558,ASIENTO,sus. Xiix.
+559,"ASIENTO, SILLA",sus. Kulxekil
+560,ASIENTO DE PRINCIPALES,sus. Ts’am
+561,ASIMISMO,"adv. Beyxan, bey xan."
+562,ASIR,v.t. Chuk
+563,ASIR CON FUERZA,v.t. Kan mach
+564,ASIR CON LA MANO,v.t. Mach
+565,ASIR CON LOS DIENTES,v.t. Naach’.
+566,ASIR CON LA PUNTA DE LOS DEDOS,v.t. Biit’
+567,ASIR ENGARRAFADO COMO AVE DE RAPIÑA,v.t.
+568,ASIR FUERTEMENTE CON LA MANO,v.t. Kan lap’
+569,ASMA,"sus. Kok se’en, lot’ kok, tusba."
+570,ASOLEAR,v.i.Jaykunaj ti’ k’iin.Lechekbal ti’ Lap’ k’iin.
+571,ASOMAR,v.i. Tíip’.
+572,ASOCIARSE,v.t. Náakultik
+573,ASOLEARSE,v.i. Lechekbal
+574,ÁSPERO,"adj. Pe’ech, to’och"
+575,"ASTILLA, LASCA",sus. Ts’ej.
+576,ASTILLAR,v.t. Ts’ej.
+577,ASTUTO,sus. Aj numan
+578,ASUSTARSE REPENTINAMENTE,v.i. Jáajaak’óol.
+579,ATACAR,"v.t. Kiblaj, ch’a’apachtik,ts’áancha btik"
+580,ATADA,adj. Jep’
+581,ATADO,adj. Jiich’il
+582,ATADO LIGERAMENTE,adj. K’a k’aax
+583,ATADO EN MUCHAS OCASIONES,adv. K’aak’aasjoltaj.
+584,ATADO TODO JUNTO,adj. Mek’ k’aaxa’an
+585,ATALAYA,sus. Ch’uuk beej.
+586,ATAR,v.t. K’aax
+587,"ATAR, ANUDAR, ENGANCHAR",v.t. Jook’.
+588,ATARDECER,sus. Chíinik k’iine’
+589,ATEMORIZAR,v.t. Saajbeskunsik.
+590,ATENCIÓN,sus. Ts’a óolal AUNQUE
+591,ATENDER,"v.t. Táanlaj, táan óoltik."
+592,"ATENDER, ESCUCHAR CON ATENCIÓN",v.t. Ch’e’enxikintej.
+593,"ATESTARSE, LLENARSE DE GENTE UN LUGAR",v.i. Chok’ba.
+594,ATOLE,"sus. Sa’a, sa’"
+595,ATOLE DE MAÍZ NUEVO,"sus. Áak’ sa’a, iis uul."
+596,"ATORADO, TRABADO MUY FUERTE",adj. Kankan
+597,ATORARSE,v.i. Léechel.
+598,ATRAER A LA MUJER CON HALAGOS,v.t. K’ubsaj ki. óol
+599,ATRAGANTAR,"v.i. Jak’ab, ku’uchul"
+600,ATRAPAR,"v.t. Cháach, chuk, laap’ik, laap’, chúuchmachtik."
+601,ATRAPAR,v.t. Léech.
+602,"ATRAPAR CON TRAMPA, CERRAR",v.t. Nuup’.
+603,ATRAPADO CON LA BOCA,adj. Náanaach.
+604,ATRAPADO VARIAS VECES,adj. Chúuchuukab.
+605,ATRÁS,"adv. de l. Paach, paachil.Estoy atrás o detrás : Paachil yaaneen."
+606,ATRAVESAR,"v.t. Maanch’akat, taats’jul, taats’ mansa’ak, k’at."
+607,"ATRAVESAR, CRUZAR",v.t. K’áatal.
+608,ATRAVESADO,adj. K’áak’at.
+609,ATRAVESARSE,v.i. K’áatal.
+610,ATREVERSE,v.t. Xet’ óolal
+611,ATREVIDO,"adj. Aj koo, aj xet’ óol, k’ul ich."
+612,ATROPELLAR,"v.t. Jéentan, náatan, naktáan."
+613,ATURDIDO,adj. Sata’an
+614,AUGURIO,"sus. Tomoj chi’, tomox chi’, tamaxchi’,yáajil."
+615,AULLIDO,sus. Ok’ol chi’ibal.
+616,AUMENTAR,"v.t. Chaybesaj, ya’abkunaj, ya’abkunsaj."
+617,AUMENTARSE,v.i. Chaketjal
+618,AUN,conj. Kex
+619,AÚN NO,"adv. de t. Ma’ to, ma’ili’."
+620,AUNQUE,"conj. advers. Kex, bakakix. Aunque no tengas hambre : Kex min’anteech wi’ij. Kex ma’ wi’ijeechi’."
+621,AUNQUE ESTÉ,Kex ti’aan
+622,AUNQUE NO,conj. advers. Kex ma’
+623,AUNQUE SEA,conj. advers. Kextúun
+624,AUNQUE SEA ESO,Kexelo’.
+625,AUSENTE,"adj. Ma’ kula’an, ma’ kula’ani’"
+626,AUSENCIA,sus. Mana’an.
+627,AUTOMÓVIL,sus. Kiis buuts’
+628,AUTORIDAD,sus. Jo’ol póopil.
+629,AVALANZAR,v.t. Pul
+630,AVARICIA,"sus. Ts’u’util, kok siits’il."
+631,AVARO,"adj. J ts’u’ut, ts’u’ut"
+632,AVENTAR,v.t. Tojlaj
+633,AVENTURA,sus. Mamantats’il
+634,AVENTURERA,adj. X ma’ beelil.
+635,AVENTURERO,"adj. J Ma’ beelil,"
+636,AVERIGUAR,"v.t. Ojelt, ojel"
+637,AVISAR,"v.t. Kuxkinaj óol, num chi’"
+638,AVISPA,sus. Yiik’el xuux.
+639,AVISPA GRANDE AMARILLA Y NEGRA,sus.Xanab
+640,AVISPA NEGRA,sus. Boox xuux.
+641,AVISPA DE LARVA COMESTIBLE,"sus. Ek, cháak. ts’eelem."
+642,AVISPERO,sus. Xuux
+643,AVIVAR EL FUEGO,v.i. Jop
+644,"AXILA, ALA",sus. Xiik’
+645,AYER,"adv. de t. Jo’oljeak, jo’oljej, jo’oljeake’."
+646,AYER AL AMANECER,adv de t. Jatskab joljej.
+647,AYUDA,"sus. áant, mak bo’oy"
+648,AYUDANTE,sus. Aj áantnáal.
+649,AYUDAR,"v.t. Áantik, áantaj."
+650,AYUDAR RECÍPROCAMENTE,v.t. Paklan áantu
+651,AYUNAR,v.i. Su’uk’iin
+652,AYUNTAMIENTO,sus. Mul kaajo’ob
+653,AZOTAR,v.t. Jaats’
+654,AZOTAR CON CINTURÓN O BEJUCO,v.t. Jaats’
+655,AZOTAR CON BEJUCO,v.t. Wíiwiich’
+656,AZOTE DE LA LLUVIA,sus. Jaats’ab ja’
+657,AZÚCAR,"sus. Monkaab, moom, ch’ujuk."
+658,AZUL,"adj., sus. Ch’ooj"
+659,AZUL TURQUESA,"adj., sus. Ya’axka ."
+660,AGUA AZUL TURQUESA,sus. ya’axkaja’.
+661,AZUZAR,"v.t. Tojl, toojol"
+662,BABA,"sus. K’aab chi’, lúul"
+663,BABAZA,sus. Lúul
+664,BÁCULO,sus. Xóolte’
+665,BAGAZO DEL HENEQUÉN,sus. Ta’ kij
+666,BAGRE,"sus. Lu’, booxkaay"
+667,BAHÍA,sus. Wats’ k’áanab.
+668,BAILADOR,adj. Aj óok’ot
+669,BAILADORA,adj. Ix óok’ot
+670,BAILAR,v.i. Óok’ot
+671,BAILE,sus. Óok’ot
+672,BAILE DE LA CABEZA DEL COCHINO,sus. Óok’ostaj pool
+673,BAJAR,"v.i. Éemel, éem"
+674,BAJAR FRUTAS O FLORES,"v.t. T’ook, jéek’, p’iik."
+675,BAJAREQUE,sus. Kolóojche’
+676,BAJO,adj. Kaabal
+677,BALA,sus. U yóol ts’oon
+678,BALANCEARSE,v.i. Ch’uyk’alakil
+679,BALBUCEAR,v.i. Altal yaak’
+680,BALBUCENCIA,sus. Ses
+681,BALBUCIENTE,"adj. Aj ses, nuntal"
+682,"BALDE, CUBETA",sus. Ch’óoy
+683,BALDÍO,adj. X tokoy
+684,BALEAR,v.t. Ts’oon
+685,BALSA PARA PASAR RÍOS,"sus. Poyte che’, payte che’."
+686,BALUARTE,sus. Jil che’
+687,BALLENA,sus. Masam.
+688,BAMBOLEAR,v.i. Takchalak
+689,BAMBOLEO,sus.Nayal kab.
+690,BAMBOLEAR,v.i. Nayal kab.
+691,BAMBOLEAR,v.i. Nayk’alankil.
+692,BANDADA,sus. Piktanil ch’íich’
+693,BANDERA,sus. Láakam.
+694,"BANDERA, PABELLÓN, ESTANDARTE",sus. Pan
+695,"BANQUETA, MUEBLE DE COCINA",sus. Banka’ k’a.
+696,BANQUETE,"sus. Waajil, nonoj ki’ki’ janal"
+697,BANQUILLO,"sus. K’áanche’, kisi che’"
+698,BAÑAR,v.i. Ichkíil
+699,BAÑO,"sus. Ichkíil BAÑO, LUGAR. sus. U kúuchil ichkíil."
+700,BARATO,"adj. Ma’ ko’oji’, junp’íit u tojol"
+701,BARBA,sus. Me’ex
+702,BARBARIE,sus. Tachi’achil
+703,BARBERO,sus. Aj k’oos
+704,BARBILLA,sus. No’och
+705,BARCO,sus. Cheem
+706,BARQUERO,sus. Aj cheemnáal.
+707,BARRANCA,sus. Bekan
+708,BARRANCA OBSCURA,sus. Jom
+709,BARRANCO,"sus. K’om, k’óom"
+710,BARRENAR,v.t. Poot
+711,BARRER,"v.t. Míist, míis"
+712,BARRER SIN ORDEN,v.t. Míimiiste
+713,BARRETA,sus. Xúul máaskab
+714,BARRIDO,adj. Míisa’an
+715,BARRIGA,sus. Nak’
+716,BARRIO DE PUEBLO O CIUDAD,sus. Kuchteel
+717,BARRO,sus. K’at
+718,"BASE, CIMIENTO, TRONCO",sus. Chuun
+719,BASILISCO,sus. Tóolok
+720,"BASINICA, BASÍN",sus. Ch’eeneb iit
+721,BASTANTE,adv. de c. Ya’ab
+722,BASTAR,v.i. Chabiljal
+723,BASTIMENTO,"sus. O’och, janal."
+724,BASTÓN,sus. Xóolte’
+725,BASTÓN PLANTADOR,sus. Xúul
+726,BASURA,"sus. Sojol, ta’ míis."
+727,BATALLA,"sus. Ba’ate’il, k’atunyaj"
+728,BATALLÓN,"sus. K’atun, molay k’atuno’ob"
+729,BATEA,"sus. Panaab, pox che’."
+730,"BATIDA,CLAMOREO, CACERÍA COLECTIVA",sus. P’uuj.
+731,BATIDOR,"sus. Bok’obxut’en, bok’ol"
+732,BATIR,"v.t. Book’ BATIR, AGITAR, REVOLVER LÍQUIDOS, MEZCLA,"
+733,LODO,v.t. Book’.
+734,BATIDO,adj. Bobook’.
+735,BATIR EL CHOCOLATE,v.t. Jaax.
+736,BAUTIZO,sus. Okja’
+737,BEBÉ (NIÑO DE BRAZOS),"sus. Nux, chanpaal, chanba’al"
+738,BEBER,v.i. Uk’ul
+739,BEBER SIN PARAR,v.i. Bits’kal
+740,BEBER A SORBOS,v.i. Xúuch
+741,BEBIDA,sus. Uk’ul
+742,BEBIDA RITUAL,sus. Sakab
+743,BEBIDA FRESCA Y VIRGEN,sus. Sujuy síis óola’
+744,BEBIDA RITUAL FERMENTADA HECHA CON LA COR,"TEZA DE UN ÁRBOL (LONCHOCARPUS VIOLACEUS),"
+745,AGUA Y MIEL,sus. Báalche’
+746,BEJUCO,sus. Aak’
+747,BELLEZA,"sus. Ki’ichpamil (f), ki’ichkelmil (m),"
+748,BENDECIR,"v.t. Kikit’aanta’ak, lóojsiko’ob"
+749,BENDICIÓN,sus. Ki’ki’t’aan
+750,"BENEFICIAR, HACER BIEN, HACER FAVOR","v.t. Meen uts, beet uts."
+751,BEODO,adj. Kala’an
+752,BESAR,v.t. Ts’u’uts’
+753,BESO,sus. Ts’u’uts’
+754,BESTIA,sus. Ba’alche’
+755,BICICLETA,sus. Balak’ t’íinchak ook. Tíinchak balak’ ook.
+756,BIEN,adv. de m. Ma’alob
+757,BIENES O PROPIEDADES,sus. Ba’alba. 
+758,BIENVENIDA,sus. K’aambe’enil.
+759,BIFURCACIÓN,sus. Xa’ay
+760,BIGOTE,"sus. Me’ex, ts’ukuti"
+761,BILIS,sus.K’anchik’íin
+762,BIOGRAFÍA,sus. Siyan
+763,BÍPEDO,sus. J ka’a ts’iit ook
+764,BIZCO,adj. Ts’eeb
+765,BLANCO,"adj. Sak, sasak."
+766,BLANCURA,sus. Sakil
+767,BLANCUZCO,adj. Sakpose’en.
+768,BLANDIR,v.t. Bik’yaj
+769,BLANDO,"adj. Mamayki, o’olki"
+770,BLASFEMIA,sus. Pooch’
+771,BOA (CONSTRICTOR SP),"sus. Ooch kaan, k’axab"
+772,BOBO,adj. Neets.
+773,BOCA,sus. Chi’
+774,BOCA ABIERTA,sus. Jáapal chi’
+775,BOCA ABAJO,"adv. de m. Nokokbaj, nokokbal,"
+776,"BOCA ABAJO, EMBROCARSE",adv. de m. Noktal.
+777,BOCA ARRIBA (ACOSTADO),adv de m. Jawtal. nóonoojkan. jawakbal.
+778,BOCANADA,sus. Pats’baj
+779,"BOCETAR, BOSQUEJAR",v.t. Túunt ts’íibtik
+780,BODA,sus. Ts’o’okol beel
+781,BOFETADA,sus. Laaj.
+782,"BOLAS, POR BOLAS","adv. Wóowool, wóol"
+783,BOLSA,"sus. Pawo’, sáabukan"
+784,BOLSA DEL PANTALÓN,sus. Témil
+785,BONDAD,sus. Utsil
+786,BONITA,"adj. Jats’uts, ki’ichpam."
+787,BONITO,adj. Jats’uts.
+788,BORDADO DE PUNTA DE CRUZ O DE HILO CONTADO,sus. Xookbil chuuy
+789,BORDADO HECHO A MANO,sus. Ts’íib chuuy
+790,BORDAR,v.t. Chuuy.
+791,BORRACHERA,. sus. Káaltal
+792,BORRACHO,adj. Kala’an
+793,BORRADO,adj. Tuupul
+794,BORRAR,v.t. Tuup.
+795,BORREGO,sus. Taman
+796,BOSTEZAR,"v.i. Jaayab, jaaya’."
+797,BOTÓN DE FLOR,sus. Totop’
+798,BÓVEDA,sus.Jobon túun.
+799,BOXEAR,v.t. Loox
+800,BRAVO,"adj. Ts’íik, p’uujul, J ts’íits’ikil."
+801,BRAVURA,"sus. Ts’íikil, p’uujulil."
+802,"BRAMAR, GEMIR, QUEJARSE",v.i. Áakam
+803,"BRAMIDO, GEMIDO, QUEJA",sus. Áakam
+804,BRASA,"sus. Kuxul chúuk, náaxche’ BRASERO O BRASA QUE SE PONE DEBAJO DE LA"
+805,BRASILETE ( CAESALPINIA PLATYLOBO (S WAT,
+806,CAMA,sus. Moj
+807,SON)),sus. Chakte’
+808,BRAVO,adj. Ts’íik
+809,BRAVO,adj. J ts’íits’ikil
+810,BRAZA (MEDIDA DE LONGITUD),sus. Sáap
+811,BRAZO,sus. K’ab BRECHA QUE SE ABRE ALREDEDOR DEL MONTE PARA
+812,FACILITAR SU MEDICIÓN,sus. Jolche’
+813,BRILLAR,"v.i. Jopba, lets’bal, léembal."
+814,BRILLOSO,adj. Ts’íits’iiban.
+815,BRINCAR,"v.i. P’iitik, p’iit, síit’, waransíit’."
+816,BRINCO,"sus. Síit’, p’iit"
+817,BRINDAR,v.t. Chun luch
+818,BRISA DE LA NOCHE,sus. Síiskabil áak’ab. BUSCAR
+819,BROMEAR,"v.i. Tuskep, tuuskeep"
+820,"BROTAR (LOS VEGETALES, LAS AVES)","v.i. Tóop’, tóop’ol."
+821,BROTE,sus. Alamil
+822,BRUJO,"sus. Bal jol, Aj puul yaaj. BRUJO QUE SE CONVIERTE EN MARRANO, CHIVO,"
+823,"TORO, BORREGO",sus. Wáay.
+824,BRUÑIR PLANCHAR,v.t. Yúul.
+825,BRUTO,"adj. Ba’alche’, maknal"
+826,BUCHE,"sus. Tsuuk, chíim."
+827,BUENO,"adj. Uts , ma’alob."
+828,BUEY,sus. J meyjil waakax
+829,BÚHO,"sus. Tunkuluchuj, xooch’"
+830,BULLIR,v.i. Om
+831,BULLIR (MUCHA GENTE),v.i. momolankil
+832,BURBUJA,"sus. P’op’oot, yóom ja’."
+833,"BURBUJEAR, HERVIR","v.i. Óomankil, óo"
+834,BURLA,sus. P’a’as
+835,BURLAR,v.i. P’a’ast
+836,BURRO,sus. Chowak xikin
+837,"BUSCAR, ENCONTRAR","v.t. Kaxan, kaxáan,"
+838,BUSCAR (OLIENDO COMO EL PERRO),"v.i. U’us kaax, xaak’al ni’ktik"
+839,CABALLERO,sus. Ts’uul.
+840,CABALLO,sus. Ts’íimin
+841,CABAÑUELAS,v.i. Xook k’iin
+842,CABECEAR DORMITANDO,sus. Nikib
+843,CABECEAR,"v.i. Bebechtik u pool, t’óont’on pool."
+844,CABECILLA,sus. Jool poop
+845,CABELLO,sus. Tso’ots
+846,CABER,v.i. Chabiljal
+847,CABEZA,"sus. Pool, jo’ol"
+848,CABEZA DE BRUJO,sus. K’ok’ol tsek’.
+849,CABILDO,sus. Mul kaajo’ob
+850,CACAREAR,v.i. Totojk’e’
+851,CACAREO,sus. Totojk’e’.
+852,CACERÍA,"sus. Ts’oon, p’uuj"
+853,CACERÍA COLECTIVA,sus. P’uuj
+854,CACIQUE,sus. Aj beelmal
+855,CADA,prep. Amal
+856,CADA UNO (PARA REFERIRSE A ANIMALES Y PERSONAS),loc pronom. Jujuntúul. Dale un plátano a cada niño :Ts’a jun ts’iit ja’as ti’ junjuntúul paal.
+857,CADA UNO (PARA REFERIRSE A OBJETOS),loc pro
+858,"CADALSO, TEMPLETE",sus. Sak’ che’.
+859,CADÁVER,sus. Aj kiimén
+860,CADENA,"sus. Máaskab suum, jok’enjok’"
+861,CADERA,sus. T’e’et’
+862,CADILLO QUE SE PEGA A LA ROPA,sus. Aj mul
+863,CAER,v.i. Lúubul
+864,"CAER, DESPRENDERSE, DESMORONARSE",v.i. Báa
+865,"CAER, DERRUMBARSE",v.i. Níikil.
+866,CAER DE BRUCES,v.i. Noktal.
+867,CAIDOS,adj. Lúuluuban
+868,CAJA,sus. Máaben
+869,"CAJA DE MUERTO, ATAUD",sus. Máaben kíimen.
+870,CAJA DEL CUERPO,sus. Ba’asil kukut.
+871,CAJETE,sus. Lak
+872,CAL,sus. Ta’an
+873,CALABAZA (CURCUBITA PEPO C ARGYROSPERMA (CUR,
+874,CUBITA SPP)),sus. K’úum
+875,CALABAZA BLANCA DE PEPITA GRUESA,"sus. X ka’, x tóop’. Chúuj ."
+876,CALABAZO (LAGENARIA SICERARIA (STANDLEY)),sus. CALABAZO PARA LLEVAR SEMILLAS DURANTE LA
+877,SIEMBRA,sus. Joma’
+878,CALAMBRES,sus.X lot’kej iik’
+879,CALANDRIA,sus. Jon xa’an.
+880,"CALAVERA, CRÁNEO",sus. Tséek’
+881,CALCAÑAR,"sus. Kuuy, tuunkuy"
+882,CALCINANTE,adj.Ku ta’anbesik
+883,CÁLCULO RENAL,sus. K’aal wiix.
+884,CALDO,sus. K’aab
+885,CALDO DE COMIDA,sus. K’aab janal.
+886,CALENTARSE CON EL SOL O JUNTO A LA BRASA,v.i. K’iich.
+887,"CALENTAR, ENTIBIAR",v.t. K’íin
+888,CALENTURA,"sus. Chakawil, Chokwil"
+889,CALIENTE,"adj. Chokoj, k’inal"
+890,CALMA EN EL MAR,sus. Leman
+891,CALMAR,v.t. Mal
+892,"CALMARSE, AQUIETARSE",v.i. Jets’tal.
+893,CALOR,sus. Ooxoj CALOR O VAPOR NOCIVO QUE SALE DE LAS TIERRAS
+894,DELGADAS O DE RAÍCES DE ÁRBOLES PODRIDOS,sus. Buy
+895,CALUMNIA,sus. Líilsaj t’aan.
+896,CALVARIO,sus. Kuuch numya.
+897,CALZADO,"sus. Xanab, xana’."
+898,CALZÓN,sus. Eex
+899,CALZONCILLO,sus. Kul eex
+900,CALLAR,v.i. Mak chi’. ¡Cállate! ¡Mak a chi’!
+901,CALLE,sus. Yam kaaj.
+902,CALLO,sus. T’aajam
+903,CAMA,"sus. Ch’áak, ch’áakche’"
+904,CAMADA,sus. Pakab
+905,CÁMARA FOTOGRÁFICA,sus. Nu’ukul ch’a’
+906,"CAMBIAR, TROCAR","v.t. Jeel, k’ex, k’eex."
+907,"CAMBIADO, MUY CAMBIADO",adv. de m. oochel K’éexk’eex.
+908,CAMINANTE,sus. Aj xíinbal
+909,CAMINAR,v.i. Xíinbal
+910,CAMINO,"sus. Bej, beel, belil"
+911,CAMINO QUE SE BIFURCA,Sus. Xa’ay bej.
+912,CAMISA,sus. Búuk.
+913,CAMOTE ( IPOMOEA BATATAS),sus. Iis.
+914,"CAMPAMOCHA , MANTIS, CABALLITO DEL DIABLO",sus. Ts’awayak
+915,CAMPANA,sus. Balamte máaskab
+916,CAMPAÑA,sus.Xíinbalil k’atunyaj
+917,CAMPESINO,"sus. J koolnáal, j koolkaab, j me"
+918,CAMPO,sus. K’áax. CANASTA TEJIDA CON BEJUCOS QUE SE UTILIZA EN
+919,LA COSECHA,sus. Xuxak
+920,CANCIÓN,sus. K’aay
+921,CANDADO,sus.K’aalab máaskab.
+922,CANDENTE,adj. Chakjole’en
+923,CANÍCULA,sus. Kin pek
+924,CANOA,sus. Cheem
+925,CANSAR,"v.i. Ka’anal, ka’anan"
+926,"CANTANTE, CANTOR","sus. Aj k’aay, ix k’aay."
+927,CANTAR,v.i. K’aay CARGAR
+928,CÁNTARO,sus. P’úul
+929,CANTIDAD,sus. Buka’aj.
+930,CANTIDAD CONCRETA,adv. de c. Tusinil
+931,CANTO,sus. K’aay.
+932,CANTO CÓMICO,sus. P’a’ast’aan k’aay
+933,CAÑA ÁSPERA,sus. Semet’
+934,CAÑA DE MAÍZ (MILPA DEL SEGUNDO AÑO EN ADE,
+935,LANTE),sus. Sak’ab
+936,CAÑA O TALLO DEL MAÍZ Y DE LA CAÑA DE AZÚCAR,sus. Sak’ab
+937,CAÑOTO (ARUNDO DONAX L),sus. Jalal
+938,CAOBA (SWIETENIA MACROPHYLLA (G KING)),"sus. Punab, ka’awakche’."
+939,CAOS,"sus. Xa’ak’, xa’ak’il."
+940,"CAPA, CAPOTE",sus. Suyen.
+941,"CAPACITAR, ENSEÑAR","v.t. Ka’anbesaj, ka’ansaj."
+942,"CAPITAL, DINERO",sus. Táak’in.¿Cuánto capital tienes? ¿Buka’aj táak’in yaanteech?
+943,CAPITANEAR,v.t. Jool poopintaj
+944,CAPTURAR,"v.t. Chukik, chukpachtik"
+945,"CARA, ROSTRO","sus. Ich, tán ich. CARACOL COMESTIBLE QUE VIVE EN LA ORILLA DE"
+946,LAGOS Y CENOTES,sus. K’awa
+947,CARACOL DE AGUA,sus. T’ot’
+948,CARACOL DE LOS JARDINES,sus. Úurich
+949,CARACOL MARINO,sus. Jub
+950,"CARACOL, ESPECIE QUE SE DA EN COZUMEL",sus.
+951,CARAPACHO,sus. Sóol
+952,CARBÓN,sus. Chúuk
+953,CARBONERO,sus. J tok chúuk
+954,CARCAJADA,sus. Awat che’ej
+955,CÁRCEL,"sus. K’aalab che’, t máaskab, k’aalab máaskab"
+956,CARCOMA DE LA SARNA,sus. Bibikankil
+957,CARDENAL,sus. Chak ts’íits’ib
+958,CARECER,"v.i. Mana’an, mina’an, sáap’al."
+959,CARGA,sus. Kuuch
+960,CARGADOR,"sus. Aj kuuch, j kuuch."
+961,CARGAR,v.t. Kuuch
+962,CARGA QUE SE LLEVA EN LA ESPALDA,sus. Kuuch
+963,CARGAR EN LA ESPALDA,v.t. Kuuch
+964,CARGAR EN LACABEZA,v.t. K’óoch.
+965,CARGAR EN EL HOMBRO,v.t. Paaj kuuchtaj
+966,CARGAR A HORCAJADAS,v.t. Jéets’ méek’.
+967,CARGAR COLGANDO,v.t. Ch’úuy.
+968,CARICIA,sus. Baay
+969,CARIDAD Y MERCED QUE SE RECIBE,sus. Yatsil
+970,CARNE,sus. Bak’
+971,CARNE HORNEADA EN LA TIERRA,sus. Píib
+972,CARNICERÍA,sus. U kúuchil kóon bak’.
+973,CARNICERO,sus. J kóon bak’
+974,CARO,adj. Ko’oj
+975,CARPINTERO,"sus. J póol che’, j xoot che’."
+976,CARRASPERA,sus. Sasak’ kaal
+977,CARRETA,"sus. Tsíimin che’, peten che’, suut che’"
+978,CARRETERA,sus. Noj beej.
+979,CARRETERA PETROLIZADA,sus. Yuyul beej.
+980,"CARRILLO, POLEA",sus. Balak’
+981,CARRIZO,"sus. Jalal, siit"
+982,CARTA,"sus. K’uben t’aan, túuxtaj t’aan, chi’t’aan, ts’íibil ju’un."
+983,CASA,"sus. Naaj, otoch, taanaaj, nay."
+984,CASA RÚSTICA QUE SE HACE EN LA MILPA PARA RE,K’uche’
+985,FUGIO,sus. Pasel.
+986,CASADO,adj. Ts’o’oka’an u beel
+987,CASA REAL,sus. Tepalil
+988,CASAMIENTO,sus. Ts’o’sklabeel
+989,CASCABEL DE LA VÍBORA,sus. Tsáab
+990,CASCAR,"v.t. Buuj, tej"
+991,CASCAR Y ROMPER SU CASCARÓN EL POLLITO,v.t. Ts’ej
+992,CÁSCARA,sus. Sóol
+993,CASCO DE CABALLO,sus. May
+994,CASI,adv de m.
+995,CASINO,sus. Naajil buul.
+996,CASPA,sus. Chab.
+997,"CASPA, ROÑA",sus. Sóok’.
+998,CASTA,sus. Ch’i’ibal.
+999,CATELLANO,sus. Kastlan t’aan.
+1000,CASTIDAD,sus. Okol k’u
+1001,CASTIGAR CON RIGOR,"v.t. Yaya ts’ektaj  t’aan, kastelan"
+1002,CASTIGO,"sus. Xoot óol, bo’olal, nolche’."
+1003,CASTIGADO,sus Aj mak pachtaj.
+1004,CASTILLO,"sus. Pa’, tulum"
+1005,CASTRAR,v.t. Pets’ toon
+1006,CATARATAS,sus. Sak t’aj
+1007,CATARRO,sus. Se’en
+1008,CATÁSTROFE,sus. Kal numya
+1009,CATORCE,sus. Kanlajun
+1010,"CAUDAL, RIQUEZA",sus. Ayik’alil
+1011,CAUDILLO,sus. Jo’ol poopi’
+1012,CAUSA,"sus. Chuun, uchbal"
+1013,CAUSA DE RUINA,sus. Naak’an óotsilil.
+1014,CAUTELOSO,adj. Aj na’at ach
+1015,CAUTERIZAR,v.t. Chuuchuujik
+1016,CAUTIVO,"sus. Baksaj, kuuch chimal"
+1017,CAVAR,v.t. Páan.
+1018,CAVERNA,"sus. Áaktun, jom áaktun"
+1019,"CAVIDAD, FOSO",sus. Bekan
+1020,CAZADOR,sus.J ts’oonnáal.
+1021,CAZAR,v.t. Ts’oon.
+1022,CEBOLLA (ALLIUM CEPA L),sus. Kukut
+1023,CEDRO (CEDRELA MEXICANA (M ROEMER)),sus.
+1024,"CÉFIRO, VIENTO SUAVE",sus. Juyuknak iik’ CEIBA (CEIBA PENTANDRA (L. GAERTH)) .
+1025,CEJA,sus. Mo’ojtun
+1026,"CELDA, CUARTO",sus. Tunk’as
+1027,CELEBRACIÓN,sus. K’iinbesaj
+1028,CÉLEBRE,adj. Tsikbe’en.
+1029,CELO,sus. Noj yail.
+1030,CELOSA,adj. Ix sawinil.
+1031,CELOSO,adj. Aj sawinil.
+1032,CELOSÍA,"sus. Selesum, tsats tun"
+1033,CEMENTERIO,"sus. Sujuy lu’um, tan múuknal, kúuchil múuknalo’ob, x kojolte’"
+1034,CENA,sus. Áak’ab janal
+1035,CENAGAL,sus. Ts’aats’
+1036,CENIT,sus. Chúumuk ka’an
+1037,CENIZA,sus. Ta’an
+1038,CENOTE,sus. Ts’ono’ot
+1039,CENTINELA,"sus. Aj ch’a’a beej. Aj pikit be, Aj"
+1040,CERRAR LA LA BOCA,v.i.Nuup’ a chi’.Maak a CINTURA naajil toj óolali’.
+1041,CERRO,"sus. Buk’tun, múul, pu’uk, wiits,"
+1042,CENTRO,"sus. Chúumuk, ts’u’."
+1043,CENTRO DE LA POBLACIÓN,sus. Chúumuk kaaj.
+1044,CENTRO DE LA POBLACIÓN,sus. K’íiwik
+1045,CENTRO DE SALUD,"sus. U najil ts’aak yaaj, u"
+1046,CENZONTLE,sus. Sak chiik
+1047,CEÑIRSE,v.i. Jíich’il
+1048,CEPILLAR PARA QUITAR EL POLVO,v.t.Púus.
+1049,CEPILLAR MADERA,"v.t. Jo’och, súus."
+1050,CEPILLAR LOS DIENTES,v.t. Ja’koj.
+1051,CERA,sus. Kib
+1052,CERA MUY PEGAJOSA,sus. Lolok
+1053,CERA VIRGEN,sus. Sujuy chaalij yik’el kaab.
+1054,CERCA,"adv. de l. Naak’, naats’"
+1055,CERCA DE LA MILPA,sus. Nok ch’áak
+1056,CERCAR,v.t. Bak’ paach
+1057,"CERCAR CON PALOS, RAMAS O ÁRBOLES SEMICORTA",
+1058,DOS,v.t. Suup’.
+1059,CERCENAR,v.t. K’up.
+1060,"CERCENAR, CORTAR DE RAÍZ, EMPAREJAR",v.t. Muus.
+1061,CERDO,sus. K’éek’en
+1062,CEREBELO,sus.X tuchts’o’om.
+1063,CEREBRO,sus. Ts’om
+1064,CEREMONIA AGRARIA PARA IMPLORAR LLUVIA,sus. Ch’a’ cháak CEREMONIA EN QUE SE CARGA POR PRIMERA VEZ
+1065,A HORCAJADAS SOBRE LA CADERA A UN NIÑO,sus. Jéets’ méek’
+1066,CEREMONIA PARA BENDECIR EL CORRAL,sus. Loj k’aalche’ wakax.
+1067,CERILLO,sus. Jiri’ich joop
+1068,CERNIR ENTRE LOS DEDOS,"v.t. Xíit, xíixt"
+1069,"CERNIR, COLAR",v.t. Máay.
+1070,"CERRAR, ENCERRAR, ENJAULAR","v.t K’aal, k’aalik,"
+1071,CERRAR LA PUERTA,v.t. K’aal le joonaj.
+1072,CERRAR EL PASO,v.t. Mak beej
+1073,CERRAR LOS OJOS,"v.i. Muuts’ a wicho’ob, ch’oot. muuts’."
+1074,CERRAR EL CAMINO,v.t. Nuuts le bejo’.
+1075,CERRAR LA OLLA,v.t.Maak le kuumo’.
+1076,CERRAR UN CANDADO O CERRADURA,v.t. chi’. Ch’óotol. mulu’uch.
+1077,CERVIZ,sus. Kulkaal
+1078,CESAR,"v.t. Jáaw, jáawal"
+1079,CESTA,"sus. Xáak, xúuxak"
+1080,CESTO,"sus. Xáak, xúuxak"
+1081,CICATERO,adj. J ts’u’ut
+1082,CICATRIZ,"sus.Chakax, cheek"
+1083,"CÍCLICO, SERIE",adj. Wuts’
+1084,CICLÓN,"sus. Chak íik’, molay íik’"
+1085,CIEGO DE CATARATA,"sus. Aj buy. CIEGO QUE TIENE LOS OJOS CLAROS, MAS NO VE CON"
+1086,ELLOS,sus. Éek’ may
+1087,CIELO,sus. Ka’an. CIELO AMARILLENTO QUE TRAE LLUVIA CALIENTE
+1088,QUE CAE EN AGOSTO Y QUEMA LOS CULTIVOS,sus. K’ank’ubul
+1089,CIEN,sus. Jo’o k’aal
+1090,CIÉNAGA JUNTO AL MAR,sus. Uk’um
+1091,CIGARRA QUE CANTA DE NOCHE Y ANUNCIA LLUVIA,"sus. Ch’och’elem, ch’och’lin."
+1092,CIGARRA QUE CANTA DE DÍA Y ANUNCIA SEQUÍA,sus.Ts’ay k’iin.
+1093,CIGARRO,sus. Chamal
+1094,CIERTO,adv. de afirmación. Jaaj
+1095,CIMENTAR,v.t. Ak kunaj
+1096,CIMIENTO,"sus. Tsek, buk’tun, chuun."
+1097,CINCO,sus. Jo’o. Cinco mujeres : Jo’otúul : Jo’op’éel ko’olelo’ob. Cinco piedras tuunicho’ob. Cinco velas : Jo’o ts’iit kibo’ob. Cinco árboles de ceiba : Jo’o kúul ya’axche’ob.
+1098,CINCUENTA,sus. Lajun p’éel ti’ óox k’aal
+1099,CINEMATÓGRAFO,sus. Péeksoochelsáasil
+1100,CINTA,sus. K’aax
+1101,CINTILAR,"v.i. Jopba, lets’bal"
+1102,CINTURA,sus. Ui’it’il
+1103,CINTURÓN,sus. K’aax nak’
+1104,CÍRCULO,"sus. Ba’al wóolis, pet."
+1105,CIRCUNCISIÓN,"sus. Suy k’up, Suy k’upil (CORDIA DODECANDRA D.C.)."
+1106,CIRUELA ( SPONDIAS MOMBIN L (SPONDIA LUTEA)),K’óopte’ sus. Abal
+1107,"CIRUELA SECA AL ASOLEARSE, UTILIZADA PARA HA",
+1108,CER DULCE QUE SE OFRENDA A LOS DIFUNTOS,sus. K’ulin.
+1109,CISTERNA HECHA POR LOS MAYAS PREHISPÁNICOS,
+1110,CIUDAD,sus. Noj kaaj.
+1111,CIZAÑA,"sus. A’al t’aan , líik’saj t’aan, a’alaj sus. Chultun ba’al."
+1112,CIZAÑERO,"adj. J a’al t’aan, j líik’saj t’aan."
+1113,CLARABOYA,sus. Kisneb
+1114,CLARIDAD,sus. Sáas
+1115,CLARÍN,"sus. Jom CLARINERO, DIVES DIVES (LICHTENSTEIN)TORDO"
+1116,NEGRO CANTADOR,sus. Aj pich’
+1117,CLAROSCURO,sus. Sáasbal kaab.
+1118,CLARO QUE SÍ,adv. de a. Binmaake’
+1119,"CLASE, SESIÓN DE TRABAJO ESCOLAR",sus. Xook CLAVADAS O HINCADAS LAS PUNTAS COMO FLECHAS
+1120,"O ESPINAS, COSA FUNDADA Y ASENTADA",adj. Ch’ika’an
+1121,CLAVAR,"v.t. Baj, ts’oop."
+1122,CLAVARSE,v.i. Ts’oop.
+1123,"CLAVAR, SEMBRAR, PRENDER",v.t. Ch’iik.
+1124,CLAVAR VARIAS VECES ALGO,v.t. Ba’abaje’.
+1125,CLAVARSE DE PUNTA,v.i. Ch’iikil
+1126,CLAVÍCULA,sus. J nutsp’ep’o’ob.
+1127,CLAVO,sus. Xolob COA (INSTRUMENTO CORTANTE DE HIERRO CON FORMA
+1128,"CURVA Y MANGO DE MADERA, SIRVE PARA DESYER",
+1129,BAR),"sus. Lóobche’, loo’che"
+1130,COAGULAR,v.i Olmal
+1131,COBARDE,"adj. J sajlu’um, oyonta’achil."
+1132,"COBERTOR, COBIJA",sus. Teep’
+1133,"COBIJAR, TAPAR, CUBRIR,",v.t. Teep’
+1134,COCER,v.i. Tajal 
+1135,"COCERSE, SAZONAR",v.i. Tak’al.
+1136,COCIDO,adj. Tak’an
+1137,COCINA,sus. K’óoben
+1138,COCINERA,sus. Ix meen janal.
+1139,COCINERO,sus. Aj meen janal
+1140,"COCHINO, MARRANO, CERDO",sus. K’éek’en.
+1141,COCOYOL (ACRONOMIA MEXICANA (KARW)),sus. Tuk’
+1142,CODO,sus. Kúuk
+1143,CODORNIZ,sus. Beech’
+1144,COGER,v.t. Ch’a’b
+1145,COGOLLO,"sus. Yol, wii’"
+1146,"COGOTE, PARTE SUPERIOR Y POSTERIOR DEL CUE",LLO. – sus. Paachka’
+1147,"COHETE, VOLADOR",sus. Eelnak báaxal.
+1148,COITO,"sus. Ts’iis, paklam, taal, toop, naach’"
+1149,COLA,sus. Nej. COLA NEGRA (OFIDIO DE GRAN TAMAÑO QUE DEVORA
+1150,A OTRAS SERPIENTES MAYORES QUE ELLA SE LE CO,
+1151,NOCE COMO LA REINA DE LAS SERPIENTES),sus. Éek’uneil
+1152,COLABORAR,v.t. Áantaj.
+1153,COLABORADOR,sus. Aj áantaj.
+1154,COLADOR,sus. Cháachab
+1155,COLAR,v.t. Máay.
+1156,COLGAR,"v.t. Ch’úuykins, ch’úuykint."
+1157,"COLGAR, TRABAR",v.t. Leech.
+1158,COLGARSE,v.i. Lechtal.
+1159,"COLGADO, HOLGADO",adj. Pojpoj.
+1160,COLGADO DE ALGO VARIAS VECES,adj.Léele’ech.
+1161,COLIBRÍ,sus. Ts’unu’un
+1162,COLILLA DE CIGARRO,sus. Xotem
+1163,COLMENA,sus.U naajil kaab.
+1164,COLMILLO,sus. Ts’a’ay
+1165,"COLOCAR, PONER","v.t. Ts’aa, ts’áaj, ts’ik."
+1166,COLOR,"Lágab, boon."
+1167,COLOR DE FUEGO IGNEO,adj. Chakjole’en
+1168,COLUMNA DE CONSTRUCCIÓN,"sus. Okom tuun, okom tuunich."
+1169,"COLUMNA , FILA, LÍNEA","sus.T’o’ol, t’o’olol."
+1170,COMADREJA,sus. Sáabin
+1171,COMAL,sus. Xamach
+1172,COMARCA,"sus. Kuchkabal, petén"
+1173,COMBATE,sus. K’atunyaj
+1174,COMBATIR,"v.t. Ba’ate’el, p’is, p’isba"
+1175,COMEJÉN,sus. K’amas
+1176,COMELÓN,sus. Aj báamban janal
+1177,COMENTAR,v.t.Tsikbal.
+1178,"COMENTARIO, NOTICIA",sus.Péeksil.
+1179,COMENZAR,"v.t. Chumbesik, chuna’an, chunbesaj, chúunpajal, jop’, jo’op’ol, káa"
+1180,COMENZAR ALGÚN TRABAJO,"v.t. Xip, chunsej."
+1181,COMENZAR EL ÁRBOL A CARGARSE DE FRUTOS,v.i. Chojba
+1182,COMER,v.i. Janal.
+1183,COMER A MORDISCOS,v.i. Níich’.
+1184,COMER SIN ÁNIMO,v.i.Nées.
+1185,"COMER SIN MASTICAR, COMER APRESURADAMEN",
+1186,TE,v.i. Maak’
+1187,COMER GRANOS SECOS,v.t. K’uux.
+1188,COMER A CADA RATO,v.t.Báamban janal.
+1189,COMERCIANTE,"sus. Aj p’olom, j kóonol"
+1190,COMERCIO,sus. P’olmal
+1191,COMETA,sus. Buts’ eek’
+1192,COMEZÓN,"sus. Saak’, saak’il."
+1193,"COMEZÓN, MUCHA COMEZÓN",sus. Sa’asaak’
+1194,COMIDA,"sus. O’och, janal, janaj, janalbe’en."
+1195,COMIENZO,sus. Chúusa’al
+1196,CÓMO ES,pron. rel. Bixi
+1197,COMO,adv. de m. Bey
+1198,COMO,conj. comp. Bix
+1199,COMPADRE,sus. Et yuum
+1200,COMPAÑERO,"sus. Etóol, nuup, nuupul, éet, batsil."
+1201,COMPAÑÍA,sus. Láak’ankil
+1202,COMPARACIÓN,sus. Etjun t’aan
+1203,COMPARAR,"v.t. Ketbesik, etjun t’aan."
+1204,COMPARECER,v.i. Suukab
+1205,COMPARTIR,v.t.Páay óoltik
+1206,COMPASIÓN,"sus. Ok’ol ich, ch’a’ óotsilil"
+1207,COMPATRIOTA,sus. Et kaajal
+1208,COMPLETAR,"v.t. Chukbes, chúukbesaj"
+1209,COMPLETO,"adv. de c. Chúuka’an, páanche’, pak lis CINFORTAR"
+1210,COMPONER,"v.t. Utskíinsik, utskins."
+1211,COMPRAR,v.t. Maan
+1212,COMPRENDER,v.i. Na’at.
+1213,COMPROBAR,v.t. Táan óolte.
+1214,COMUNICAR,v.t. A’al.
+1215,COMUNIDAD,sus.Kaaj.
+1216,CON,conj. cop. Yéetel
+1217,CON,prep. Ti’
+1218,CON BUENA VOLUNTAD,adv. de m. Ki’ki’
+1219,CONCLUIR,"v.t.Ts’o’okol, ts’o’oksaj."
+1220,CONCUBINA,sus. Weey
+1221,CON DIFICULTAD,adv. de m. Istikia
+1222,CONDIMENTO,sus. Xa’ak’.
+1223,CONFIANZA,"sus. Jets’ óol, ts’aa óol."
+1224,CON FLUJO SUAVE LAS AGUAS,adv de m. Yiyibki
+1225,CON FRECUENCIA,adv. de t. Bukyaj
+1226,CON PERFECCIÓN,adv. de m. Ki’ki’
+1227,"CON, EN COMPAÑÍA",adv. de m. Wéet
+1228,CONCEDER,v.t. Silk’a
+1229,CONCERTACIÓN,sus. Ts’a t’aantanba.
+1230,"CONCERTAR,, TOMAR ACUERDO","v.t. Ak kunaj, Ch’a’ t’aanil."
+1231,CONCERTAR EL PRECIO,v.t. Chimtaj
+1232,CONCERTARSE,v.t. K’aax t’aan
+1233,CONCLUIR,"v.t. Jáawal, jaw, jepajal óol"
+1234,CONCORDAR,v.t. Ketbesaj
+1235,CONCHA DE MAR,sus. Xixim
+1236,CONDENA,sus. Yaya xoot k’iinil
+1237,CONDENACIÓN,sus. Yaya xoot k’iinil
+1238,CONDENADO,sus. Aj bo’ol k’eban
+1239,CONDENAR,v.t. Yaya tse’ ktaj
+1240,CONDIMENTOS,sus. Xa’ak’
+1241,CONEJA,sus. Ch’úupul t’u’ul
+1242,CONEJO,sus. Xiibil t’u’ul
+1243,CONFEDERARSE,v.t. K’aax t’aan
+1244,CONFESAR,"v.t. A’al k’eban, p’aa chi’"
+1245,CONFIANZA,sus. Alab óol
+1246,CONFIAR,v.t. Alab óoltaj
+1247,CONFIAR EN OTRO,v.t. Alkunaj óol
+1248,CONFIDENTE,sus. Nup t’aan
+1249,CONFIRMAR,v.t. Jaajkuntik
+1250,CONFORTAR,v.t. Kuxkintaj óol
+1251,CONFUNDIR,v.t. Lam.
+1252,CONFUNDIRSE,v.i. Lamal.
+1253,"CONFUSIÓN, DESCONCIERTO",sus. Jub t’aan
+1254,CONGREGARSE,v.i. Bantal
+1255,CONGRUENCIA,sus. Najil
+1256,"CONJUNTO,EJÉRCITO, REBAÑO, ENJAMBRE","sus. Molkab, Molkabil."
+1257,"CONJURO, HECHIZO, ENCANTAMIENTO",sus. Ku
+1258,CONCIENCIA,sus.Sajak puksi’ik’il
+1259,CONMIGO,pron. Tin wéetele’
+1260,CONO,sus. Wóolis p’ich
+1261,CONOCER,"v.t. K’a óol, k’ajóol, ojelt, ojel"
+1262,CONOCIMIENTO,"sus. K’aj óolal, k’ajóolo, yits’atil."
+1263,COMPLACENCIA,sus. Núukbesaj.
+1264,CON QUE,prep. Likil
+1265,CONQUISTA,sus. Baksajil.
+1266,CONSAGRADO,adj. K’uyenkunsa’ab
+1267,CONSAGRAR,v.t. K’uyenkunsaj
+1268,CONSEJERO,sus. Aj otlom kabal
+1269,CONSEJO,"sus. A’almajxikin, molay aj kano’ob"
+1270,CONSIDERACIÓN,sus. Tumut
+1271,CONSIDERAR,v.i. Mana óol
+1272,CONSIDERAR,v.t. Nen óol
+1273,CONSOLAR,"v.t. Baytaj, kuxkintaj óol"
+1274,CONSOLARSE,v.i. Toj jal óol
+1275,CONSOLIDAR,v.t. Táak muk’ pajak
+1276,CONSTANTE,adj. K’uchpaja’an yóol
+1277,CONSTANTEMENTE,adv. de t. Jun tiich’
+1278,CONSTELACIÓN,sus. Tsool eek’o’ob CONSTELACIÓN DE TRES ESTRELLAS QUE ESTÁN EN
+1279,EL SIGNO GÉMINIS,sus. Áak eek’
+1280,CONSTRUIR,"v.t. Meent, beet."
+1281,CONSUEGRO,sus. Jachil
+1282,CONSULTAR,v.t. K’áat chi’.
+1283,CONTAGIO,"sus. Taak’, paak’."
+1284,CONTAGIOSO,adj. Paak’be’en.
+1285,CONTAR CUENTOS,v.t. Tsikbal.
+1286,CONTAR,v.t. Bak’ xook.
+1287,CONTAR MENTIRAS O CHISMES,v.t. Líik’saj t’aan 
+1288,CONTAR NÚMEROS,v.t. Xook.
+1289,CONTEMPLAR,"v.t. Cha’ant, nen óol"
+1290,CONTENER ALGUNA COSA,v.t. Balinaj
+1291,CONTENTO,"sus. Ki’ ki’ óolal, ki’imak óol."
+1292,CONTERRÁNEO,sus. Et kaajal
+1293,CONTESTAR,"v.t. Núuk, núuk t’aan."
+1294,CONTESTAR MAL,v.t. Núunuuka.
+1295,CONTESTACIÓN,sus. Núukbesaj.
+1296,CONTIENDA,sus. Ok yail
+1297,CONTIGO,"pron. Ta wéetel, ta wéeteli’."
+1298,CONTINUAR,"v.i. Bayjal, bayli’"
+1299,CONTINUARSE,v.i. Malel k’iin
+1300,CONTRA,"prep. Ta wok’ol, tu nup"
+1301,CONTRACCIÓN,sus. Motsa’anil.
+1302,CONTRACORRIENTE,adv. Tu nup nix.
+1303,CONTRALUZ,sus. Nup sáasil.
+1304,CONTROLAR,v.t. Pets’
+1305,CONVENIENTE,adj. Yalpak’a
+1306,CONVENCIDO,adj. Oyan óol.
+1307,CONVERSACIÓN,sus. Tsikbalile’
+1308,CONVERSAR,v.t. Tsikbal
+1309,CONVICTO,adj. Oksaja’an óol ti’
+1310,CONVIDAR,v.t. Chaybesaj
+1311,CONVOCAR,"v.t. Tsabaj, molaj, t’aanaj"
+1312,CÓNYUGE,sus. De la mujer : íicham ; del hombre : atan.
+1313,COORDINACIÓN,sus. Tsool
+1314,COPAL (PROTIUM COPAL (ENGL)),sus. Pom
+1315,COPETE,sus. P’oot.
+1316,COPIAR LO ESCRITO,"v.t. Joch, ts’íib, ka’a ts’íib."
+1317,COQUETA,adj. X ken k’oj
+1318,CORAJE,"sus. Lep’ óol, lep’óolal"
+1319,CORAZÓN,sus. Puksi’ik’al
+1320,CORDILLERA,sus. Bolon wits
+1321,CORMORÁN,sus. Bich’
+1322,CORNEAR,v. K’óoch
+1323,CORNETA,sus. Jom
+1324,CORNIZUELO ( ACACIA CORNIGA (WILLD)),sus. Su
+1325,CORO,sus.Múuch’ k’aay.
+1326,CORONA,"sus. K’aax jo’ol, nak, pet jo’ol"
+1327,CORONA DE CLÉRIGO,sus. Pet
+1328,CORONILLA,sus. Suy jo’ol
+1329,COROZO (ATTALEA COHUNE (MART),"sus. Ch’unkuy, muklil"
+1330,"COSA CLARA, MANIFIESTA, PATENTE",sus. Ma’ mop
+1331,CORPIÑO,sus.Láat’ab iimo’ob
+1332,CORRAL,sus. Pak’ tuunil wakax
+1333,CORRECCIÓN,sus. Xoot óol
+1334,CORRECTAMENTE,Adv de m. Tu beel.
+1335,CORREO,sus. Mukul tuchiil ts’íib
+1336,CORREOSO,adj. Ts’u’uy
+1337,CORRER,v.i. Áalkab
+1338,"CORRESPONDE, SER DE SU INCUMBENCIA",sus. Lay
+1339,"COSA COLMADA, QUE POR ESTAR MUY LLENA SE DE",
+1340,RRAMA,sus. Tutul nak
+1341,COSA CONCERTADA,"adj. Keta’an, ketbesaj."
+1342,COSA CURVA Y VUELTA COMO GARFIO,sus. Pakax ye
+1343,COSA DADA A DIOS Y CONSAGRADA,sus. K’uya’an
+1344,COSA DIBUJADA,sus. Ts’íiben ts’íib
+1345,COSA DIFÍCIL,"sus. Talam, toop."
+1346,COSA DIGNA DE SER CONSIDERADA,sus. u t’aanul. Lumtabe’en.
+1347,CORRIDA DE TOROS,sus. Paywakaxil
+1348,CORRILLO,sus. Múuch tsil
+1349,CORTAR CON CUCHILLO O SERRUCHO,v.t. Xoot
+1350,"CORTAR, DIVIDIR, PARTIR",v.t. Xoot’.
+1351,CORTAR CON GOLPE DE HACHA O MACHETE,v.t. Ch’áak Ch’áach’áak. Ch’áach’áakbil
+1352,CORTAR EN PEDAZOS CON HACHA O MACHETE,v.t.
+1353,CORTADO EN PEDAZOS CON HACHA O MACHETE,adj.
+1354,CORTAR CON TIJERAS,v.t. K’oos.
+1355,CORTAR O MAL CORTAR REPETIDAMENTE CON TIJE,
+1356,RAS,v.t. K’óok’oos.
+1357,CORTE DE CAÑA DE AZÚCAR,v.t. Paak sak’ab.
+1358,CORTÉS,adj. Uts
+1359,CORTESÍA HECHA INCLINANDO LA CABEZA,sus. Chíin pool
+1360,"CORCHAR, HILAR",v.t. Jaax.
+1361,CORTEZA,sus. Sóol
+1362,CORTO,adj. Kóom
+1363,CORVA DE HIERRO,sus. Loch máaskab
+1364,CORVA DE MADERA,sus. Loch che’
+1365,COSA,sus. Ba’al
+1366,COSA ARDIENDO,adj. T’aba’an
+1367,"COSA ARRASTRADA, HOLLADA, MUY SUCIA",adj. Ki’irits’.
+1368,COSA ASENTADA,sus. Ets’a’an
+1369,COSA BUENA Y VIRTUOSA,sus. Tibil
+1370,COSA CARA,sus. Ko’oj u tojol
+1371,COSA CLARA Y MANIFIESTA,sus. Ajajbil
+1372,COSA DIVINA,"sus. K’uyen, k’ul."
+1373,COSA ENCENDIDA,adj. T’aba’an
+1374,COSA ENREDADA (COMO LOS CABELLOS),sus. Tsu’uy
+1375,COSA EXTRAÑA E INCREÍBLE,adj. Maktsil
+1376,COSA FALSA,sus.Ba’al ma’ jaaji’
+1377,"COSA FIJA, QUE NO SE MENEA",sus. Babanki
+1378,COSA FIRME,sus. Ets’a’an
+1379,COSA FIJA,sus. Ets’a’an
+1380,COSA GORDA,sus. Nuk
+1381,COSA GRUESA,"sus. Nuk, piim."
+1382,COSA HARTA,adj. P’up’ulki
+1383,COSA HINCHADA,adj. Chup
+1384,COSA HONRADA,adj. Tilis
+1385,COSA ILUSTRE,adj. Tilis
+1386,COSA HECHA DE CORAZÓN,sus. Olbil
+1387,COSA HORRIBLE QUE CAUSA PAVOR,sus. Tibibt
+1388,COSA HUECA,sus. Ma’ba’l
+1389,COSA HUNDIDA EN EL HORIZONTE,adj. Lam
+1390,COSA INFINITA,adj. Cheket
+1391,COSA INNUMERABLE,adj. Cheket
+1392,COSA LABRADA,sus. Winkilis
+1393,COSA LADEADA,sus. Tsela’an
+1394,COSA LARGA Y FRÁGIL,sus. K’ajlakum
+1395,"COSA LEJANA, QUE ESTÁ MUY APARTADA",adj. Lam
+1396,COSA LLAMADA,sus. Paybil
+1397,COSA MARAVILLOSA,adj. Maktsil
+1398,COSA MELLADA,adj. P’eja’an
+1399,COSA PINTADA,"sus. Ts’íiben ts’íib, winkilis"
+1400,COSA PROVECHOSA Y NECESARIA,sus. Ma’kenlik
+1401,COSA QUE ANDA ACOMPAÑADA,sus. Lak’alak
+1402,COSA QUE ES LLAMADA,adj. Paya’an
+1403,COSA QUE ESTÁ OFRECIDA,adj. Siibil
+1404,COSA QUE SE ESCONDE,sus. Balaknak
+1405,COSA QUE SE HA TROCADO POR OTRA,sus. K’exa’an
+1406,COSA QUE SE RECIBE,sus. K’ambe’en
+1407,COSA REAL,adj. Ajawiil
+1408,COSA REPLETA,adj. P’up’ulki
+1409,COSA RESPETABLE Y HONESTA,adj. Talan
+1410,COSA SAGRADA,"sus. K’ul, k’uyen"
+1411,COSA SOLEMNE,adj. Tilis
+1412,COSA TERRIBLE,sus. Tibantsil
+1413,COSA UNIVERSAL QUE LO COMPRENDE TODO,sus. Yuk’
+1414,COSA VACÍA,sus. Ma’ba’l
+1415,COSA VENERABLE,adj. Tilis
+1416,COSA VOLUNTARIA,sus. Olbil
+1417,COSECHAR ELOTES,v.t. Jooch.
+1418,COSECHAR FRUTOS,"v.t. T’ook, éemsaj."
+1419,COSER,v.t. Chuuy
+1420,COSMOS,sus. Balkaaj
+1421,COSMOGONÍA,sus. Tsikbal yóok’ol balkaaj.
+1422,COSTA,"sus. Jáal ja’, chi’"
+1423,COSTADO,adv. de l. Tséel.
+1424,COSTADO,"sus. Tsel, tselil"
+1425,COSTAL,"sus. Ba’al, mukuk, nasa."
+1426,COSTEAR,v.t. Tojolt
+1427,COSTILLA,sus. Ch’ala’at
+1428,COSTO,sus. Tojol
+1429,COSTUMBRE,"sus.Suuk, suukil, suukbe’en."
+1430,COSTURA,sus. Chuuy
+1431,"COSTURAR, COSER, BORDAR",v.t. Chuuy
+1432,COXIS,"sus. K’uul, bobox"
+1433,CRÁNEO,sus. Tséek’
+1434,"CREADOR, DIOS",sus. Aj Síijsajul.
+1435,CREADOS,adj. J síijsa’ab
+1436,CRECER EL HOMBRE,v.i. Ch’iil
+1437,CRECER,"v.i. Nojochtal, ch’íijil"
+1438,CRECIDO,adj. Ch’íija’an 
+1439,CREENCIA,"sus. Ok óolal, oka’an óolal"
+1440,CREER,"v.i. Tuukul, oksaj óoltik."
+1441,CREER,v.t. Oksaj óol.
+1442,CREENCIA,"sus.Oksaj óol, ok óoltik."
+1443,CREER,v.i. Táan óolte.
+1444,CREPITACIÓN,sus. Wawak’il
+1445,CREPÚSCULO,sus. Okol k’iin
+1446,CRESTA,sus. P’iich
+1447,CRÍA DE AVES O DE CUALQUIER ANIMAL CUADRÚPE,
+1448,DO,sus. Pakab
+1449,CRIADO,"sus. (m) J k’oos, (f) X k’oos."
+1450,"CRIAR, ALIMENTAR","v.t. Tséem, tséent"
+1451,CRISTAL DE ROCA,sus. Nenus.
+1452,CROAR,v.i. Awat muuch
+1453,CRUCIFICADO,sus. Aj simsim che’
+1454,CRUCE,sus. Xa’ay
+1455,CRUDO,"adj. Che’che’, ma’ tak’ani’, chéecheb."
+1456,CRUEL,adj. J kalbach.
+1457,CRUELDAD,sus. Tachi’achil
+1458,CRUELDAD EXCESIVA,sus. Kalbach
+1459,CRUJIR,"v.i. Jech’,jíirich’, wáak’ach."
+1460,CRUZ,sus. K’atab che’.
+1461,CRUZADO,adj. K’atakbal.
+1462,CRUZAR,v.t. K’aat.
+1463,CUADRADO,sus. Amayte’.
+1464,"CUADRÚPEDO DEL TAMAÑO DE UN PERRO, DE CO",
+1465,"LOR NEGRO, HABITA EN LAS CAVERNAS",sus. E’e muuch.
+1466,CUÁL,pron. rel. ¿Máakalmáak?
+1467,CUALQUIER ANIMAL,sus. indef. Na’kjal
+1468,CUALQUIERA,pron. indef. Je’ máaxak Je’
+1469,"CUAJAR, COAGULAR",v.i. Olmal
+1470,"CUAJADO, COAGULADO",adj. Olmalja’an.
+1471,CUÁNDO,"Interrogación. Ba’ax k’iin, bik’iin, bik’ix"
+1472,CUANDO,"adv. Kéen, káan"
+1473,CUÁNTO,"adv. de c. Bajux, bajun ¿CUÁNTOS ANIMALES O adv.¿Jaytúul? ¿CUÁNTOS OBJETOS?."
+1474,CUARENTA,sus. Ka’a k’aal
+1475,PERSONAS?,le ba’alo’ob
+1476,CUARTA,sus. Náab
+1477,"CUARTEADO, MUY CUARTEADO",adj. Xíixi’ik.
+1478,CUARTO,sus. Tunk’as
+1479,CUATRO,sus. Kan. Cuatro mujeres: Kantúul ko’olelo’ob. Cuatro piedras: : Kanp’éel tuunicho’ob. Cuatro velas: : Kan ts’iit kibo’ob. Cuatro árboles de ceiba : Kan kúul ya’axche’ob.
+1480,CUBETA,sus. Ch’óoy
+1481,"CUBRIR, TAPAR","v.t. Bal, bo’oybesaj, piix,"
+1482,CUCARACHA,"sus. K’uuluch, x k’úuruch"
+1483,CUCHARA,"sus. K’ab kum CUCHAREAR, COMER CON LA CUCHARA."
+1484,CUCHICHEAR,v.i. X muukult’aan
+1485,CUCHICHEO,v.i. Tutukchi’
+1486,CUCHILLO,"sus. Xooteb, xootob"
+1487,CUELLO,sus. Kaal.
+1488,CUENTA,"sus. Xookil, xookul"
+1489,CUENTA EN GENERAL,sus. Buk’xookil
+1490,CUENTERO,"sus. Aj kansiyaan, tsikbali máak."
+1491,CUENTO,"sus. Jajal t’aan, jujub kan, weyil t’aan, tsikbal, xookil, tuusil t’aan, tuus tsikbal, tsikbal tuus, popolt’aan."
+1492,CUERNO,sus. Baak.
+1493,CUERNO DE VENADO O DE OTRO ANIMAL,sus. Xu
+1494,CUERO,sus. K’éewel
+1495,CUERPO,"sus. Wíinklil, kukutil, wíinkil"
+1496,CUEVA,sus. Jomlil ¡CUIDADO!.
+1497,"CUIDAR, PROTEGER","v.t. Kanáant, kaláant, ka"
+1498,CULEBRA,sus. Kaan CULEBRA QUE ATACA Y ENGULLE A SU VÍCTIMA COMO
+1499,BOA,sus. K’aaxab yuuk
+1500,CULEBRA QUE TRAGA A OTRAS,sus. Tsel kaan.
+1501,CULEBREAR,v.i. Bik’chalák
+1502,CULPA,"sus. Si’ipil, k’ochil."
+1503,CULPABLE,sus. Aj k’ocha’n
+1504,CULPADO,sus. Aj k’ocha’n
+1505,CULPAR,v.t. K’óochbesaj.
+1506,"CULTO, VENERACIÓN",sus. K’áat óolal.
+1507,CULTURA,sus. Miatsil
+1508,"CULTO, SABIO, DOCTO","adj. Aj miats, j miats."
+1509,CUMBRE DE UNA ALTURA,sus. Ni’
+1510,CUMPLEAÑOS,sus. K’iin k’aaba’
+1511,CUMPLIR,"v.i. Bojol t’aan, chukbesaj"
+1512,CUMPLIRSE EL PLAZO,v.i. Je’ep’el
+1513,CUÑADA,"sus. Muil, mu’il, múu, x"
+1514,CUÑADO,sus. Baal.
+1515,"CURA, MEDICAMENTO",sus. Ts’aak.
+1516,CURANDERA,"sus. Ix ts’aak, x ts’aak"
+1517,CURANDERO,"sus. Aj ts’aak, j ts’aak"
+1518,CURAR,v.t. Ts’aak
+1519,"CURIOSIDAD, MAÑA, INGENIO NATURAL",sus. Its’atil
+1520,CURSO,"sus. Belili’, beelil"
+1521,CURVA,sus. Ka’lop.
+1522,CURVA O VUELTA,sus. Wats’
+1523,"CURVEADO, MUY CURVEADO",adj.K’éek’eech.
+1524,CURVEAR,v.i. P’uum.
+1525,CHACHALACA (ORTALIS),"sus. Baach, koba’"
+1526,CHAPARRO,". sus. Aj kaabaj, j kiis lu’um."
+1527,CHAPEAR,v.t. Jaran ch’áak.
+1528,CHAPOTEAR,"v.t. Bok’ol ja’, bok’ol naktik."
+1529,CHARAL,sus. Tsak’.
+1530,CHARCO,"sus. Chulub, temanja’, ja’akakbal. CHAYA (EUPHORBIACEAE (CNIDOS COLUS CHAYAMANSA (MC"
+1531,VAUGH)),. sus. Chay. CHAYOTE (SECHIUM EDULE (JACQ) SWARTZ) .
+1532,CHICLE,"sus. Sikte’, cha’"
+1533,CHICO,"adj. Chichan, chan, mejen."
+1534,CHIFLAR,v.i. Xuuxub
+1535,CHILE (CAPSICUM ANNUUM CASPSICUM SPP),sus. Iik
+1536,CHILE ROJO QUE SE SECA AL SOL,sus. Chak iik
+1537,CHILLAR,v.i. Awat
+1538,CHINCHE,sus. Kisil
+1539,CHISME,"sus. A’al t’aan, líik’saj t’aan, tak"
+1540,CHISMOSO,"sus. (m) Aj a’al t’aan, (f ) Ix a’al t’aan. t’aan."
+1541,CHISPA,"sus. Tip’ix k’áak’, p’ilis, xikin k’áak’"
+1542,CHISPAS DEL HERRERO,sus. P’ilis k’áak’
+1543,CHISPORROTEAR,v.i. Tip’ix.
+1544,CHISTE,"sus. Báaxal t’aan, che’ej t’aan."
+1545,CHOCOLATE,sus. Chukwa’
+1546,"CHORREAR, MANAR",v.i. Chooj.
+1547,"CHUPAFLOR, COLIBRÍ",sus. Ts’unu’un
+1548,CHUPAR,v.t. Chu’uch
+1549,DADOS,sus. Baakil buul
+1550,DAMA,"sus. Xunáan, ko’olel"
+1551,DAÑADO,adj. Loobkinan
+1552,"DAÑAR, HERIR",v.t. Loob
+1553,DAÑO,sus. Loob
+1554,DAÑO MUY GRANDE,sus. Noj loob.
+1555,DAR,"v.t. Tich’, ts’áaj, ts’ik."
+1556,"DAR DE COMER, MANTENER",v.t. Tséen.
+1557,DAR EJEMPLO,v.t. Joch jaban
+1558,DAR EL PASO,v.t. Xáak’abt
+1559,DAR FRUTOS,v.i. Iichankil.
+1560,DAR LIMOSNA,v.t. Ts’áaj yatsil.
+1561,DAR NOTICIA,v.t. Num chi’
+1562,DAR ORDEN,v.t. Ts’áaj u tumutil
+1563,DAR PRINCIPIO,v.i. Belbesaj
+1564,DAR REVUELCOS Y RODAR,v.i. Kukchalankil.
+1565,DAR SOMBRA,v.t. Bo’oybesaj
+1566,DAR SU BENEPLÁCITO,v.t. Ts’áaj óol
+1567,DAR SU CONSENTIMIENTO,"v.t. Ts’áaj óol, éeje"
+1568,DAR TESTIMONIO,v.t. Jalkunaj
+1569,DARDO,sus. Juul
+1570,DE (para interrogar),Tu ba
+1571,DE,prep. Ti’
+1572,DE ABDOMEN PROMINENTE,"sus., adj. P’urux nil. nak’."
+1573,DE ALGUNA PARTE,adv. de l. Lik’ul
+1574,DE ANTES,adv. de t. Ka’ach
+1575,DEBAJO,prep. Yáanal.
+1576,DEBAJO,adv. de l. Yáanal.
+1577,"DEBER, OBLIGACIÓN",sus. Unaj.
+1578,"DEBER, DE DEUDA",v.t. P’aax.
+1579,DEBE SER,Unaj
+1580,DÉBIL,"adj. T’ona’an, ma’ muuk’il, ma’ t’a’aji’."
+1581,DE CABEZA,adj. Chíinchinpool
+1582,DE CADA DÍA,adv. de t. Ti’ amalk’iinil
+1583,DE CAMINO,adv. de t. Jun k’uli’
+1584,"DECANTAR, ESCURRIR UN LÍQUIDO","v.i. Ts’ibt,"
+1585,DECENCIA,"sus. Subtal, su’tal"
+1586,"DECIR, MANDAR, ORDENAR","v.t. A’alaj, a’almaj tsi’its. , a’al."
+1587,DECIDIR,v.i. Tumaja’an.
+1588,DE COLOR CENIZO,adj. Chukim.
+1589,DE COLOR CENICIENTO,"adj. Éek’pose’en, koob."
+1590,DEDO,sus. Yaal k’ab.
+1591,DEDO DE LA MANO,"sus. Aal k’ab, ts’elek. (Hon"
+1592,DEDO DEL PIE,sus. Aal ook
+1593,DEDO ÍNDICE,sus. Tuch’ub.
+1594,DEDO MEÑIQUE,sus. T’uup.
+1595,DE DOS FILOS,adj. Ka’amat yeej
+1596,DE ESTE TAMAÑO,adv. de c. Buka’aj
+1597,DEFECAR,v.i. Ta’
+1598,DEFENDER,"v.t. Tóok, bo’oybesaj"
+1599,"DEFENDER, VENGAR",v.t. Tokbaj.
+1600,DEFINIR,v.t. Ts’ok.
+1601,DEGLUTIR,v.t. Luuk’
+1602,DEGOLLAR,v.t. Xoot kaal.
+1603,DEGRADAR,v.t. T’ooki
+1604,DEGÜELLO,sus. Xoot kaalil DEIDAD MAYA DE LA CAZA MENCIONADA POR DIEGO
+1605,DE LANDA,sus. K’u bolay.
+1606,"DEJAR, ABANDONAR","v.t. Cha’, p’aat."
+1607,DEJARSE VARIAS VECES,v.t. P’aap’aat.
+1608,DEJAR SILENCIOSO,adj. Ch’enaj
+1609,DEJAR EN LIBERTAD,"v.t. Cha’aj, cha’b,"
+1610,DERRAMAR,"v.t. Week, tiix"
+1611,DERRAMARSE,v.i. Wéekel.
+1612,"DERRAMAR, VERTER UN LÍQUIDO A CHORROS",v.t. jáalk’ab t. Tselepk’iin. DE LAS TRES DE LA TARDE EN ADELANTE.
+1613,DELANTE,"adv. de l. Bat’an, aktáan."
+1614,DELANTE,prep. Táanile.
+1615,DELANTERO,sus. Aktáanil.
+1616,DELATAR,"v.t. Manchi’taj, tak pool,"
+1617,DELGADO,"adj. Bek’ech, bi’ich, ts’ooy, ts’uuts’, pa’apchi’it. ts’oya’an."
+1618,DELIBERACIÓN,sus. Xot óol
+1619,DELICADO,adj. Mamayki
+1620,DELICIOSO,adj. Ki’
+1621,DELIRAR,"v.i. T’aant’an pool, t’aant’aan, ko’ja."
+1622,DELIRIO,sus. K’aak’as waya’asbe’ene’.
+1623,DELITO,"sus. Si’ipil. (Hondzonot, municipio de Tulum, Q. Roo)"
+1624,DE MAÑANA,adv. de t. Ja’atskab k’iin.
+1625,DEMASIADO,"adv. de c. Máanal, jach ya’ab."
+1626,DEMASIADO,adj. Nóonooj.
+1627,DEMENTE,sus. Choko jo’ol.
+1628,DEMOLER,v.t. Juut
+1629,DEMONIO,"sus. Kisin, xulub, k’aak’as ba’al."
+1630,DEMORARSE,v.i. Xáantal.
+1631,DESMORONAR,v.i. Báanal.
+1632,DEMOSTRAR,"v.i. E’es, e’esaj"
+1633,DENODADO,adj. Aj koo.
+1634,DENTRO,"prep. Ich, ichil"
+1635,DENUNCIAR,v.t. Manchi’taj
+1636,DE OJOS ZARCOS,sus. Sak buye’en ich
+1637,DE PASO,adv. de t. Jun k’uli’ DE POCO PESO.
+1638,"DEPORTE, JUEGO",sus. Báaxal.
+1639,DEPOSITADO,adj. K’uba’an
+1640,"DEPRESIÓN, DESÁNIMO",sus. Lúubul óol.
+1641,DERECHA,"sus. No’oj, x no’oj ."
+1642,DERECHAMENTE,adv. de m. Juntats’
+1643,DERECHO,"adj. Napul, no’oj, toj. Tóox."
+1644,"DERRETIR, FUNDIR",v.i. Yiib
+1645,DERRIBAR,"v.t. Jeen, juut"
+1646,"DERRIBAR, DERRUMBAR, DESTRUIR",v.i. Niik.
+1647,DERROTAR,"v.t. Lúubesaj, lúubsaj, lúusaj."
+1648,DERROTERO,"sus. Belili’, beelil"
+1649,DERRUMBADO,adj. Juutul.
+1650,DERRUMBADO POR PARTES,adj. Jéejeem
+1651,DERRUMBAR,"v.i. Juut, niik, jeen"
+1652,DERRUMBARSE,v.i. Jéenel
+1653,DESAGRAVIAR,v.t. Loj
+1654,DESAGRAVIO,sus. Loj.
+1655,DESAHUCIAR AL ENFERMO,v.t. Xet’ óol.
+1656,"DESÁNIMO, DEPRESIÓN",sus. Lúubul óol.
+1657,DESAPARECER,"v.i. Balk’ajalak, sa’at, báalal."
+1658,DESAPARECER,v.i. Samk’aj.
+1659,DESAPARECER DE LA MEMORIA,v.t. Tubul
+1660,DESAPARECER DE LA VISTA,v.t. Samchajal
+1661,DESARMADO,adj. Sipa’an.
+1662,"DESATAR, DESABROCHAR",v.t. Waach’
+1663,"DESATAR, AFLOJAR, DESENREDAR",v.t. Chóol.
+1664,DESATAR SIN ORDEN,v.t. Wáawaach’.
+1665,DESAYUNAR,v.i. Uk’ul.
+1666,DESAYUNO,sus. Uk’ul.
+1667,"DESBARATAR, DESHACER, DESMORONAR","v.t. Juub, juut."
+1668,DESBASTAR,"v.t. Póol, ji’ixtik"
+1669,DESBOCA,adj. Pich’il chi’.
+1670,DESCALZO,"adj. Ma’ xaanab, x ma’ xaanbil, j ma’ xaanbil."
+1671,DESCANSADERO,sus. Je’eleb
+1672,DESCANSAR,v.i. Je’elel
+1673,DESCARNAR,v.t. Ch’awak.
+1674,DESCENDENCIA,sus. Ch’i’ibal
+1675,DESCENDER EL AVE,v.i. Jáayal.
+1676,DESCOMPONERSE,v.i. K’aastal.
+1677,DESCONCERTAR,v.i. Kowol
+1678,DESCONFIANZA,sus. Péek óol
+1679,DESCONOCER,v.t. Kúulpaachkúuns
+1680,DESCONOCER A OTRO,v.t. Maklaj
+1681,DESCORTEZAR LOS ÁRBOLES A GOLPES,v.t. Bax
+1682,"DESCORTEZAR, DESCASCARAR, DESINFLARSE, DES",
+1683,HINCHARSE,v.i. Ts’úumul.
+1684,DESPELLEJAR CON LAS UÑAS,v.t. Le’ep’.
+1685,"DESPRENDERSE, CAERSE",v.i. Júutul
+1686,"DESCORTEZAR, ROER",v.t. Néet’.
+1687,DESCOYUNTAR,v.t. Juk’
+1688,DESCUARTIZAR,v.t. Xo’xo’ot.
+1689,DESCUBIERTO,adj. Jok’a’an
+1690,DESCUIDAR,"v.i. Náay, náays óol"
+1691,DESCUIDO,"sus. Manak’óol, náay óolal"
+1692,DESDE,"prep. Ix tak, lik’ul, lik’bal,takti."
+1693,DESDECIRSE,v.i. Jelaj
+1694,DESDOBLAR,v.t. Waach’al
+1695,DESEAR,"v.t. Táan óoltik, ts’íiboltik, sits’, k’áat DESGRANAR MAZORCAS DE MAÍZ (GOLPEÁNDOLAS"
+1696,"CON UNA VARA EN UN COSTAL, HAMACA, KA’ANCHE’)",v.t. P’uch
+1697,DESGRANAR ALGO,"v.t. P’éep’eel, p’eel"
+1698,DESHABITARSE,v.t. Joch jal
+1699,DESHACER,"v.t. Cháajal, puuk’"
+1700,DESHEBRAR (CARNE),v.t. Tsíik.
+1701,"DESHIERBAR, ARRANCAR LAS HIERBAS O MALEZA",v.t. Páak.
+1702,"DESHINCHARSE, DESINFLARSE",v.i. Ts’úumul.
+1703,DESHONESTIDAD,sus. Ko’il
+1704,DESIERTO,"sus. Ch’ena’an, x tokoy lu’um, x tokoy sam."
+1705,DESIGNAR,v.t. Yéey.
+1706,DESILUSIÓN,sus. Tuup óolal.
+1707,DESILUSIONADO,"adj. J tuupa’an óol, j óoltik, táak óol tuupa’an ich."
+1708,"DESEAR, QUERER","v.t. Óot, k’áat."
+1709,DESENCAJARSE EL HUESO,v.i. Juk’ul
+1710,DESENCOGER,"v.t. Tats’, ji’b"
+1711,"DESENGAÑO, DESILUSIÓN",sus. Tuup óol.
+1712,DESENROLLAR,v.t. Waach’al.
+1713,DESENVAINAR,"v.t. P’el, jíil."
+1714,DESEO,"sus. Ts’íibol, ts’íibolal."
+1715,DESEOSO,"adj. Pooch, siits’."
+1716,DESERTAR,v.i. Púuts’ul.
+1717,DESERTOR,sus. J púuts’ wíinik.
+1718,DESESCAMAR,"v.t. Pox, poxtik."
+1719,DESESPERACIÓN,sus. Xet’ óolal
+1720,"DESESPERADO, ANGUSTIADO",adj. Chíichiiknak
+1721,DESESPERADO,adj. Yáanyaanki.
+1722,DESFIBRAR,v.t. Jo’och kij.
+1723,DESFIGURAR,v.t. K’aaskunaj ich.
+1724,"DESFLORAR, DESVIRGAR",v.t. T’aak.
+1725,DESFONDAR,v.t. Joom.
+1726,DESGAJAR (QUEBRAR UNA RAMA),v.t. Jéek’
+1727,DESGAJADO,adj. Jéejéek’.
+1728,DESGARRAR,v.t. Jatlom.
+1729,DESGRACIA,"sus. Loob, ilálalil."
+1730,"DESGRACIAR, DAÑAR",v.t. Loob.
+1731,DESGRANAR A MANO LAS MAZORCAS DE MAÍZ,"v.t. Oxo’omt, oxo’om"
+1732,DESINFLADO O VACÍO,adj. Pats’
+1733,DESINFLAR,v.i. Chaak’al.
+1734,"DESLEIR, DISOLVER, DESHACER",v.t. Puuk’
+1735,DESLUMBRADO,"adj. Chaaj iich, tupa’an ich."
+1736,DESMAYADO,adj. Sajkíimeen
+1737,DESMENUZAR LA CARNE,v.t. Tsíik.
+1738,"DESMONTAR, TALAR LA SELVA",v.t. Ch’akbe’ent.
+1739,"DESMONTAR, TALAR ÁRBOLES, HACER MILPA",v.t. Kool. yóok’ol.
+1740,DESMONTAR DE UNA CABALGADURA,v.t. Éemel
+1741,DESMONTE,"sus. Kool k’áax, kajkool, kool."
+1742,DESMORONAR,v.i. Juut.
+1743,DESNIVELADO,adj. Nixa’an
+1744,DESORDEN,"sus. K’ok’otkij, xa’axak’."
+1745,DESOVAR,"v.t. E’elankil, e’elankal, e’el ."
+1746,DESPACIO,"adv. de m. Chaanbéel, xanbel"
+1747,"DESPARRAMAR , ESPARCIR","v.t. K’iit’, t’iit’."
+1748,"DESPARRAMARSE, ESPARCIRSE","v.i. K’íitil, k’i’itpajal. DESPARRAMADO, DERRAMADO, MANCHADO CON"
+1749,LÍQUIDO,adj.Wéeweek.
+1750,DESPEDAZADO,"adj. Xéexeet’. DESPEDAZADO, HECHO JIRONES. Adj.Tsiitsiik."
+1751,DESPEDAZAR,v.t. Xe’exet’.
+1752,FRAGMENTAR,v.t.
+1753,DESPEJADO,"adj. Jaabal, sáasil, DESPEJADO UN TERRENO. Adj. Jáanch’in."
+1754,DESPEJAR,"v.i. Jabkuba, píik’il."
+1755,DESPEJAR O ESCOMBRAR UN LUGAR,v.t. Ch’óoch’
+1756,DESPEGADO,adj. Láakal.
+1757,"DESPEGAR, DESPRENDER",v.t. Láak.
+1758,DESPERDICIAR,"v.t.Pak’mab, manba’alkuntik."
+1759,DESPERTAR UNO MISMO,v.i. Ajal.
+1760,DESPERTAR A ALGUIEN,v.t. Ajsaj.
+1761,DESPIERTO,adj. P’ixa’an ich
+1762,"DESPLUMAR, DESHOJAR","v.t. P’éep’, p’ep’,"
+1763,DESPOBLARSE,v.t. Joch jal
+1764,DESPEINADO O DE PELO MUY ESPONJADO,adj. t’úut’ik. Xáaxaak.
+1765,DESPRECIO,sus. Pinab ach
+1766,DESPRECIABLE,adj. P’eekbe’en.
+1767,DESPRENDER,"v.i. Báanal, láak, lúub, poots."
+1768,DESPRENDERSE,v.i. Báanal
+1769,DESPRENDIDO,adj. Láakal
+1770,DESPRESTIGIAR,v.t. Manba’alkunsik.
+1771,DESPUÉS,"adv. de t. Je’ ka’, je’lilie’"
+1772,"DESTEJER, DESFLECAR",v.t.T’iik.
+1773,DESTETE,sus. Took chu’uch.
+1774,DESTINO,"sus. K’iintaj, k’iin."
+1775,DESTREZA,"sus. Noj ach óolal, péek, séeba’anil"
+1776,DESTREZA EN CUALQUIER COSA,sus. Nonojil
+1777,DESTRUCCIÓN,sus. Jay kaabal.
+1778,DESTRUCCIÓN DEL MUNDO,sus. Jay kaabal.
+1779,DESTRUIR,"v.t. Jay aj , nojmal."
+1780,DESVANECER,v.i. Koo’ jal óol.
+1781,DESVARIAR,v.i. T’aant’aan.
+1782,DESVELO,sus. Benel weenel.
+1783,DESVESTIR,"v.t. Pit nook’, luk’saj nook’, tsel nook’. "
+1784,"DESVIAR, LADEAR",v.t. K’uuy.
+1785,DESYERBAR,v.t. Páak.
+1786,DESYERBE (CON TODO Y RAÍZ),sus. Lo’che’páak. DESYERBE (SUPERFICIAL O MAL HECHO).
+1787,DETENER,v.i. T’íilit
+1788,DETENER EL RESUELLO,v.i. Kuup.
+1789,DETENERSE EN CASA DE ALGUNO CONTRA SU VO,
+1790,LUNTAD,v.t. Koyba
+1791,DETENIDO,adj. Kuma’n
+1792,DETERIORADO,adj. Laab
+1793,DETERIORAR,"v.i. K’astal, laab"
+1794,DETERMINACIÓN,sus. Xot óol
+1795,DETERMINAR,v.t. Jepajal óol
+1796,DETESTAR,"v.t. P’éek, p’ek"
+1797,DETONACIÓN,sus. Wáak’
+1798,DETONAR,v.i. Wáak’
+1799,DETRÁS,prep. Tu paach
+1800,DEUDA,sus. P’áax
+1801,DE UNA VEZ POR TODAS,adv. de t. Junpuli’
+1802,DEVOCIÓN,"sus. Ts’áaj óolal, ts’a óolal, yaaku"
+1803,DEVOLVER,v.t. Suut.
+1804,DÍA,sus. K’iin
+1805,DÍA CALIENTE,"sus., adj. Chokoj k’iin"
+1806,DÍA NUBLADO,"sus., adj. Nookoy k’iin"
+1807,DIABLO,"sus. Kisin, xulub, k’aak’as ba’al"
+1808,DIADEMA,sus. Nak
+1809,DIARIAMENTE,adv. de t. Sáansamal
+1810,DIARIO,adv. de t. Sáansamal.
+1811,DIARREA,"sus. Waach’, tirix ta’, waach’iit"
+1812,DIBUJADO,adj. Jochol
+1813,DIBUJAR,"v.t. Ts’íib oochel, boon."
+1814,DIBUJO,sus. Ts’íibil oochel
+1815,DICTAR,v.t. A’albil utia’al ts’íibil.
+1816,DICTADO,sus. A’albil ts’íib.
+1817,DICHOSO,adj. Ki’óol
+1818,DIECINUEVE,sus. Bolon lajun
+1819,DIECISÉIS,sus. Wáaklajun
+1820,DIECISIETE,sus. Úuklajun
+1821,DIENTE,sus. Koj
+1822,DIEZ,sus. Lajun
+1823,DIFERENCIAR,v.t. Jelkunaj
+1824,DIFERENTE,"adj. Jela’an, jejelás"
+1825,DIFÍCIL,adj. Talam.
+1826,DIFICULTAD,"sus. Toop, talamil."
+1827,DIFUNTO,sus. Kimen
+1828,DIGERIR,v.i. Éemel janal
+1829,DIGNIDAD,"sus. Subtal, su’tal"
+1830,DIGNO,adj. Tsikbe’en
+1831,"DILIGENCIA, GESTIÓN, TRÁMITE",sus. Noj ach óolal
+1832,DILIGENTE,"adj. Noj ach, sa’ak’ol"
+1833,DILUIR,"v.t. Puuk’, yaach’"
+1834,DILUVIO,sus. Búul kaabil.
+1835,DINERO,sus. Táak’in
+1836,DIOS,"sus. K’uj, yuum, yuumtsil"
+1837,DIOS CREADOR,sus.Aj síijsajul.
+1838,DIOS DEL VINO,sus. Aj akaan
+1839,DIRECCIÓN,"sus. Jel, belil, u tojil, u bejil."
+1840,DIRECTAMENTE,adv. de m. Napul
+1841,DIRIGENTE DE UN POBLADO,"sus. Tatich, pooli, nojochil."
+1842,DIRIGIR,"v.t. Paybe, paybe’en, belbesaj."
+1843,DISCÍPULO,"sus. (m) Aj kanbal, j káanbal (f) Ix kanbal, x káanbal."
+1844,DISCORDIA,"sus. Jeb óolal, nupankil, ok yail, óolal xab óolal"
+1845,DISCRECIÓN,"sus. Kux óol, tumut óolal"
+1846,DISCURSO,sus. Tse’ek
+1847,DISCUTIR,"v.t. Sakach t’aan, ba’ate’el t’aan."
+1848,DISGUSTADO,"adj. K’u’ux, ts’íik, p’u’uj."
+1849,DISGUSTAR,"v.i. K’uux, ts’íikil, p’u’ujul"
+1850,DISGUSTO,"sus. K’uuxil, ts’íikil, p’u’ujul."
+1851,DISMINUIR,v.i. Jáatspajal
+1852,DISPARAR,v.t. Sipit
+1853,DISTINTO,"adj. Jela’an, jejeláas. DON"
+1854,DISTRACCIÓN,"sus. Nay óolal, náay óol"
+1855,DISTRIBUIR,v.t. T’oox.
+1856,DIVERSIÓN,sus. Ki’imakkunaj óol.
+1857,DIVERSIFICACIÓN,sus. Jelkunaj
+1858,DIVERSO,"adj. Jela’an, jejeláas."
+1859,"DIVIDIR, REPARTIR, SEPARAR",v.t. Jaats.
+1860,DIVINA,adj. K’uyen
+1861,DIVINO TABERNÁCULO,sus. Sujuy máakaben.
+1862,DIVISIÓN,sus. Jeb óolal
+1863,DIVISIÓN EN PORCIONES,sus. Jaatslil DOBLADO FORMA EN DE
+1864,RESORTE,"adj. Ch’óoch’oot. DOBLADO, MUY DOBLADO SE APLICA AL METAL Y LA"
+1865,MADERA,adj.Wúuwuuts.
+1866,DOBLADILLO,sus.Paakalil.
+1867,"DOBLAR, PLEGAR",v.t. Paak
+1868,DOBLAR ALGUNA COSA,v.t. Uuts’. DOBLAR (LAS CAÑAS DE MAÍZ PARA QUE PROTEJAN LAS
+1869,MAZORCAS DE LA HUMEDAD),v.t. Waats’
+1870,DOBLEGAR,v.t. T’ooki
+1871,DOCE,sus. Laj ka’a
+1872,DÓCIL,"adj. Suuk, suuka’an"
+1873,DOCTOR,sus. Ts’aak yaaj.
+1874,DOCUMENTACIÓN,sus. Ju’un.
+1875,DOLER,"v.i. K’i’inam, yáajtal"
+1876,DOLOR,"sus. Chi’ibal, k’i’inam, yaaj, ok’om"
+1877,DOLOR DE ESPALDA,sus. Kampaach
+1878,DOLOR DE ESTÓMAGO Y NÁUSEAS,sus. Ki’inak’
+1879,DOMADO,adj. Suuk kinsaja’an
+1880,DOMESTICAR,v.t. Yaalak’tik
+1881,DOMÉSTICO (ANIMAL),adj.Aalak’.
+1882,DOMÉSTICO (TRABAJADOR),"adj.X k’oos.(f), j k’oos (m)"
+1883,DOMICILIO,sus. Otoch.
+1884,"DOMINIO, PROPIEDAD, HACIENDA",Ba’alba.
+1885,"DON, SEÑOR",Yuum.
+1886,DON O MERCED QUE UNO DA O HACE,sus.
+1887,DON O PRESENTE QUE UNO DA,sus. Ts’áaul
+1888,DONAR,v.t. Ts’áabilaj
+1889,DONCELLEZ,adj. Suju’uyil
+1890,DONDE QUIERA,adv. de l. Tatalak
+1891,DÓNDE,Interrogación. Tu’ux.
+1892,"DOÑA, SEÑORA","X nuk ko’olel, x nuk xunáan"
+1893,DORADO,adj. K’anjoojop.
+1894,DORADO,adj. Naban ti’ k’an.
+1895,DORADO,adj. K’anjuul.
+1896,DORMILONA (MIMOSA PÚDICA L),sus. X mu
+1897,DORMIR,v.i. Weenel
+1898,DORMIR PROFUNDAMENTE,v.i. T’uubul wee
+1899,DORMITAR,v.i. K’aas weenel
+1900,DORSO DE LA MANO,sus. Paach k’ab.
+1901,DOS,sus. Ka’a. Dos perros: Ka’atúul peek’o’ob; Dos machetes: Ka’ap’éel máaskabo’ob; Dos árboles de ciricote : Ka’a kúul k’óopte’ob; Dos velas: Ka’a ts’iit kibo’ob.
+1902,DOS COSAS JUNTAS,adv. de m. Ka’a lot
+1903,DOS COSAS UNIDAS,adv. de m. Ka’a lot
+1904,DOSCIENTOS,sus. Lajun k’aalo’ob
+1905,DOTE PARA EL CASAMIENTO,sus. Mujul
+1906,DUDA,sus. Péek óol.
+1907,DUDAR,v.i. Ch’ajal óol
+1908,DUEÑO,sus. Yuumil
+1909,DULCE,"sus., adj. Ch’ujuk"
+1910,"DUNA, MÉDANO","sus. Múul saam, múul sin"
+1911,DURANTE,"adv de t. Kalikil, kali’ikil , láakej."
+1912,DURAR,"v.i. Baili’, malel k’iin"
+1913,DURO,"adj. Chich, pe’ech, ts’u’uy"
+1914,E,conj. cop. Yéetel
+1915,"ECHARSE, TIRARSE AL SUELO",v.i. Pektal.
+1916,ECLIPSE DE LUNA,sus. Chi’ibil uj
+1917,ECLIPSE DE SOL,"sus. Chi’ibil k’iin, máansaj táanbo"
+1918,ECO,sus. Eets’
+1919,ECHAR,"v.t. Tojl, toojol"
+1920,"ECHADO, TIRADO",adj. Pekekbaj.
+1921,ECHAR FLORES LOS ÁRBOLES O HIERBAS,v.i. Nikankil
+1922,ECHAR MAZORCAS EL MAÍZ,v.i. Jejekankil
+1923,ECHAR RAÍCES,v.i. Motsankil
+1924,EDAD,"sus. Kian, ya’abil, ja’abil."
+1925,EDAD EN QUE SE TIENE FUERZA Y VIGOR,sus. Ke
+1926,EDAD O TIEMPO EN QUE UNO NACIÓ,sus. Siyan
+1927,EDUCACIÓN,"sus. Ka’ambes, kaans"
+1928,EDUCAR,"v.t. Ka’ansaj, ka’anbesaj."
+1929,EDUCADOR,sus. Aj Ka’anbesaj .
+1930,EDUCADORA,Ix Ka’anbesaj.
+1931,EFECTO,sus. Kuchul
+1932,EGOISMO,sus.ts’u’utkepil. ts’u’util.
+1933,EGOÍSTA,adj. J ts’u’ut (m) x ts’u’ut (f)
+1934,EJEMPLO,"v.t. Joch jaban, e’esaj, e’esajil."
+1935,EJERCICIO (TAREA),"Sus. Meyaj, meyaj ts’íib, ts’íibil meyaj, meyaj ti’ xook."
+1936,EJERCICIO CORPORAL,sus. Jóok’esaj muuk’.
+1937,EJÉRCITO,"sus. K’atun, molay k’atuno’ob"
+1938,EJIDO,sus. K’áax.
+1939,"EL, ELLA",pron. pers. Leti’
+1940,"ELLOS, ELLAS",pron. pers. Leti’ob.
+1941,ELABORAR,"v.t. Meent, beet."
+1942,EL COMPAÑERO QUE ESTA SENTADO CON OTRO,sus. Éetkulik.
+1943,EL MAYOR O MEJOR,sus. Lalail
+1944,ELÁSTICO,"adj. Saats’, sasats’kil"
+1945,ELECCIÓN,"sus. Wakunaj, yéey, téet."
+1946,ELECCIONES,sus.Yéey táanbalo’.
+1947,ELECTO,adj. Wakuna’an
+1948,ELEGIDO PARA ALGUN CARGO,adj. Wakunaj
+1949,ELEGIR,"v.t. Téet, yéey"
+1950,ELEVAR,v.t. Na’aks
+1951,"ELEVAR, ALZAR",v.t. Tuuch’
+1952,ELOGIAR,v.t. Ki’ki’t’aanta’al
+1953,ELOTE HORNEADO BAJO TIERRA,sus. Píibinal
+1954,EMBARAZADA,sus. Yo’om ko’olel
+1955,EMBARAZAR,v.t. Yo’omkin
+1956,EMBARAZARSE,v.i. Yo’omtal
+1957,EMBARRO,sus. Pak’ lu’um
+1958,EMBAUCADOR,"sus. Aj es, aj naysaj óol"
+1959,EMBAUCAR,v.t. Esaj
+1960,EMBELESO,sus. Sa’at óol
+1961,"EMBESTIR, CORNEAR","v.t. Kiblaj, K’óoch"
+1962,"EMBONAR, EMPATAR, EMPALMAR, UNIR",v.t. Tsaay
+1963,EMBORRACHAR,"v.i. Káalkun, káaltal"
+1964,EMBOSCADA,sus. Balbaj
+1965,EMBOSCAR,v.t. Balba
+1966,EMBRIÓN,sus. Baal nak’.
+1967,EMBROCADO,"adj. Nooka’an, nóonook."
+1968,EMBUTIR,"v.t. Bababuut’, buut’"
+1969,"METER, ACHOCAR, ATESTAR, EMBUTIR",v.t. Cho
+1970,EMOCIÓN,sus. Jak’ óolal
+1971,EMPACAR,"v.t. Paak, wool"
+1972,"EMPAPADO, QUE HA ABSORBIDO MUCHA AGUA",adj. Jaja’kij
+1973,EMPAREJAR,"v.t. Keet, táaxkun, taxkun"
+1974,EMPAREJAR CON LA MANO,v.t. Jaax.
+1975,EMPATADO VARIAS VECES CON AMARRAS,adj.
+1976,EMPEZAR,"v.t. Chumpajal, chúun, jo’op’ol, Jóojook’ káajal, káajsaj"
+1977,"EMPEZAR, INICIAR",v.i. Léekel.
+1978,EMPINARSE,v.i. Jottal.
+1979,"EMPINARSE, ESTAR A GATAS",v.i. Xaktal.
+1980,EMPLEO,sus. Meyaj.
+1981,EMPOLLAR,"v.t. Pajkun, júuk"
+1982,EMPONZOÑADO,adj. Ts’akan
+1983,EMPRENDER,v.t. Chumbesik
+1984,EMPUJAR,"v.t. Túulch’in, léench’in , túul."
+1985,EMPUJAR A EMPELLONES,v.t. Ts’ats’a kabil
+1986,EMPUJAR ALGO,"v.t. Jentan, júul."
+1987,EMPUÑADURA,sus. Lap’k’abil
+1988,EMPUÑAR,v.t. Lap’
+1989,EN,prep. Ti’ ENAMORAR.
+1990,ENANO,"sus. Áak wíinik, aklax , p’utum wíi"
+1991,ENANO CORCOVADO,sus. P’uus
+1992,ENCABEZAR,"v.t. Jo’olpóop, jool poopintaj"
+1993,ENCAMAR GALLINAS O PAVAS,v.t. Pajkuns
+1994,ENCAMINAR,v.i. Belbesaj
+1995,ENCANDILADO,"adj. Chaaj iich, tupa’an ich"
+1996,ENCANTADOR,"sus. Aj es, aj kunaj t’aan, bal"
+1997,ENCANTADOR DE JAGUARES,sus. Aj kunaj báa
+1998,ENCANTAR,v.t. Esaj
+1999,ENCARCELAR,"v.t. K’aal, k’aal máak."
+2000,ENCARGAR,v.t. K’uben.
+2001,ENCARGO,sus. K’uben EN (para interrogar).
+2002,ENCALLAR,v.i. Kuulul cheem
+2003,ENCANDILAR,"v.t. Tupul ich, chaa ich. "
+2004,"ENCARAMARSE, ENCAMARSE",v.i. Paktal.
+2005,ENCARNADO,adj. Chakboxe’en.
+2006,ENCENDER,"v.t. T’aab, joop"
+2007,ENCENDER FUEGO,v.t. Joop.
+2008,"ENCENDERSE, PRENDERSE",v.i. T’áabal.
+2009,ENCERRAR,v.t. K’aal.
+2010,ENCIMA,"prep. Yóok’ol, yóok’."
+2011,EN COMPAÑÍA,adv. de m. Pak’te
+2012,ENCONTRAR,v.t. Kaxan
+2013,"ENCONTRARSE, DAR CON OTRO",Naktan.
+2014,EN CONTRARIO,prep. Tu nup
+2015,ENCRUCIJADA,sus. Xa’ay beej
+2016,"ENCUENTRO, DAR CON EL OTRO",sus.Naktan.
+2017,EN DÓNDE,adv. de l. Tu’ubi’
+2018,EN EFECTIVO,adj. Túujkab
+2019,EN EL MUNDO,adv. de l. Yóok’ol kaab
+2020,ENERVAR,v.t. T’ona’ankinsik ENCENDER Y PROPAGAR EL FUEGO DE LA QUEMA
+2021,ALREDEDOR DEL TERRENO DESMONTADO,sus. Bat’aab
+2022,ENCERRADO,"adj.(m) J k’aala’an, (f) x k’ala’an."
+2023,ENCÍA,sus. Niich’o’
+2024,"ENCOGER, AGAZAPAR","v.i. Moot’, moots’"
+2025,ENCOGIDO AL DORMIR,adv. Móomoochki.
+2026,ENCONTRAR,"v.t. Kaxan, kaxtik"
+2027,"ENCONTRARSE, DAR CON OTRO",v.t. Naktan.
+2028,ENCORVADO,adj. Koopil
+2029,ENCOSTALAR,v.t. To’oy
+2030,ENCRUCIJADA,sus. Xa’ay
+2031,ENCUBIERTO,adj. Muukul
+2032,ENCUBRIR,"v.t. Bal, balantik"
+2033,ENDEREZAR,"v.t. Tats’, tojkíinsik, ji’b , t’ees."
+2034,ENDULZAR,v.t. Ch’ujukinsik
+2035,ENEMIGOS,"sus. K’uxtaanbalo’ob, k’ux lu’um taanbalo’ob"
+2036,ENEMIGO,sus. K’ajual
+2037,ENEMISTAD,sus. Nupankil
+2038,ENERGÍA,"sus. Óol, k’inaj."
+2039,ENERVACIÓN,sus. T’ona’anil
+2040,ENFERMAR,v.i. K’oja’antal.
+2041,ENFERMEDAD,sus. K’oja’anil.
+2042,ENFRENTE,adv. de l. Aktáan
+2043,BIOS,sus. Xayak’.
+2044,ENFERMEDAD DE LA VISTA,sus. Áak’abich
+2045,ENFERMERA,sus. X áantaj ts’aak yaaj.
+2046,"ENFERMO, ENFERMA",adj. K’oja’an.
+2047,ENFILADO,adj. Tsoola’an
+2048,ENFLAQUECER,"v.i. Ts’oy, not’bal"
+2049,ENFRENTE,"prep. Aktáan, táan"
+2050,ENFRIAR,v.i. Síiskunsik
+2051,ENFRIARSE,v.i. Síistal
+2052,"ENFUNDAR, ENCAJAR",v.t. Juup.
+2053,ENGAÑAR,v.t. Tuus
+2054,ENGAÑO,sus. Tuusil.
+2055,ENGARROTADO,adj. Lóoloot’
+2056,ENGENDRAR,v.t. Tsay
+2057,ENGRANDECER,v.t. Nojochkunkik.
+2058,ENGRANDECER,"v.i. Nojochtal, nojochchajal."
+2059,ENGULLIR LA COMIDA SIN MASCARLA,"v.t. Pot luuk’, totop luuk’"
+2060,"ENHEBRAR, ENSARTAR",v.t. Juul.
+2061,ENJAMBRE,sus. Jom.
+2062,ENJUAGAR,v.t. Chaal.
+2063,EN LA NOCHE,adv. de t. Óok’iin
+2064,EN LA TARDE,adv. de t. Éek’same’en
+2065,ENMARAÑADO,"adj. Loob, so’osok’"
+2066,ENMARAÑAR,v.t. Chu’uy.
+2067,EN MEDIO,"adv. de l. Chúumukil, tu chúu"
+2068,ENMIENDA,sus. Tojkilnaj óol.
+2069,ENMUDECER,v.i. Tootnaj
+2070,ENSORDECER,"v.i. Kóokkinaj, mak xikin."
+2071,EN NINGÚN LUGAR,adv. de l. Mix tu’ux
+2072,EN OTROS TIEMPOS,"adv. de t. Ka’atuchi, ka’achuchi"
+2073,ENOJADO,"adj. P’uja’an, ts’íik, k’uux"
+2074,ENOJAR,"v.i. P’u’uj, k’uux, ts’íik, ts’íikil."
+2075,ENOJO,"sus. Lep’ óol, tachi’achil"
+2076,EN PRESENCIA,prep. Tu táan
+2077,EN PRESENCIA,prep. Tak’ kabal ich.
+2078,EN TODAS PARTES,adv. de l. Tatalak ENTREGA
+2079,ENRAMADA,"sus. Makan, máakan."
+2080,ENREDADERA,sus. Aak’il
+2081,ENREDADO,adj. So’osok’
+2082,ENREDAR,"v.t. Babak’taj, baak’"
+2083,"ENREDADO, MUY ENREDADO",adj So’oso’ok’
+2084,"ENROLLAR, TORCER","v.i. Kopej, biil"
+2085,ENROLLAR,v.t. Wóolis wuts’.
+2086,"ENROLLAR, ENROSCAR",v.t. Koots’
+2087,"ENROLLAR, ENCORVAR, ENROSCAR",v.i. Koop.
+2088,ENROLLARSE,v.i. Kóots’ol
+2089,ENROSCADO,adj. Koopa’an
+2090,ENROSCARSE LA CULEBRA,v.i. Koopba
+2091,ENSALADA DE CÍTRICOS Y JÍCAMA,sus. Xe’ek’
+2092,ENSANGRENTARSE,v.i. Tul k’ik’jal
+2093,ENSARTAR,"v.t. Juul, loom"
+2094,ENSAYAR,v.t. Túuntaj
+2095,ENSEGUIDA,adv. de t. Séeb
+2096,ENSEÑANZA,"sus. Káanbesajulo’, kanbesaju"
+2097,ENSEÑAR,"v.t. Ka’ans, ka’ansaj."
+2098,ENSEÑAR VARIAS VECES,v.t. Yéeye’esaj.
+2099,ENSORTIJADO,adj. Mu’uch
+2100,ENSUCIAR,v.t. Éek’kunaj
+2101,ENTARIMADO DE MADERA,sus. Tsatsal che’
+2102,ENTENDER,"v.t. Na’at, na’atbe’en."
+2103,ENTENDIMIENTO,"sus. Its’atil pool, na’at"
+2104,ENTERO,adj. Túulis
+2105,ENTERRADO,"adj. Múukul, múuka’an."
+2106,ENTERRADO POR PARTES,adj. Múumuuk.
+2107,ENTERRAR,"v.t. Múuk, mu’ukul."
+2108,ENTONAR,v.i. U núuk u k’aayil.
+2109,"ENTONCES, PUES",adv. de m. Túun
+2110,ENTONCES,"adv. de t. Ti’ túun, túun."
+2111,ENTORNO,sus. Bak’paach
+2112,ENTRAÑAS,sus. Jobnel
+2113,ENTRAR,"v.i. Okol, ok"
+2114,ENTRE,"prep. Ich, ichil"
+2115,ENTRE ELLOS,adj. Batanbao’ob
+2116,"ENTREGA, ENCARGO",sus. K’uub.
+2117,ENTREGAR,v.t. K’uub.
+2118,ENTRE TANTO,adv. de t. Tamuk’
+2119,ENTREGA,"sus. K’uubilaj, k’uuba’an paach"
+2120,ENTREGADO,adj. K’uuba’an
+2121,"ENTREGAR, SOMETERSE",v.t. K’uub
+2122,ENTRETENER,"v.i. Náay, náays óol"
+2123,ENTRISTECER,"v.i. K’om óol, yaaj óol"
+2124,ENTUMIDO,adj. Si’is
+2125,ENTURBIADO,adj. Puuk’a’an
+2126,ENTUSIASMO,sus. Ki’óolal
+2127,"EN VANO, INÚTIL",adj. Najel.
+2128,"ENVEJECER,CRECER",v.i. Ch’íijil
+2129,ENVENENADO,adj. Ts’akaja’an
+2130,"ENVIAR, MANDAR",v.t. Túuxt
+2131,ENVIDIA,"sus. Sawin achil, ts’íibol."
+2132,ENVOLTURA,sus. To’.
+2133,ENVOLTURA DE LA MAZORCA DEL MAÍZ,sus. Jolo
+2134,ENVOLVER,"v.t. Teep’, to’."
+2135,ENVOLVER CON SÁBANA O COBERTOR,v.t. Babaltep’ik
+2136,ÉPOCA,sus. K’iinil.
+2137,ÉPOCA DE LA FLORACIÓN FEMENINA DEL MAÍZ,sus. Chakpak’e’en
+2138,ÉPOCA DE LLUVIA,"sus. Ja’aja’al, ja’ ja’ab"
+2139,EQUINOCCIO,sus. Laket k’iin yéetel áak’ab
+2140,EQUIPO,sus. Múuch’ul.
+2141,EQUIVOCACIÓN,"sus. K’ebaan t’aan, k’ex óol"
+2142,"ERECTO, MUY DERECHO",adj. Tsantsanki.
+2143,"ERGUIR, QUEBRADO DE ESPALDAS, QUE SACA EL PE",
+2144,CHO,adj. T’es.
+2145,ERIZARSE,v.i. Xíibil.
+2146,ERIZO,sus. K’i’ixpach ooch
+2147,ERIZO DE MAR,sus. K’i’ixpach ooch ja’
+2148,ERMITAÑO,sus. Ch’abtan
+2149,ERUCTAR,v.i. Kéeb
+2150,ERUCTO,sus. Kéeb
+2151,ESA,pron. dem. Lelo’
+2152,ESBELTA,adj. Toj basts’e’en
+2153,ESCALDADO,adj. Máak’an
+2154,ESCALDAR,"v.i. Máak’an., xaak."
+2155,ESCALERA,sus. Eeb
+2156,ESCALOFRÍO,sus. Xixib ke’el.
+2157,ESCALÓN,sus. Tem
+2158,"ESCAPAR, HUIR","v.i. Púuts’, púuts’ul. "
+2159,"ESCAPE, HUIDA, FUGA",sus. Púuts’ul.
+2160,ESCARABAJO PELOTERO,sus. Kuklim
+2161,ESCARBAR,"v.t. Pan, páan"
+2162,"ESCARBAR, ARAR",v.t. Buuk’.
+2163,"ESCARBAR, HACER HOYOS",v.t. K’óoy.
+2164,"ESCARBAR, LIMPIAR DE ESCOMBROS UNA CAVI",
+2165,DAD,v.t. Pa’as
+2166,"ESCARNIO, BURLA",sus. P’a’as
+2167,ESCLAVITUD,sus. Paalitsilta’alil
+2168,ESCLAVO,"sus. Palitsil, palbil, p’entak"
+2169,ESCOBA,sus. Míisib
+2170,ESCOBILLA DEL PECHO DEL PAVO,sus. Tsum
+2171,"ESCOGER, ELEGIR, SELECCIONAR","v.t. Téet, yéey"
+2172,ESCOMBROS,sus. Ta’il pak’
+2173,ESCONDER,"v.t. Balantik, ta’ak"
+2174,ESCONDER DEBAJO DE ALGO,v.t. Bal
+2175,ESCONDIDO,adj. Ta’akmauba
+2176,ESCONDITE,sus. Ta’akun
+2177,ESCOPETA,sus. Ts’oon
+2178,ESCORA DE TORTILLAS O BILLETES,adj.Ts’apab.
+2179,ESCOZOR,sus. Saak’
+2180,ESCRIBIR,v.t. Ts’íib
+2181,ESCRITURA,"sus. Wooj, ts’íib."
+2182,"ESCUCHAR, OIR","v.i. U’uy, u’ub."
+2183,ESCUCHAR DE MANERA OCULTA,v.i. Xikintaj
+2184,ESCUDO,sus. Chimal
+2185,ESCUELA,sus. Naajil xook
+2186,ESCUPIR,v.i. Túub
+2187,ESCURRIR,v.t. Tsi’itspajal
+2188,ESE,pron. dem. Lelo’
+2189,ESENCIA,sus. Yelmal
+2190,ESFUERZO,"sus. Chichil óolal, lep’óolal"
+2191,ESÓFAGO,sus. Yúule’
+2192,ESPACIO,sus. Yaambesaj. kúuchil.
+2193,ESPACIO EN LA HAMACA,sus. Xáax
+2194,ESPALDA,"sus. Pu’uch, paach"
+2195,ESPANTAJO,sus. Wenak
+2196,ESPANTAR,"v.t. Ja’as óol, jak’ óol"
+2197,ESPANTO,sus. Baba’al
+2198,ESPAÑOL,"sus. Kastlan t’aan, kastelan t’aan."
+2199,ESPARCIR,"v.t. K’iit, t’iit’, toos, t’óot’."
+2200,ESPARCIDO EN UN ÁREA GRANDE,adj. K’íik’iit.
+2201,ESPECIAL,adj. Mina’an uláak’ beyo’.
+2202,ESPECÍFICO,adj. Jach leti’.
+2203,ESPECTÁCULO,"sus. Cha’ant, cha’an"
+2204,ESPECULAR,v.i. Mana óol
+2205,ESPEJEAR,v.i. Néent
+2206,ESPEJISMO,sus. Tuus náach ja’il.
+2207,ESPEJO,sus. Néen ESPELÓN LEGUMINOSAE (VIGNA UNGUICULATA) (L)
+2208,WALP),sus. X
+2209,ESPERANZA,sus. Alab óol
+2210,"ESPERAR, AGUARDAR","v.i. Pa’at, pa’atik, páak’t"
+2211,ESPESO,adj. Tat.
+2212,"ESPESO, MUY ESPESO",adj. Ma’amaaki
+2213,ESPÍA,sus. Aj ch’uukt (m) x ch’uukt (f) ESPÍA QUE MIRA DONDE ENTRA Y SALE UNO Y QUE
+2214,TRATOS HACE,sus. Aj Ch’uukt paach.
+2215,"ESPIAR , ACECHAR","v.t. Ch’uukt, ch’úuk."
+2216,ESPIGA DE MAÍZ,"sus. Yi’ij, p’och"
+2217,ESPIGAR EL MAÍZ,"v.i. P’ochakal, p’ochajal, P’o’ochajal."
+2218,ESPINA,sus. K’i’ix
+2219,ESPINILLA,sus. Tselek
+2220,ESPIRAL,sus. Babak’
+2221,ESPÍRITU,sus. Iik’
+2222,ESPÍRITU SANTO,"sus. Kili’ich pixan, kili’ichiik"
+2223,ESPOLÓN,sus. Subin
+2224,"ESPOLVOREAR, ESPARCIR",v.t. Tóos.
+2225,ESPOLVOREAR SEMILLAS EN ERAS,v.t. T’ot.
+2226,ESPONJARSE COMO PAVO,v.i. P’olba
+2227,ESPONJADO,adj. So’oso’op’.
+2228,ESPOSA,"sus. Atan, atantsil. Mi esposa, in watan ; tu esposa, a watan ; su esposa, u yatan."
+2229,ESPOSO,"sus. Íicham, íichamtsil. Mi esposo ,in wíicham; tu esposo , a wíicham ; su esposo, u yíicham."
+2230,"ESPUELA, ACICATE",sus. Xok’ lich.
+2231,ESPULGAR,"v.t. Ch’íich’, xíit, xíixt"
+2232,ESPUMA,sus. Óom
+2233,ESPUMAR,v.i. Óomankal
+2234,ESQUELETO,sus. Chej baakel
+2235,ESQUELETO PINTADO,sus. Chamay baak ESTRELLA
+2236,ESQUINA,"sus. Ti’its, tu’uk’il."
+2237,"ESQUIVAR, EVITAR",v.i. Jeech.
+2238,ESTA,pron. dem. Lela’
+2239,"ESTABILIZAR, PONER EL PENSAMIENTO EN ASIEN",
+2240,TO,v.i.Kulkinaj tuukul.
+2241,ESTABLECER,v.i. Aantal.
+2242,ESTACA,sus. Ts’op che’
+2243,ESTALACTITA,sus. Ch’ak xiik
+2244,ESTALLIDO,sus. Wáak’
+2245,ESTAMPIDA,sus.Mul xa’ak’ yáalkab.
+2246,ESTÁN,"Ti’aan, ti’ yaan"
+2247,ESTANCADA,adj. Ets’ekbal
+2248,"ESTAR, HABER",v.i. Yaantal.
+2249,ESTAR DE CUATRO PATAS,v.i. Xaktal
+2250,ESTAR INFLADO,adj. P’op’oltal
+2251,ESTAS,pron. dem. Lelo’oba’
+2252,ESTATURA,sus. Ka’analil baakel.
+2253,ESTE,pron. dem. Lela’
+2254,"ESTE, ORIENTE",sus. Lak’iin
+2255,ESTERNÓN,"sus. P’ep’táan, p’éep’tanil."
+2256,ESTERO,sus. Uk’um
+2257,ESTERO DE MAR O RÍO,sus. Bots
+2258,ESTIBAR,v.t. Ts’aap
+2259,"ESTIBA, ESCORA",sus. Ts’aap.
+2260,ESTIMA EN QUE SE TIENE A UNO,sus. Kobol
+2261,ESTIMADO,"adj. (m) Aj yaakunta’an, Aj x"
+2262,ESTÍMULO,sus. Líik’il óol.
+2263,ESTIRAR,v.t. Saats’
+2264,ESTIRADO (MUY ESTIRADO),adj. Sáasaats’.
+2265,ESTIRAR LOS PIES,v.t. T’íinchak’
+2266,ESTÓMAGO DE LOS RUMIANTES,sus. Tsúk.
+2267,ESTÓMAGO DE LOS HUMANOS,sus. Nak’
+2268,ESTORNUDAR,"v.i. Je’esíim, je’etsíim."
+2269,ESTORNUDO,sus. Je’etsíim.
+2270,ESTOS,pron. dem. Lelo’oba’
+2271,ESTOY,"Táan, tun"
+2272,ESTRADO,"sus. Poopts’áan, ts’am"
+2273,ESTRANGULAR,v.t. Bits’ kaal
+2274,ESTRELLA,sus. Eek’
+2275,ESTRELLA DEL NORTE O POLAR,sus. Xaman
+2276,ESTRELLAR,"v.t. Pak ch’iintaj, week’"
+2277,ESTREÑIMIENTO,sus. K’aal ta’
+2278,ESTRUCTURA,sus. U wíinkilil.
+2279,ESTUCO,sus. Pak’ bitun
+2280,ESTUDIANTE,"sus. Aj káanbal, J"
+2281,ESTUDIAR,"v.t. Xook, kanbal."
+2282,ESTUDIO,sus. U kúuchil xook.
+2283,ESTÚPIDO,adj. Maknal
+2284,ESTUPRO,"sus. Sat suju’uyil, jaat suju’uyil"
+2285,ETERNAMENTE,adv. de t. Maxulik’iin
+2286,"ETERNO – adj Junk’ul, ma’ jaway, ma’ xulum",te’
+2287,EVADIR,v.t. Xáak’abt
+2288,EVAPORAR,"v.i. Saap’, k’osmal."
+2289,EVITAR,v.t. Weet’.
+2290,EXACTO,adj. P’elech
+2291,EXAMEN,"sus. Tumut, túuntaj ka’anbale’, p’iis káanbal."
+2292,EXAMINAR,"v.t. Túumtaj, túuntaj."
+2293,EXCAVAR,v.t. Páan
+2294,EXCESIVO,adv. de c. Maanal
+2295,EXCESO,sus. Tip’a’an.
+2296,EXCITACIÓN,sus. Ko’il
+2297,EXCOMULGADO,"sus. Aj tsakom, aj ak’ayil"
+2298,EXCREMENTO,sus. Ta’
+2299,EXIGIR,v.t. Yaayantik.
+2300,EXISTIR,"v.i. Aantal, yaantal"
+2301,EXPERIENCIA,"sus. Pak’ tumut, túuntajil."
+2302,EXPLICACIÓN,sus. U tsoolil.
+2303,EXPLICAR,v.t. Tsool.
+2304,EXPLORAR UN LUGAR CON INTERÉS,v.t.Uéej.
+2305,"EXPLOTAR, ESTALLAR",v.i. Wáak’al.
+2306,EXPRESAR,v.t. A’al.
+2307,EXPRIMIDO,adj. Yets’bil
+2308,EXPRIMIR,v.t. Yeets’.
+2309,ÉXTASIS,sus. Sa’at óol
+2310,EXTENDER,"v.t. Jayba, sin, jaik’iint, jaay."
+2311,EXTENDER VARIAS VECES ALGO,v.t. Xíixiit’.
+2312,EXTENDER O ABRIR LO DOBLADO,v.t. Xiit’
+2313,"EXTENDERSE, REGARSE",v.i. Jáayal.
+2314,EXTENDIDA COMO PLASTA,adj. Jenekbal
+2315,EXTERMINAR,v.t. Xu’ulsik
+2316,EXTRAER MIEL DE ABEJA,"v.t. Púus, jóok’saj kaab"
+2317,"EXTRANJERO, CABALLERO",sus. Ts’uul
+2318,EXTRAÑAR,v.t. Maklaj
+2319,"EXTRAVIARSE, PERDERSE",v.i. Sa´atal
+2320,EXTREMO DE LA MILPA,sus. Xu’uk’il.
+2321,"EXTREMO, LADO",sus. Tséel.
+2322,FÁCIL,"adj. Chéen ch’a’abil, ma’ talami’"
+2323,FACILITAR DINERO O ALGUNA COSA,"v.t. Páay, k’inam"
+2324,FEROZ (BESTIA BRAVA Y FIERA),"adj. Ts’íik, aj majan. maan."
+2325,FACTURA,"sus. U ju’unil koonol, u ju’unil"
+2326,FAISÁN,sus. K’anbul
+2327,FAJA,sus. K’aax nak’
+2328,FAJINA,sus. Múuch’ meyaj
+2329,FALO,"sus. Keep, toon"
+2330,FALTAR,"v.i. Mana’an, mina’an, na’antal."
+2331,FAMILIA,"sus. Ch’i’ibalil, láak’tsilil, kuchkabal"
+2332,FAMILIAR,"sus. Láak’, láak’tsil"
+2333,FANFARRÓN,"adj. Sakach, ko’ chi’"
+2334,FANTASMA,sus. Áak’ab kulenkul
+2335,FARDO,sus. Kuuch
+2336,FARINGE,sus. Yúul
+2337,FARO,"sus. Tajche’ k’áanáab, U no’oj beej chemnáal, mumutsil sáasil k’aa’náab."
+2338,FAROL,sus. Ch’úuyubsáas
+2339,FASTIDIAR,v.t. Toop
+2340,FATIGA,"sus. Ok’om óolal, ka’ana’anil."
+2341,FAVOR,"sus. Anat , mamakbo’oy , meent uts."
+2342,FAVORECER,v.t. Boch’besaj
+2343,FECUNDAR,v.t. Tsay
+2344,FECHA,sus. K’iin.
+2345,FELICIDAD,sus. Ki’imak óolal
+2346,FELICITACIÓN,sus. Peulil
+2347,FELONÍA,sus. K’eban t’aan
+2348,FÉMUR,sus.Chakbakel
+2349,FEO,adj. K’aas
+2350,FERMENTAR,"v.i. Omankal, pajtal"
+2351,FERROCARRIL,sus. Wakax k’áak’
+2352,FERVOR,sus. Ts’a óolal
+2353,FETIDEZ,sus. Tu’ bookil.
+2354,FÉTIDO,adj. Tu’
+2355,FETO,"sus. Balnak’ , baalnak’il"
+2356,FIBRA DE HENEQUÉN,sus. Sóoskil
+2357,"FIBROSO, DIFÍCIL",adj. Ts’u’uy
+2358,FIEBRE,"sus. Chakawil, chawakil, chokwil,"
+2359,FIEBRE QUE QUEMA,sus. T’at’abki
+2360,FIEBRE TERCIANA CON FRÍO O CON CALENTURA,chokuil sus. Yax ke’el
+2361,"FIERRO, HIERRO",sus. Máaskab.
+2362,FIESTA,"sus. Cha’an, cha’ant, mánk’iinal, mánk’iinalil, ki óotsilil K’iinbesaj."
+2363,FIESTA DE GUARDAR,sus. Ta’akumbilo’ob
+2364,FIGURA,"sus. Oochel, wíinkilis"
+2365,FIJAR,v.t. Tak’
+2366,FIJO,adj. Muuk’a’an
+2367,FILA,"sus. T’is, t’isil, tsool"
+2368,FILO,sus. Yeej
+2369,FILÓSOFO,sus. J miats
+2370,FILTRAR,"v.i. T’aj, xix,"
+2371,FIN,"sus. Cheel, ts’o’ok"
+2372,FINAL,"sus. Xu’ul, xuul."
+2373,"FINALIDAD, UTILIDAD","sus. Beelal, biilal."
+2374,FINALIZAR,"v.t. Xu’ul, ts’o’okbesaj"
+2375,FINGIDOR,"adj. Aj ken k’oj, J ken k’oj"
+2376,FINGIDORA,"adj. Ix ken k’oj, X ken k’oj."
+2377,FINO,adj. Mamaykij
+2378,FIRMA,sus. Joron ts’íib.
+2379,FIRMAR,"v.t. Chikibelsaj, joron ts’íib."
+2380,FIRME COMO EDIFICIO,"adj. Muuk’a’an, chich ets’ekbal."
+2381,FIRMEMENTE,adj. Chich ets’ekbal
+2382,FIRMEZA,sus. Jets’il
+2383,FIRMEZA Y CONSTANCIA,sus. Jun xotoma
+2384,"FISCALIZAR, VIGILAR EL INGRESO",v.t. P’ix náaja
+2385,FISURA,sus. Teejel
+2386,"FLÁCIDO, SIN FUERZA PARA ERGUIRSE",adj. Jóo
+2387,FLACO,"adj. Ts’oya’an, bek’ech, k’ak’al baak."
+2388,FLAGELAR,v.t. Jaats’
+2389,FLAMA,sus. Yaak k’áak`
+2390,FLAQUEZA DE ÁNIMO,sus. Tseem óolal.
+2391,FLAUTA,sus. Chul
+2392,FLECHA,"sus. K’aax jalal,"
+2393,FLOJERA,sus. Mak’óolil.
+2394,FLOJO,"adj. Mak’óol, jooy keep, meelen keep. te’"
+2395,FLOR,"sus. Lool, nikte’."
+2396,FLOR DE MAYO (PLUMERIA ALBA L),sus. Saknik
+2397,ET ARN),sus. Chaklolmakal
+2398,FLORECER,"v.i. Loolankil, loolankal"
+2399,FLORECER EL MAÍZ,v.i. Jekankil
+2400,FLOTAR,v.i. K’ak’aknak
+2401,FLUIR SUAVEMENTE,v.i. Yiyibankil
+2402,FLUJO DE SANGRE POR LA NARIZ,sus. X k’ulimkan
+2403,FOGAJE,sus. K’áak’
+2404,FOGÓN,sus. K’óoben
+2405,FONDO,sus. Yit
+2406,FORASTERO,"sus. J táanxenil, j ma’ wayil"
+2407,FORCEJEAR,"v.t. P’iislant, p’iisbaj, p’iis muuk’o’ob."
+2408,FORCEJEAR POR SOLTARSE,v.i. Chopayba
+2409,"FORMA, FIGURA",sus. Patul. FORMADA (SE APLICA A LA MUJER DE PROPORCIONES 
+2410,ARMONIOSAS),adj. K’úuk’uutki.
+2411,FORMAR MONTONES,v.t. Tutukal
+2412,FORMAR OVILLO,v.t. Wóol
+2413,FORNICAR,"v.t. Pak’ k’eban, ko’il"
+2414,"FORRAR, CUBRIR",v.t. Piix
+2415,FORTALEZA,"sus. Muk’óolalil, pa’, tulum"
+2416,FORTALEZA DE ÁNIMO,adj. Jich’ óolal
+2417,FORTALEZA DE UNA COSA,sus. Chichil
+2418,FORTIFICAR,v.t. Lem
+2419,FORTIFICAR ALGUNA COSA,v.t. Cheeb
+2420,FORTUNA,sus. Ayik’alil
+2421,FÓSFORO,sus. Jiri’ich joop
+2422,FOSA,sus. Mok’och.
+2423,FOSO,"sus. Bekan, ok’op lu’um"
+2424,FOTOGRAFÍA,"sus. Oochel, etpatkunaj"
+2425,FRACTURA,sus. Kaach
+2426,FRAGANCIA,sus. Ki’ibokil
+2427,FRÁGIL,adj. Kakachki
+2428,"FRÁGIL, QUE SE LASCA CON FACILIDAD",adj. Ts’éets’e’ejki.
+2429,FRASCO,sus. Chan sáasil p’úul.
+2430,FRATRICIDA,sus. J kíimsaj láak’
+2431,FRECUENTE,adj. Mantats’
+2432,FRECUENTEMENTE,adv. de t. Chich muuk’
+2433,FREÍR,v.t. Tsaaj
+2434,FRENESÍ,sus. Koo’ tamkas
+2435,FRENTE,prep. Aktáan.
+2436,FRENTE (PARTE DE LA CABEZA),sus. Táan jo’ol.
+2437,FRESCO,"adj. Áak’, síis óol."
+2438,FRESCURA,sus. Síist’ube’ FRESCURA Y SOMBRA QUE HACEN LOS ÁRBOLES
+2439,GRANDES,sus. Síisal
+2440,FRIJOL (PHASEOLUS SPP),sus. Bu’ul
+2441,FRIJOL DE LIMA (PASHEOLUS LUNATUS),sus. Ib
+2442,FRÍO,"sus. Ke’el, síis"
+2443,FRITO,adj. Tsaajbi
+2444,FROTAR,v.t. Jaax
+2445,FROTAR APLICANDO UN POLVO,v.t. Ku’ult
+2446,FRUTO,"sus. Ich, u yich che’. FRUTO ESFÉRICO DE PERICARPIO DURO QUE SIRVE"
+2447,PARA CONSERVAR SUAVES Y CALIENTES LAS TOR,
+2448,TILLAS,sus. Leek
+2449,FUEGO,sus. K’áak’
+2450,FUEGO CONSUMIDO,sus. Jabal
+2451,FUENTE,sus. Sayabil
+2452,FUERA,"sus. Junpachil, táankab"
+2453,FUERTE,"adj. Muuk’a’an, muuk’náal"
+2454,"FUERTE (SE UTILIZA PARA EL VIENTO, LA LLUVIA)",adv.
+2455,FUERZA,"sus. Chichil, k’inam, lox t’aan, de m. K’aam muuk’, yail"
+2456,FUERZA DE HOMBRE FUERTE,sus. Lox t’aan
+2457,FUERZA PARA HACER ALGO,sus. Kal
+2458,FUGA,sus. Púuts’ul
+2459,FUGAR,v.i. Púuts’
+2460,FUGARSE,v.i. Púuts’ul
+2461,FUMAR,v.t. Ts’u’uts’
+2462,FUNDA,sus. Piix
+2463,FUNDAMENTAL,"adj. Jach k’a’abéet, k’abéet."
+2464,FUROR,sus. Lep’ óol
+2465,FUSILAR,v.t. Ts’oon
+2466,FUSTÁN,sus. Piik
+2467,GAJO O RAMA,"sus. K’ab che’, xa’ay che’, jéek’ che’."
+2468,GAJO Y DESGAJAR UNA RAMA,sus. Jéek’
+2469,GALARDÓN,sus. Makul
+2470,GALLINA,"sus. X káax, káax"
+2471,GALLINA CLUECA,"sus., adj. X si’is ook káaxo’."
+2472,GALLINERO,sus. So’oy
+2473,GALLO,sus. T’eel
+2474,GANADERO,sus. Yuumil wakaxo’ob
+2475,GANADO VACUNO,sus. Wakax
+2476,GANANCIA,sus. Náajal
+2477,GANAR DINERO,v.t. Náajalt
+2478,"GANAR, VENCER","v.t. Ts’áanchek, ts’áanchak’."
+2479,GANAR VARIAS VECES,v.t. Jóojo’och.
+2480,GANCHO PARA BAJAR FRUTAS,sus. Kóokool
+2481,GANGLIO DEL SOBACO O DE LA INGLE,sus. Ma’aj
+2482,GARGANTA,"sus. Kaal, bab kaltaj"
+2483,GARGANTA CORTA,sus. Kulkaal
+2484,GARRA,sus. Iich’ak
+2485,GARRA DE LOS FELINOS,sus. Mo’ol
+2486,GARRAFÓN,sus. Sáasil p’úul
+2487,GARRAPATA,sus. Peech
+2488,GARZA BLANCA,sus. Sak bok
+2489,GASTAR,"v.t. Nojmal, xuup"
+2490,GASTAR POR GASTAR DINERO O ALGUNA COSA,v.t. Xúuxuup.
+2491,GASTO,sus. Xuup.
+2492,GATEAR,v.i.Juuk’
+2493,GATO,sus. Miis
+2494,GAVILÁN,"sus. Ch’úuy, i’"
+2495,GEMELO,sus. Iich 
+2496,GEMIDO,sus. Áakam
+2497,GENTE,"sus. Máak, máako’ob."
+2498,GENTE QUE TIENE UNO A SU CARGO,sus. Kuchka
+2499,GERMINAR,"v.i. Top’ol, jok’ol."
+2500,GESTO,sus. Eets’
+2501,GIBA,sus. P’uus
+2502,GIGANTE,"sus. Wa paach, wa’n chak, chawak ach wíinik"
+2503,GIRAR,v.i. Pirin suut
+2504,"GIRAR, VOLTEAR, REGRESAR",v.i. Suut.
+2505,GLIFO,sus. Wooj
+2506,GLORIA,"sus. Ki’ ki’ óolal, tepalil, nojbe’enil."
+2507,GLOTONA,"adj. X balnak’, x banban janal."
+2508,GLOTÓN,"adj. Aj balnak’ , aj banban janal"
+2509,GLOTONERÍA,"sus. Bal nak’il, balta’achil"
+2510,GLÚTEO,sus. P’u’uk iit
+2511,GOBERNADOR,"sus. Aj belnal, aj mek’tan"
+2512,GOBERNANTE,"sus. Jalach wíinik, nojoch jaa"
+2513,GOBIERNO,sus. Mek’tan mail
+2514,GOLONDRINA,sus. Kusam
+2515,GOLPE QUE SE DA A COSAS HUECAS,sus. Boj
+2516,GOLPEADO O AZOTADO VARIAS VECES,adj. Jáajaats’an.
+2517,GOLPEAR,"v.t. jaats’, k’ool, k’op, kooj"
+2518,"GOLPEAR, APISONAR, ABATANAR",v.t. Kooj.
+2519,GOLPEAR CON EL PUÑO,v.t. Loox
+2520,GOLPEAR CON LA PALMA DE LA MANO,v.t. Laaj
+2521,GOLPEAR CON LOS NUDILLOS,"v.t.Boboj, k’op."
+2522,GOLPEAR CON MARTILLO,v.t.K’op yéetel bajab.
+2523,GOLPEAR POR GOLPEAR,"v.t.Báabaaloox. GOLPEAR, ROMPER O DESHACER A GOLPES ALGO"
+2524,DURO,v.t. Baax.
+2525,GOLPEAR VARIAS VECES,v.t. P’úup’uuchbil.
+2526,GONORREA,sus. Puj tu bell wiix
+2527,GORDO,"adj. Polok, werek’, p’urux, p’uk’us."
+2528,GORDITO,"adj. Kukutki, yúujúus."
+2529,"GORJEAR, CANTAR",v.i. K’aay.
+2530,GOTA,sus. X t’un
+2531,GOTA DE AGUA O DE LICOR,"sus. X t’un, t’aj, ch’aj"
+2532,GOTA PEQUEÑA,sus. T’un
+2533,GOTEAR,v.i. Ch’aaj
+2534,GOTERO,sus. Ch’aaj
+2535,GRACIA,"sus. Chich óolal, ts’aabilaj"
+2536,"GRACIA, DÁDIVA",sus. Ts’aabilaj
+2537,GRACIAS,"sus. Niib óolal, Ki’ichkelem Yuum bo’otik, Yuum bo’otik."
+2538,GRACIOSO AL HABLAR,adj. Ki’ki’ t’aan.
+2539,GRADA,sus. Tem
+2540,GRADA PARA SUBIR,sus. Tem
+2541,GRAJO,sus. K’a’aw
+2542,GRAN SEÑOR,sus. Ajau
+2543,GRANDE,"adj. Nojoch, noj, nonoj, nuuk."
+2544,GRANDES,adj. Plural. Nukuch
+2545,"GRANDES, COSAS GRANDES",adj Núunuuktal.
+2546,GRANDEZA,"sus. Lakam, nojil"
+2547,GRANERO,"sus. Ch’iil, kumche’"
+2548,GRANIZAR,"v.i. K’áaxal bat, batil ja’"
+2549,GRANIZO,sus. Bat
+2550,GRASA,sus. Tsaats
+2551,GRASA QUE LE SALE AL PIPIÁN Y A OTRAS COMIDAS,sus. Yek’
+2552,GRASOSO,adj. Ch’ach’alkij
+2553,GRATIS,"adj. X ma’ bo’oli’, mix bo’oli’."
+2554,GRATUITO,adj . Chéen siibil
+2555,GRAZNIDO,sus. Jolk’olok
+2556,GRILLO,"sus. J máas, máas"
+2557,GRIS,"adj. Éek’ popos, sak boox, sak éek’"
+2558,GRITAR,v.i. Awat
+2559,GRITAR ALOCADAMENTE,v.i.Táataaj awat. GUSTAR
+2560,GRITO,sus. Awat
+2561,GRUESO,adj. Piim
+2562,"GRUESO, MUY GRUESO",adj. Píimpiin.
+2563,GRUPO,sus. Múuch’.
+2564,GRUTA,sus. Áaktun
+2565,GUACAMAYA,sus. Moo
+2566,GUACAMAYO,sus. Xoop
+2567,GUAJOLOTE,"sus. Tso’, úulum"
+2568,GUANÁBANA [ANNONCEAE (ANONA MURICATA L)],"sus. Tak’oop, k’iix pa’ach oop. GUANACASTE [ENTEROLUBIUM CYCLOCARPUM (JACQ)] ."
+2569,GUANO,sus. Xa’an
+2570,GUARAPO,sus. Sa’il moom
+2571,GUARDAR,"v.t. Li’is, ta’ak"
+2572,"GUARDADO, MUY GUARDADO","adj . Báabaalki, táata’ak."
+2573,GUARDAR LAS ESPALDAS,v.t. Mak paach
+2574,GUARDARRAYA,"sus. Bekab, míis jool paach."
+2575,GUARDIA,"sus. Aj ch’a’aj beej, Aj pikit beej, aj kanan beej. K’onchle’ chintok’"
+2576,GUARUMBO (CECROPIA OBTUSIFOLIA (BERT)),sus.
+2577,GUAYABA (PSIDIUM GUAJAVA L),sus. Pichi’
+2578,GUAYACÁN (GUAIACUM SANCTUM L),sus. Chun
+2579,GUERRA,"sus. K’atunyaj, muul ba’ate’el, noj ba’ate’el, nupankil"
+2580,GUERREAR,"v.t. Ba’ate’el, p’iis."
+2581,GUÍA,"sus. Aj bejil, Aj bej, Aj belbesaj."
+2582,GUIAR,"v.t. Belbesaj, joch jaban"
+2583,GUIÑAR EL OJO,v.t. May ich
+2584,GUIÑAR,v.i. Chaak’
+2585,GUIJARRO,sus. Ch’ich’il tuun.
+2586,GUIRNALDA,sus. K’aax jo’ol
+2587,GUITARRA,"sus. X t’in k’áanil páax ,Táabil páax, k’aayun che’."
+2588,GULA,"sus. Bal nak’il, balta’achil"
+2589,GUSANO,"sus. Nook’ol, x nook’ol"
+2590,GUSARAPO,"sus. Bolin, x bube’"
+2591,"GUSTAR, VER CON DELEITE",v.t. Cha’an
+2592,HÁBIL,adj. Péeka’an
+2593,HABILIDAD,sus. Its’atil pool
+2594,HABITANTE,sus. Kaajnáalil
+2595,HABITAR,"v.i. Kaaj, kaajtal, kaajlan."
+2596,HÁBITO,sus. Suukil.
+2597,HABLANTE,sus. Aj t’aan.
+2598,HABLAR,v.i. T’aan
+2599,HABLAR ALBOROTÁNDOSE,v.i. Tsay óoltaj
+2600,HABLAR EN VOZ BAJA,v.i. X muukul t’aan
+2601,HABLAR HISTÉRICAMENTE,v.i. Báabaalt’aan.
+2602,HABLAR PRIMERO,v.i. Paybe
+2603,HABLAR RIÑENDO,v.i. Tsay óoltaj
+2604,HABLAR SOLO,v.i. T’aant’aan
+2605,HABLOTEAR,v.i. Sakacht’aan
+2606,HACE TRES DÍAS,adv. de t. Óoxejeak
+2607,HACE UN AÑO,adv. de t. Jun ja’abake’
+2608,HACER,"v.t. Beet, meent, meen,"
+2609,HACER POR HACER,v.t. Báabaal meenbil.
+2610,HACER ALBARRADA,v.t. Koot
+2611,HACER ARDER LA LUMBRE SOPLANDO,v.t. Jopsaj
+2612,HACER CAMINO,"v.t. Belbesaj, jool ch’áak."
+2613,HACER CAUTIVO,"v.t. Baksaj HACER,"
+2614,CONFECCIONAR,"CONSTRUIR,"
+2615,HACER REALIDAD,v.t. Béeykuntik.
+2616,HACER RODAR,v.t. Balk’esen
+2617,HACER SANGRÍA,v.t. Tok’
+2618,HACERSE MARAVILLOSA Y MILAGROSA,adj. Maktsiljal
+2619,HACIA ABAJO,adj. Chinchin.
+2620,HACIENDA,sus. Ti’yal.
+2621,"HACIENDA, CONJUNTO DE BIENES MUEBLES E IN",
+2622,MUEBLES,sus. Ba’aba.
+2623,HACHA,sus. Báat
+2624,HALO NOCTURNO,sus. Chéelil áak’ab.
+2625,HAMACA,sus. K’áan
+2626,HAMBRE,sus. Wi’ij
+2627,HAMBRUNA,sus. Wi’ijil kiimilo’ob
+2628,HARTO,adj. Na’aj
+2629,HASTA,prep. Tak
+2630,HASTA AHORA,adv. de t. Tak walkila
+2631,HASTA MAÑANA,adv. de t. Tak sáamal
+2632,HASTA MÁS TARDE,adv. de t. Tak ka’akate’
+2633,HASTÍO,sus. Nak óol.
+2634,HAY,v.i. Yaan
+2635,HEBRA TORCIDA O HILADA EN PABILOS,sus. Máak’antik.
+2636,HECHICERO,"sus. Aj kunaj t’aan, aj kunyaj, pul v.t. Ch’ot"
+2637,HACER DE NUEVO UN TRABAJO,v.t. Líik’ meyaj HACER ALGUNA FUERTE
+2638,COSA,v.t. ya’aj Múuk’kankunsik.
+2639,HACER GESTOS O MUECAS,v.i. Eets’
+2640,HACER MONTONES,v.t. Tutukal
+2641,HACER OBRA DE MANO,v.t. K’abtaj
+2642,HACER QUE UNA COSA ABUNDANTE SE AGOTE,v.t.
+2643,HECHICERO QUE ATRAE CON SUS CONJUROS A ALGU,
+2644,NA PERSONA O ANIMAL,sus. Aj pay kun.
+2645,HECHICERO QUE CAUSA DAÑO POR MEDIO DEL AIRE,sus. Aj ch’in iik’.
+2646,HECHIZO,sus. Pul
+2647,HEDOR,"sus. Tu’, tu’ book"
+2648,HELADO,adj. Síis Ch’eejel
+2649,HELECHO,sus. Bebtun.
+2650,HEMBRA,"sus. Ch’úup, ko’olel, x ba’al"
+2651,HENDER ROMPIENDO,v.i. Jet
+2652,HENDIDURA,sus. Jet’
+2653,HENEQUÉN (AGAVE SPP),sus. Kij
+2654,HEREDAD DONDE HAY COSAS PLANTADAS,sus. aale’ paal. Páak’al Loma’an yóok’ol
+2655,HERENCIA,sus. K’aam ba’albail
+2656,HERIDA,"sus. Loob, jatlom."
+2657,HERIDO A LANZADAS O ARPONEADO,adj.
+2658,HERIDO DE MUCHAS HERIDAS,adj. Tulkintan
+2659,HERIR,v.t. Loob
+2660,HERIR CON AGUIJÓN,v.t. Julche’
+2661,HERIR CON ARMA O INSTRUMENTO PUNTIAGUDO,
+2662,HERIR O LASTIMAR EL OJO CON EL DEDO ÍNDICE,v.t. Loom v.t. Ch’oop.
+2663,HERMAFRODITA,"sus. X ch’úupul xiib, síis óol."
+2664,HERMANA,sus. Kiik
+2665,HERMANO MAYOR,sus. Suku’un
+2666,HERMANO MENOR,sus. Iits’in
+2667,HERMOSA,"adj. Jats’uts, ki’ichpam"
+2668,HERMOSO,adj. Ki’ichkelem
+2669,HERRADURA,sus. Xanab tsíimin
+2670,HERRAMIENTA,sus. Nu’ukul
+2671,HERRERO,"sus. Aj meyaj máaskab, J meyaj"
+2672,HERVIR,"v.i. Lóok, om"
+2673,HERVIR DE PERSONAS O ANIMALES,sus. To
+2674,HIELO,Sus. Síis chich ja’.
+2675,HIEL,sus. K’aaj
+2676,HIERBA,sus. Xíiw
+2677,HIERBA QUE CAUSA COMEZÓN,sus. P’óop’oox.
+2678,HÍGADO,"sus. Táaman, tamnel HIGUERA CUYA CORTEZA SERVÍA PARA HACE PAPEL (FICUS COTINIFOLIA H.B. ET K)."
+2679,HIGUERILLA (RICINUS COMMUNIS),sus. K’ooch HIJA O HIJO DE LA MUJER (SÓLO SE APLICA A LA MADRE
+2680,O SÓLO ELLA DESIGNA ASÍ A SUS HIJOS),"sus. Aal, x HOMBRE"
+2681,HIJASTRO,sus. Majan mejen paal.
+2682,HIJO (AL REFERIRSE LA MUJER),sus. A’al.
+2683,HIJO (AL HACER ALUSIÓN EL HOMBRE),"sus. Meejen,"
+2684,HIJO EN GENERAL,"sus. Paal, paalal, mejnil"
+2685,HILAR,"v.t. Jaax, k’uuch"
+2686,HILERA,sus. Tsool
+2687,HILO,sus. K’uuch
+2688,HILVANAR,v.t. Máak’a’an chuuy.
+2689,HIMNO,sus. Noj k’aay.
+2690,HINCADO,adj. Xolokbal
+2691,HINCAR,"v.i. Xolkin, xoltal."
+2692,HINCARSE,"v.i. Xoltol, xoltaj, xoltal."
+2693,HINCHADO,adj. Chuup
+2694,HINCHARSE,"v.i. Chuup, si’ip’il."
+2695,HINCHARSE EL VIENTRE DE COMIDA,v.i. Pemal.
+2696,HIPAR,v.i. Juuyub
+2697,HIPO,sus. Tuk’ub
+2698,HIPÓCRITA,"adj. Ka’ap’éel ak’, x ken k’oj"
+2699,HIPÓTESIS O SUPOSICIÓN,sus. Ch’a’ach’itika’
+2700,HISTORIA,"sus. K’ajlay, siyan"
+2701,HOCICO,sus. Ni’
+2702,HOGAR,"sus. Otoch, naaj, taanaj, naay."
+2703,HOGUERA,sus. Ban k’aák’
+2704,HOGUERA CONSUMIDA,sus. Jabal
+2705,HOJA,sus. Le’
+2706,HOJA DE LIBRO,"sus. Tsil, wáal, wáal ju’un."
+2707,HOJAS SECAS,sus. Sojol
+2708,HOLLEJO,"sus. Saay, saayel."
+2709,HOLLÍN,"sus. Sabak, yebek naaj"
+2710,HOMBRE,"sus. Máak, wíinik, xiib HOMBRE ASTUTO. sus., adj. Aj na’at ach"
+2711,HOMBRE CERTERO EN APUNTAR AL BLANCO,sus. Toj k’ab
+2712,HOMBRE DISCRETO,sus. Aj na’at
+2713,HOMBRE ENTENDIDO,sus. Aj na’at
+2714,HOMBRE FUERTE,"sus. Muuk’a’an wíinik, Aj muuk’náal."
+2715,HOMBRE ILUSTRE,sus. Aj na’at HOMBRE MÍTICO DIMINUTO HECHO DE BARRO QUE
+2716,"COBRA VIDA, CUIDA LOS MONTÍCULOS ARQUEO",
+2717,LÓGICOS Y LAS MILPAS,"sus. Alux, arux."
+2718,HOMBRO,sus. Keléembal
+2719,HOMENAJE,sus. Nojbe’enkant
+2720,HOMICIDA,sus. Kíinsaj wíinik
+2721,HONDA PARA ARROJAR PIEDRAS,sus. Yúuntun
+2722,HONDO,adj. Taam
+2723,HONDONADA,"sus. K’om, k’óom"
+2724,HONGO,"sus. Kuuxum, xuxum che’"
+2725,HONGO DE ÁRBOL,sus. Xikin che’
+2726,HORA,"sus. Tsilk’iin, lat’ab k’iin, jech ti’ k’iin, k’iintsil."
+2727,HORADAR,"v.t. Jool, poot"
+2728,HORIZONTE,"sus. Chuun ka’an, siyan ka’an."
+2729,HORMIGA,sus. Síinik
+2730,HORMIGA CARNICERA,sus. Xuulab HORMIGA NEGRA QUE SE DESPLAZA EN GRANDES
+2731,GRUPOS,sus. Saakal
+2732,"HORMIGA ROJA, DENOMINADA ARRIERA",sus. Saay che’.
+2733,HORNEAR EN LA TIERRA,"v.t. Píibt, píib."
+2734,HORNO HECHO EN LA TIERRA,sus. Píib
+2735,HORNO DE PIEDRAS,sus. Tsuk tun
+2736,HORQUETA,"sus. Ts’opche’, xa’ay che’, táak"
+2737,"HORRIBLE, QUE ESPANTA",adj. Jak’ óoltsil
+2738,HOSPEDAJE,sus. Jula kabil
+2739,HOSPEDAR,v.t. K’aam
+2740,HOSPITAL,"sus. U naajil k’oja’ano’ob, U naajil ts’aak yaaj."
+2741,HOTEL,"sus. K’aam naaj, otoch kabil."
+2742,HOY,"adv. de t. Bejela’e’, bejla’e’, bejele’,bejle’, bejla’ake’."
+2743,HOYA,"sus. K’om, k’óom"
+2744,HOYO,"sus. Jom, jool"
+2745,HOYUELO EN LA MEJILLA O EN LA BARBA,"sus. Tuux HUANO ENANO CUYAS HOJAS SIRVEN PARA TECHAR CONSTRUCCIÓN, HACER ESCOBAS, ETC (SABAL"
+2746,YAPA C (WRIGTH)),sus. Ch’iit
+2747,HUANO (THRINAX RADIATA (LOOD)),sus. Xa’an
+2748,HUANO BLANCO,sus y adj. Sak xa’an.
+2749,HUAYA (TALISIA OLIVAEFORMIS (KUNT) RADLK),sus. Wayum
+2750,HUECO,sus. Jool
+2751,HUELLA DE LOS PIES,"sus. Bilim, chek’, pe’echak’,pe’eche’"
+2752,HUELLA DE LAS MANOS,"sus. Péets’ k’ab, waay."
+2753,HUESO,sus. Baak
+2754,HUESO DE ELOTE,sus. Baakal
+2755,HUESO DE LA MAZORCA,sus. Baakal
+2756,HUESO DE UNA FRUTA,sus. Neek’
+2757,HUEVO,"sus. Je’, e’el, ye’el"
+2758,HUEVO ESTRELLADO,sus. Pa’ ch’iintaj je’
+2759,HUIPIL,sus. Iipil.
+2760,"HUIR, FUGARSE","v.i. Púuts’, púuts’ul"
+2761,"HULE (CASTILLA ELÁSTICA, CERV)",sus. K’i’ik’che’
+2762,HUMANO,"sus.Wíinik, máak."
+2763,HÚMEDO,adj Lolok
+2764,HUMILDAD,"sus. Kaabal óol, suuk óol."
+2765,HUMILDE,"sus. J nuun óol, J suuk óol."
+2766,HUMILLAR,v.t. T’oonkíisaj
+2767,HUMILLACIÓN,sus. T’oonkíinsajil
+2768,HUMO,sus. Buuts’
+2769,HUNDIR,"v.i. Búulul, lam"
+2770,HURGAR CON PALO,v.t. Julche’
+2771,HUSMEAR,v.i. Tsukul iik’taj
+2772,IDEA,sus. Tuukul.
+2773,IDENTIFICAR,v.t. K’ajóol.
+2774,IDIOMA,sus. T’aan
+2775,IDIOMA ESPAÑOL,"sus. Kastilan t’aan, kastran pom. t’aan k’ult naaj."
+2776,IGLESIA,"sus. Naaj K’uj, k’unaj, Yotoch K’uj,"
+2777,IGNORANCIA,sus. X ma’ ojelil.
+2778,IGUAL,"sus. Keet, lajket."
+2779,"IGUALAR, EMPAREJAR","v.t. Keet, keetbesik."
+2780,IGUALDAD,sus. Keetil.
+2781,IGUAL EN FUERZA,sus. Etmuuk’il
+2782,IGUALAR,v.t. Taxkun
+2783,IGUANO,sus. Juuj
+2784,IJADA,sus. Páaknak’
+2785,ILUMINAR,v.t. Sáaskun
+2786,ILUSTRACIÓN,sus. Oochel.
+2787,IMAGEN,sus. Oochel
+2788,IMAGINACIÓN,"sus. Num óol, tuukul"
+2789,IMAGINAR,"v.t. Nen óol, num óol"
+2790,IMAGINARIO,adj. Tuukulbil.
+2791,IMITAR,"v.t. Ch’a ts’ilib, joch, p’a’ast"
+2792,IMPETUOSO,adj. Seeb óol
+2793,IMPLORACIÓN,sus.Yaaj k’áatik.
+2794,IMPORTANCIA,sus. Kananil
+2795,IMPORTANTE,"adj. K’a’anan, k’a’ana’an, k’ojol, jach k’abéet."
+2796,INCESTO,sus. Panpib
+2797,INCIENSO,"sus. Jaak’, pukak’"
+2798,INCLINADO,"adj. T’oonol, chíin"
+2799,INCLINADO SOBRE ALGO,adj. Páapáak.
+2800,INCLINAR,v.t. Chíina’an
+2801,"INCLINAR, LADEAR",v.t. Ch’eeb.
+2802,INCLINARSE,"v.i. T’oon, chíinil"
+2803,INCORDIO,sus. Chu’chum
+2804,INCRUSTADO,adj. Ts’opokbal
+2805,INCRUSTAR,v.t. Tak’aj
+2806,INDAGAR,v.t. K’áat chi’
+2807,"INDICAR, MOSTRAR",v.t. E’esaj.
+2808,INDICAR CON EL DEDO ÍNDICE,v.t. Tuch’ub.
+2809,INDIFERENTE,adj. Ma’bal yóol.
+2810,INDIO,sus. Máasewal
+2811,INDIRECTAS,sus. Ch’iinch’int’aano’ob.
+2812,INDIVIDUAL,adj. Tu juun.
+2813,INERTE,"adj. Ma’ péek óol, muuk’a’an"
+2814,INFANCIA,sus. Paalil
+2815,INFIERNO,"sus. Ak’bal naj, metnal, mitnal."
+2816,INFINITO,"adj. Chaket, cheket, ma’ xulumte’, ma’ xuul."
+2817,INFLAMABLE,adj. Joojóopki.
+2818,INFLAR,"v.t. P’uru’us, p’ulu’ust"
+2819,INFORMAR,"v.t. Num chi’, num chi’tik"
+2820,INFORMACIÓN,"sus. Tsool, Nu’uksaj, num"
+2821,IMPREGNAR,v.t. Ts’am.
+2822,IMPRESO,adj. Ts’ala’an
+2823,IMPRUDENTE,adj. J ma’ kux óol
+2824,IMPUESTO,sus. Patan
+2825,INCENSARIO,"sus. Ch’uyub pukak’, ch’uyub chi’taj"
+2826,INFORME,"sus. Num chi’, tsool ts’íib. INFORTUNIO."
+2827,INFUNDIR,v.t. Oksaj tu pool.
+2828,INGENIOSO,sus. Aj numan
+2829,INGLE,sus. Je’ej
+2830,INHALAR,"v.i. Ch’a’ book, ch’a’ iik’"
+2831,INJURIA,sus. Pooch’.
+2832,INGRATITUD,sus. X ma’ niib pixanil
+2833,INJERTO,sus. K’ubche’.
+2834,INJUSTICIA,"sus. Ma’ tibil, X ma’ tojil."
+2835,INMEDIATAMENTE,"adv. de t. Ma’ muklik, tu séeblankil, jach náapulak. INMINENTE, A PUNTO DE"
+2836,SUCEDER,adv.
+2837,INMÓVIL,"adj. Ma’ péek óol, muuk’a’an, xoxo"
+2838,INQUIETO,adj. Chuklak iik’
+2839,INSCRIBIR,v.t.Ts’íib k’aaba’.
+2840,INSECTO,"sus. Yik’el, yilk’il"
+2841,INSECTO ACUÁTICO,sus. Bubul. INSECTO CON EL CUERPO LUSTROSO DE COLOR AZUL PAVO Y ALAS AMARILLENTAS. SE LE ENCUENTRA
+2842,EN TRONCOS VIEJOS SU PIQUETE OCASIONA DO,
+2843,LOR INTENSO Y TEMPERATURA ELEVADA,sus. Báalamjolom
+2844,INSERVIBLE,"adj. Laab, ma’patali’."
+2845,INSISTENCIA,sus.Tsaantsan t’aane’
+2846,INSÓLITO,adj. Ma’ napaja’an
+2847,INSOMNIO,sus. P’ix ich
+2848,INSTANTE,adv. de t. Súutuk
+2849,INSTITUCIÓN,sus. Molay
+2850,INSTRUCCIÓN,"sus. Nu’ukbesaj , tsool núuk."
+2851,INSTRUMENTO PARA ALGUNA ACTIVIDAD,sus. Nu’ukul
+2852,INSTRUMENTO PARA ESCRIBIR,"sus. Cheeb INSTRUMENTO QUE SIRVE PARA SACAR EL ELOTE DE SU ENVOLTURA EN LA COSECHA. PUEDE SER UN CUERNO DE CIERVO ENANO, UNA MADERA"
+2853,"AGUZADA, UN INSTRUMENTO DE METAL",sus. Bakche’
+2854,INSTRUMENTOS PARA ALGÚN OFICIO,sus. Yeem
+2855,INSTRUMENTO MUSICAL,sus. Páax
+2856,INSULTAR,v.t. Pooch’.
+2857,INSULTO,"sus. Pooch’, pooch’il."
+2858,INSULTAR REPETIDAMENTE,v.t. Póopooch’il
+2859,INTACTO,"adj. Báayli’e’, suju’uy"
+2860,INTANGIBLE,adj. Ma’ takabil.
+2861,ÍNTEGRO,adj. Báayli’e’
+2862,INTELIGENCIA,sus. Na’at
+2863,INTENCIÓN,"sus. Tuukul, tuukulil."
+2864,INTERÉS,sus. Ts’áaj tuukul
+2865,INTERIOR,"adv. de l. Ts’u’, ichil"
+2866,INTERPONER,v.t. Ba’alchaja
+2867,INTERROGACIÓN,sus. K’áat chi’.
+2868,INTERROGANTE,sus. K’áat chi’il.
+2869,INTERRUMPIR,v.t. Nikkabtaj
+2870,INTESTINO,sus. Chooch
+2871,INTRANQUILIDAD,sus. Chi’ichnak
+2872,INTRANQUILIZARSE,v.i. Nich’bal
+2873,INTRODUCCIÓN,"sus. Oksaj t’aanil, káajbal."
+2874,INTRODUCIR,"v.t. Oks, oksaj, ts’ot"
+2875,"INTRODUCIR, METER LA AGUJA",v.t. Juup’
+2876,"INUNDAR, AHOGARSE","v.i. Buul, búulul"
+2877,INVASOR,"sus. Aj okaj kaaj, ch’a kaaj"
+2878,INVENTAR,v.t. Meen.
+2879,INVESTIGACIÓN,sus. Kaxan tsikbal
+2880,INVIERNO,"sus. Ak’ ya’abil, ich ke’el"
+2881,INVISIBLE,adj. Ma’ ilbil.
+2882,INVITAR,"v.t. Payalte’et, payal óol, pay óol, pay t’aan."
+2883,INVOCAR,"v.i. Awat pay, awat paytaj."
+2884,"INVOLUCRAR, PARTICIPAR",v.t. Táakpajal.
+2885,INYECCIÓN,sus. Juup’ ts’aak.
+2886,INYECTAR,v.t. Juup’
+2887,IR,"v.i. Biin, xi’ik."
+2888,IR EN COMPAÑÍA DE OTRO,"v.t. Éetbenel, éet"
+2889,IR TRAS ÉL,v.t. Ch’a ok
+2890,IRA,"sus. K’uuxil, lep’ óolil, p’uujil, ts’íikil."
+2891,ISLA,sus. Petén
+2892,IZQUIERDA,adj. Ts’íik
+2893,JABALÍ (PECARI TAYASSU),sus. Kitam
+2894,JABÍN (PISCIDIA PISCIPULA (L) SARG),sus. Ja’abin
+2895,JACAL,"sus. Naaj, pasel (choza sencilla de un alero o dos, que se hace en la milpa para descanzar o para vigilar.)"
+2896,JADE,"sus. Tuun, ya’ax tuun"
+2897,JADEAR,"v.i. Jéesbal, jéesbaj"
+2898,JAGUAR,"sus. Báalam, chak mo’ol"
+2899,"JALAR, SEPARAR",v.t. Kóol
+2900,JALAR,"v.t. Jáanpaytik, páay."
+2901,JALAR POR BRAZADA PARA SACAR AGUA DEL POZO,v.t. Sáasáap.
+2902,JALAR AGUA DE POZO,v.t. Páay ja’.
+2903,JAMÁS,adv. de t. Mix bik’iin
+2904,JARANA,"sus. Paax k’ool, síit’ óok’ot."
+2905,JARDÍN,sus. Páak’alnikte’
+2906,JARRA,"sus. Buleb, chan p’úul"
+2907,JARRO,sus. Buleb
+2908,JASPEADO,adj. Wewel JÍCAMA (LEGUMINOSAE PACHYRAHIZU EROSUS (L)
+2909,JÚBILO,sus. Ki’imak óolil.
+2910,JUEGO,"sus. Báaxalnen, báaxal"
+2911,JUEGO DE AZAR,sus. Buul
+2912,JUEGO DE PELOTA PREHISPÁNICO,sus. P’okta
+2913,JUGAR,v.t. Báaxal
+2914,JUGAR TROMPO,v.t. T’óoch.
+2915,JUGO,sus. K’aab
+2916,JUICIO,"sus. Kux óol, kuxóolal, na’at, xoot"
+2917,JUNCIA,sus. Semet’
+2918,JUNTAR,"v.t. Múuch’, mool, nup"
+2919,JUNTAR LOS LEÑOS PARA HACER MÁS FUEGO,v.t.
+2920,JUNTAR O LLEVAR EMPUÑADO,v.t. Lóot.
+2921,JUNTARSE,"v.i. Bantak, bantal"
+2922,JUNTO,"adv. de l. Naak’, múul, yiknal, tu"
+2923,JUNTOS,adv. de m. Pa’ate’
+2924,"JUNTOS, MUY APRETADOS",adv. de m. p’ok k’iin Nuuch. tséel
+2925,URBAN),sus. Chi’ikam Pe’epe’ech’ki.
+2926,JÍCARA (CRESCENTIA CUJETE L),sus. Luuch
+2927,JINETE,"sus. Aj naat’, Aj léej wakaxo’"
+2928,JOROBA,sus. P’uus
+2929,JOVEN,"sus, adj. (m) Xi’ipal, táankelem (f)X ch’úupal, X lo’bayan, X lo’bayen."
+2930,JOVEN DE LA NOBLEZA,"sus. (m)J ajauil, (f) X"
+2931,JURISDICCIÓN,sus. Mek’tan kaajil
+2932,JUSTICIA,"sus. Tibil, tojil"
+2933,JUSTO,"adj. Tibil, tojil"
+2934,JUVENTUD FEMENINA,sus. X lóobaymil
+2935,JUVENTUD MASCULINA,sus. J Táankelmil
+2936,JUZGAR,"v.t. Ts’áaj, yaya tse’ ktaj, p’iis óol. ajauil. JUZGAR"
+2937,LABERINTO,sus. Satun sat.
+2938,LABIO,sus. Booxel chi’
+2939,LABORAR,v.i. Meyaj
+2940,LABRAR MADERA,v.t. Póol che’
+2941,LABRAR MADERA SACÁNDOLE PUNTA,v.t. Bits’
+2942,LADEADO,adj. Nixa’an
+2943,LADEADO,Tséetséel.
+2944,LADEAR,"v.t. Nix, tseltal."
+2945,"LADEAR, INCLINAR",v.t. Ch’eeb
+2946,"LADEAR, DESVIAR, TORCER",v.t. K’eech.
+2947,LADO,"adv. de l. Tséel, tséelil, xáax"
+2948,LADO DE LA CAMA O DE LA HAMACA,"sus. Xáax, t’uub."
+2949,LADRAR,v.i. Chi’ibal peek’
+2950,"LADRAR EL PERRO, PERSIGUIENDO A ALGÚN ANI",
+2951,MAL,v.i. Tóojol
+2952,LADRÓN,sus. Ookol
+2953,LAGAÑA,sus. Ch’eem
+2954,LAGARTIJA,"sus. Bebech, meemech."
+2955,LAGARTIJA VERDE CON CRESTA,sus. Tolok
+2956,LAGARTO,"sus. Áayin, áaim, juuj (Hondzonot, municipio de Tulum, Q. Roo.)"
+2957,LÁGRIMA,sus. Ja’il ich
+2958,LAGUNA,sus. Áak’al che’
+2959,LAJA,sus. Chaltun
+2960,LAMA O MOHO VERDE DE LA TIERRA HÚMEDA Y SOM,
+2961,BRÍA,sus. Ya’ax k’oxmal
+2962,LAMENTO,"sus. Akanjal, ok’ol."
+2963,LAMER,v.t. Léets’
+2964,LAMPIÑA,adj. Biirich
+2965,LANA,sus. U tso’otsel taman.
+2966,LANGOSTA DE MAR,sus. Chakay. 
+2967,"LANGOSTA, INSECTO QUE ES PLAGA PARA LA AGRI",
+2968,CULTURA,sus. Sáak
+2969,LANZA,"sus. Tsopche’, julte’, nabte’"
+2970,LANZAR,v.t. Ch’iin
+2971,LANZAR CON ÍMPETU,v.t. Tojlaj
+2972,"LÁPIDA, LOSA, LAJA",sus. Tsal
+2973,LÁPIZ,sus. Ch’ilib ts’íib
+2974,LARGO,adj. Chowak
+2975,LARGO RATO,"adv. de t. Sam, same’, samak."
+2976,LASCA,sus. Xeet’
+2977,LASCAR,v.t. Ts’eej.
+2978,LASCADO,adj. Ts’éets’eej.
+2979,LÁSTIMA,sus. Men óolal
+2980,LASTIMAR,"v.t. K’iil, toop, k’ii"
+2981,"LASTIMARSE, HERIRSE",v.i. Ki’impajal.
+2982,"LASTIMADO, MUY LASTIMADO",adj.Pu’upu’uch
+2983,LÁTEX,sus. Iits
+2984,LATIGAZO,sus. Jaats’
+2985,LATIR,v.i. K’i’inam
+2986,"LATIR EL PULSO, SALTAR COMO LOS NERVIOS",v.i. Titip’ánkil
+2987,LAVANDERA,sus. Ix p’o’
+2988,LAVANDERO,sus. J p’o’.
+2989,LAVADO,sus. P’o’.
+2990,LAVAR,v.t. P’o’
+2991,LAZAR,v.t. Léej
+2992,LAZO,sus. Jook’.
+2993,"LECCIÓN, LECTURA",sus. Xook
+2994,LECTO,ESCRITURA.
+2995,LECHE,sus. K’aab iim
+2996,LECHONA,sus. Ch’úupil k’éek’en
+2997,LECHUZA (GLAUCIDIUM),sus. T’oojka’ x nuuk
+2998,"LEER, ESTUDIAR, CONTAR",v.t. Xook
+2999,LEGUA (MEDIDA DE LONGITUD DE CUATRO KILÓME,
+3000,TROS),sus. Lub
+3001,LEJANO,Adj. Náach.
+3002,LEJOS,adv. de l. Náach
+3003,LENGUA,sus. Aak’
+3004,LENGUAJE,sus. T’aan.
+3005,LENTAMENTE,"adv. de m. Chaanbéelil, cha"
+3006,LEÑA,sus. Si’
+3007,LEÑAR,v.t. Si’intik.
+3008,LEPRA,"sus. Jaway, chachak uay"
+3009,LETRA,sus. Wooj
+3010,LEVADURA,sus. Paj sakan
+3011,LEVANTAR,"v.t. Líik’, li’is LEVANTAR SUSPENDIENDO CON LAS DOS MANOS"
+3012,UNA JÍCARA,v.t. Láat’
+3013,LEVANTAR O ENCENDER LA GUERRA,v.t. Tsay
+3014,LEVANTAR PUEBLOS,"v.t. Líik’saj kaajtal, líik’saj k’atun kaajo’ob."
+3015,LEY,sus. A’almaj t’aan.
+3016,LEY DEL PONTÍFICE,sus. Ya’almaj t’aanil ajaw
+3017,LEY DEL REY,sus. Ya’almaj t’aanil ajaw.
+3018,LIADA APRETADAMENTE,adj. Jep’ LIANAS O BEJUCOS FLEXIBLES Y RESISTENTES QUE SIRVEN PARA AMARRAR LA ESTRUCTURA DE LA
+3019,CASA,sus. Aanikab
+3020,LIBÉLULA,"sus. Xtulix, xturix"
+3021,"LIBERACIÓN, SALVACIÓN",sus. Tóoksajil.
+3022,"LIBERTADOR, SALVADOR",adj. Aj tóoksajil
+3023,"LIBERAR, SOLTAR",v.t. Jáalk’ab
+3024,LIBERTAD,"sus. Síij óol, jalk’abil, jáalk’a’abil"
+3025,LIBRAR ARREBATANDO,v.t. Tóok
+3026,LIBRAR QUITANDO,v.t. Tóok.
+3027,LIBRARSE DE CARGO,"v.i. Sip ik’, mak k’och"
+3028,LIBRARSE DE LO QUE LE IMPUTAN,v.t. Mak k’och
+3029,LIBREMENTE,adv. de m. Síij óolal
+3030,LIBRO,"sus. Ánaltee’, pikju’un, salbiju’un"
+3031,LÍDER,"sus. Jalach, poolil, jo’olil, jo’ol póop."
+3032,LIEBRE,sus. Tsuub
+3033,LIJAR,v.t. Jix LOCO
+3034,LIMA,"sus. Jaab, juux, jóoch."
+3035,LIMADO,"adj. Jii’an,ji’ix kaya’an."
+3036,LIMAR,"v.t. Jaab, jáay."
+3037,LÍMITE,sus. Xuul
+3038,LIMOSNA,"sus. Yatsil, ts’ayatsil."
+3039,LIMPIADA DE SUCIEDAD,adj. Pita’an
+3040,LIMPIAR,v.t. Bili’in.
+3041,"LIMPIAR, ESCOMBRAR",v.t. Ch’óoch’.
+3042,LIMPIAR CON PAPEL O TELA,v.t .Cho’oik.
+3043,LIMPIAR sacudiendo,v.t. Púust.
+3044,LIMPIAR UN PLATO O UNA VASIJA,v.t. Chúul.
+3045,"LIMPIO, SIN HIERBA",adj. Bibilki.
+3046,LIMPIO,adj. Ma’ éek’i’
+3047,"LIMPIO, SIN POLVO",adj. Pu’upu’uski.
+3048,"LIMPIO, VACÍO",adj. Jojochil.
+3049,LIMPIO DEL CUERPO,adj. Kekexkij.
+3050,LIMPIO REFIRIÉNDOSE A CASA,"adj. Míisa’an LIMPIO, MUY LIMPIO. Bíibíilki."
+3051,LINAJE,"sus Ch’i’ibal, olom"
+3052,LINDERO,sus. Ektolol
+3053,LÍNEA,sus. T’o’ol
+3054,LIQUEN,sus. Me’ex cháak.
+3055,LISO,"adj. Táax, babayki"
+3056,"LISO, MUY LISO",adj. Báabayki.
+3057,LISO Y RESBALOSO,adj. Ts’íits’iiki.
+3058,LISONJERO,adj. Aj bay pool
+3059,LISTA,sus. Wewel
+3060,LISTA DE PERSONAS,sus. Tsool k’aaba’ob
+3061,LISTADO DE COLORES,adj. Wewel
+3062,LISTO,adj. Ts’o’ok beyo’
+3063,"LISTO, ATENTO","adj. P’il ich., ts’aaj óol"
+3064,LITERA PARA VIAJAR,sus. Pepem che’
+3065,LITORAL,"sus. Jáal já, chi’ ja’"
+3066,LIVIANO DE PESO,adj. Sáal
+3067,LODAZAL,sus. Ts’oots’oopki.
+3068,LO MÁS FUERTE Y DURO DE LA MADERA DE UN ÁR,
+3069,"BOL, EL CORAZÓN DEL ÁRBOL",sus. Chulul
+3070,LO MÁS IMPORTANTE,sus. Noj lail
+3071,LO QUE HA DE SER PROMOVIDO,sus. Kulkinbil
+3072,LOCALIDAD,sus. Kaaj.
+3073,LOCALIZAR,v.t. Kaxan
+3074,LOCO,"adj. Choko pool, choko jo’ol, saatal"
+3075,LOCOMOTORA,"sus. Tsíimin k’áak’, wakax múuk’."
+3076,LOCUTOR,sus. Aj num chi’
+3077,LODO,sus. Luuk’.
+3078,LOGRAR,"v.t. Náajal, najmat, chuuk."
+3079,LOMA O MÉDANO DE ARENA,"sus. Tséel ka’anil k’áanab, tséel ka’an."
+3080,LOMBRIZ DE TIERRA,sus. Lukum kaan
+3081,LOMO,"sus. Paach, pu’uch"
+3082,"LOMO , ESPINAZO DE CUALQUIER CUADRÚPEDO",bil sus. Sibnel.
+3083,LORO,"sus. T’uut’, x t’uut’"
+3084,LOTE BALDÍO,sus. X tokoy
+3085,LUCERO DE LA MAÑANA,"sus. Aj ajsaj, kab eek’, noj eek’, xuux eek’"
+3086,LUCIÉRNAGA,sus. Kóokay
+3087,LUCHAR CUERPO A CUERPO,"v.t. P’iisba, p’iislam"
+3088,"LUCHAR, DEBATIR, PELEAR","v.t. Paaklam muuk’. P’iislam muuk’,"
+3089,LUEGO,adv. de t. Ka’ tun
+3090,LUEGO QUE,adv. de t. Kitak
+3091,LUGAR,sus. Kúuchil
+3092,"LUGAR DE MALEZA, BREÑAS Y ESPINAS",sus. Lo
+3093,LUJURIA,sus. Ko’il
+3094,LUMBAGO,sus. Kampach
+3095,LUMBRE,sus. K’áak’
+3096,LUNA,sus. Uj
+3097,LUNA LLENA,"sus. Yi’ij uj, túulis uj, ts’aykan uj"
+3098,LUNA NUEVA,"sus. paal uj, yáax uj"
+3099,LUNAR,"sus. Ta’ uj, yuuy"
+3100,LUZ,"sus. Sáas, sáasil."
+3101,LLAMA DEL FUEGO,"sus. Yaak’, k’áak’"
+3102,LLAMADA,sus. K’aaba’maj
+3103,LLAMAR,v.t. T’aan.
+3104,LLAMAR CON LA MANO,v.t. Béech’k’abt
+3105,LLANO,"adj. Táax, táax lu’um."
+3106,LLANTO INTENSO,sus. Banbanok’ol
+3107,LLAVE,"sus. Je’eb, ch’otob, x ch’otobil."
+3108,LLEGAR,"v.i. Taal, k’uchul, u’ul, kóoj, k’óojol."
+3109,LLEGAR,v.i. K’uch.
+3110,"LLEGAR, VENIR",v.i. U’ul.
+3111,LLEGAR AL CORAZÓN,v.t. Najal ti’ol
+3112,LLENAR,v.t. Chuup
+3113,LLENARSE EL VIENTRE DE VIENTO,v.i. T’ibal.
+3114,LLENO,"adj. Chuup, chuka’an."
+3115,LLENO DE AIRE,adj. P’op’oltal
+3116,LLENO DE MALEZA,adj. Loob
+3117,LLENO POR HABER COMIDO SUFICIENTE,adj. Na’aj
+3118,LLEVAR,v.t. Bis
+3119,LLEVAR EN UN PUÑADO,v.t. Lóoch’. LLEVAR CARGADO O APOYADO SOBRE EL HOMBRO
+3120,DETRÁS DEL PESCUEZO,v.t. Lechkaltaj
+3121,LLORAR,v.i. Ok’ol
+3122,LLORIQUEAR,"v.i. Xuxuch ni’, xuxub ni’."
+3123,LLORÓN,"adj. Chéech, chéech keep."
+3124,LLOVER,"v.i. K’áaxal ja’, K’áaxal cháak"
+3125,LLOVIZNA,"sus. Banaja’, tosja’, wíits’ij ja’."
+3126,LLUVIA,sus. Cháak.
+3127,LLUVIA QUE MOJA LEVEMENTE LA TIERRA,sus. Lak may. LLUVIA
+3128,"MACHACAR,TAMULAR EN MOLCAJETE",v.t. K’uut.
+3129,"MACHACADO, TAMULADO",adj. K’uuta’an.
+3130,"MACHACAR, APLASTAR APACHURRAR",v.t. Puu
+3131,MACHETE,"sus. Máaskab, x"
+3132,MACHO,sus. Xiibil ba’alche’
+3133,MADERA,sus. Che’
+3134,MADRASTRA,sus. X
+3135,MADRE,"sus. Na’, na’tsil."
+3136,MADRINA,sus. Ye na’
+3137,MADRUGADA,"sus. Ajal kaab, sáastal"
+3138,MADRUGADOR,sus. Aj jatskaab ajal
+3139,MADURACIÓN,sus. Yiijtalil
+3140,MADURAR,v.i. Tajal
+3141,MADURAR,adj. Síisíip’ki.
+3142,MADUREZ DEL MAÍZ,sus. Yij
+3143,MADURO PARA FRUTAS,"adj. K’an, tak’an,"
+3144,MAESTRA DE ESCUELA,"sus. X ka’ansaj xook, X"
+3145,MAESTRO DE ESCUELA,"sus. Aj ka’ansaj xook, J tak’antak. ka’anbesaj ka’anbesaj"
+3146,MAGIA,sus. K’askunaj ich.
+3147,MÁGICO,v.t. Esaj
+3148,MAGULLADO,adj. Maxal
+3149,"MAGULLAR , MACHACAR, LASTIMAR",v.t. Nuul.
+3150,MAÍZ (ZEA MAYS L),"sus. Ixi’im, xi’im"
+3151,MAÍZ AMARILLO,sus. K’an ixi’im MAÍZ BLANCO (SU CICLO DE PRODUCCIÓN ES DE 
+3152,DÍAS),"sus. Sak ixi’im, x nuuk nal"
+3153,MAÍZ DE GRANOS AZULOSOS,sus. Éek’jub
+3154,MAÍZ DE GRANOS COLOR ROJO OSCURO,sus. Éek’chob
+3155,MAÍZ DE GRANOS ROJOS,"sus. Chakchob MAÍZ DEL GALLO, VARIEDAD DE MAÍZ QUE TARDA  DÍAS EN DESARROLLARSE."
+3156,DÍAS),sus. X mejen nal
+3157,MAÍZ TIERNO,sus. Ak’ ixi’im
+3158,MAJAR,v.t. Pech’ pets’
+3159,"MAJAR, MACHACAR, MAGULLAR",v.t. Maax.
+3160,"MAJAR, APLASTAR",v.t. Yaach’
+3161,MAJESTAD,"sus. Aj tepal, tepalil MAKAL O ÑAME (DIOSCORACEAE (DIOSCOREA ALATA"
+3162,L)),sus. Makal
+3163,MAL,"sus. K’aas, loob"
+3164,MAL DE PINTO,"sus. Wáaway, Paj is."
+3165,MALDECIR,"v.t. Manab chi’, loolobt’aantik."
+3166,MALDICIÓN,"sus. Kóots ak’il, ak’ayil"
+3167,MALDITO,adj. Aj ak’ayil
+3168,MALEZA,"sus. Aban, jaban, loob"
+3169,MALO,"adj. Ma’ patali’, k’aas."
+3170,MALOLIENTE,"adj. P’u’us, tu’"
+3171,MALTRATAR,v.t. Ba’abaj toop.
+3172,MAMA,sus. Chu’uch
+3173,MAMÁ,"sus. Na’, maamatsil, natsil."
+3174,"MAMAR, SUCCIONAR",v.t. Chu’uch. MAMEY DE SANTO DOMINGO (MAMMEA AMERICANA
+3175,L),sus. Chakalja’as.
+3176,MANADA PEQUEÑA DE ANIMALES,sus. Banab.
+3177,MANANTIAL,"sus. Aklin, sayab."
+3178,"MANAR, CHORREAR",v.i. Chooj.
+3179,MANCHADO,adj. Wewel
+3180,MANATÍ,"sus. Téek, chiil."
+3181,MANCHA,sus. Xiijul. MANCHA DE COLOR VIOLETA QUE TIENEN ALGUNOS
+3182,NIÑOS EN LA ESPALDA SOBRE EL COXIS,sus. Waaj
+3183,MANCHADO POR PARTES,adj. Wéeweek’
+3184,MACHACADO,adj. Ya’ach’ta’an
+3185,"MANDAMIENTO, LEY",sus. A’almaj t’aan.
+3186,MANDAR,"v.t. A’alaj, a’almaj"
+3187,"MANDAR, ENVIAR","v.t. Túux, túuxt, tusbeel"
+3188,MANDATO,sus. A’almaj t’aan
+3189,MANDÍBULA,sus. Kama’ach
+3190,MANERA,"sus. Yalul, bixil."
+3191,MANGLAR,sus. Chuk te’
+3192,MANGO DE HERRAMIENTA,sus. Lap’k’abil
+3193,MANIFESTAR,v.t. E’esaj.
+3194,MANIFIESTO,adj. Xech
+3195,"MANIQUÍ, MUÑECO",sus. Wenak
+3196,MANO,sus.K’ab.
+3197,MANOSEAR,v.t. Máamaachik.
+3198,"MASCAR, MASTICAR",v.t. Cha’ach.
+3199,MANOJO O ATADO,adv. de c. K’áax
+3200,MANOJO DE ALGO,adv. de c. Jikipil
+3201,"MANOJO DE CUALQUIER COSA, COMO VARAS, CABE",
+3202,"LLOS, VELAS, ETC",adv. de c. Cháach MANSO.
+3203,MANTA,sus. Nook’
+3204,MANTECA,sus. K’ab tsaats.
+3205,MANTEL,sus.U nook’il mayak che’.
+3206,MANTENER,v.t. Tséent
+3207,MANUAL,sus. Nu’ukul ku tsoolik wáa ba’ax.
+3208,MAÑA EN CUALQUIER COSA,sus. Nonojil
+3209,MAÑANA,adv. de t. Sáamal
+3210,"MAÑANA, EL AMANECER",sus. Ja’atskab k’iin. MAPACHE (PROCYON LOTOR SCHUFELDTI(NELSON Y
+3211,GLODMAN)),sus. K’ulu’
+3212,MAR,"sus. K’áanab, k’áak’náab, k’áanáab"
+3213,MARAÑA,sus. Mamak.
+3214,MARAVILLAR,v.i. Nunuyaktaj
+3215,MARAVILLARSE DE ALGUNA PERSONA COMO DESCO,
+3216,NOCIÉNDOLA,v.t. Makat MEADO
+3217,MARAVILLOSA,adj. Máktsil
+3218,MARIDO,sus. Iicham
+3219,MARIPOSA,sus. Péepen
+3220,MARIPOSA NOCTURNA,sus. Áak’ab ts’unu’um
+3221,MARISMA,sus. Uk’um
+3222,MARRANA,"sus. Ch’úupil k’éek’en, x leech"
+3223,MARRANO,sus. K’éek’en
+3224,MARTILLO,sus. Bajab.
+3225,MÁS,adv. de c. Paymun
+3226,MAS,conj. advers. Jebak
+3227,MÁS TARDE,"adv. de t. Ka’akate’, ma’ sáame."
+3228,MASA DE MAÍZ,sus. Sakan
+3229,MASA ENCEFÁLICA,sus. Ts’o’om.
+3230,MASAJE,"sus, v.t. Páats’, yeet’, yoot’."
+3231,"MASCAR, MASTICAR",v.t. Jaach
+3232,"MASCAR, ROER",v.t. K’uux.
+3233,MÁSCARA,"sus. K’oj, piix ich."
+3234,MASCULINO,adj. Xiib.
+3235,MASTICAR,"v.t. Cha’ach , jaach’."
+3236,MASTICAR VARIAS VECES,v.t. Jáajaach’.
+3237,"MASTICADO POR BOCA GRANDE DE CABALLO, MA",
+3238,"RRANO, PERRO",adj. Cha’acha’an.
+3239,MASTICADO POR BOCA PEQUEÑA DE RATA O TUZA,v.t. Ne’ene’es.
+3240,MASTURBACIÓN,"sus. Kol ach, baxalba."
+3241,MASTURBACIÓN MASCULINA,sus. Kóol keep
+3242,MASTURBARSE,v.i. Baxalba
+3243,MATANZA,sus. Banban kíimsaj
+3244,MATAR,"v.t. Kíins, kíimsaj."
+3245,MATERIA,sus. Ba’alil.
+3246,MATERIA DE UNA HERIDA,"sus. Puj, pu’uj jal."
+3247,MATERNO,adj. Na’itsil.
+3248,MATORRAL,sus. Aban
+3249,MATRIMONIO,"sus. Ts’o’okol beel, k’amnikte’"
+3250,MATRIZ,sus. Sayomal.
+3251,MAXILAR,sus. Kama’ach
+3252,MAYOR,adj. K’ojol.
+3253,MAYOR,adj. U nojochil
+3254,MAYORÍA,adv. U ya’abil.
+3255,MAZORCA DE MAÍZ,sus.Tiijol nal.
+3256,"MEADO, ORÍN",sus. Wíix
+3257,"MEAR, ORINAR",v.i. Wiix.
+3258,MECAPAL,"sus. Táab MECATE, MEDIDA AGRARIA DE  M O DE  M"
+3259,LINEALES,sus. K’aan(Para el singular) Ts’áak (Para el plural)
+3260,MECER,v.t. Úumbal
+3261,MEDIA NOCHE,sus. Chúumuk áak’ab
+3262,MEDIANO,adj. Tuntun
+3263,MEDIBLE,adj. P’iisbe’en
+3264,MEDICINA,sus. Ts’aak
+3265,MÉDICO,sus. Ts’aak yaaj MEDIDA DE LONGITUD ENTRE EL DEDO PULGAR Y EL
+3266,MEÑIQUE CON LA MANO ABIERTA,sus. Náab
+3267,MEDIANTE,adj. Tu yo’olal.
+3268,MEDIDA,"sus. P’iis, p’iisib, betan."
+3269,MEDIDO SIN ORDEN,adv. de m.P’íip’iis
+3270,MEDIO,"sus. Táankuch, táan chúumuk, táan"
+3271,"MEDIO MADURO, A PUNTO DE MADURAR",Adj. K’aas chumuk tak’an
+3272,MECERSE,v.i. Úumbal.
+3273,"MEDIO, MEDIA","adj. Chúumuk, búuj."
+3274,MEDIODÍA,sus. Chúumuk k’iin
+3275,MEDIR,v.t. P’iis
+3276,MEDITAR,"v.t. Nen óol, num óol"
+3277,MÉDULA,sus. Noy
+3278,MEJILLA,sus. P’u’uk
+3279,MEJOR,"adj. Paymun, u ma’alobil"
+3280,MELLIZO,sus. Iich
+3281,MEMORIA,sus. K’aj lay
+3282,MEMORIZAR,v.t. oksaj ti’ pool.
+3283,MENCIONAR,v.t. Ch’a’ chi’.
+3284,"MENDIGAR, PEDIR",v.t. Máat
+3285,MENDIGO,sus. Aj k’áat matan.
+3286,MENEAR,v.t. K’u’uy
+3287,"MENEAR, MOVER ALGÚN LÍQUIDO",v.t.Yúuk
+3288,MENOR,"adj. U chichanil, t’uup."
+3289,MENOS,"adv. de c. Ma’ chuka’an , matla"
+3290,MENOS ENTRE OTROS,adv. de c. Tuntumil
+3291,MENOSPRECIAR,v.t. Kúulpaachkúuns
+3292,MENSAJERO,sus. Aj bisaj t’aanilo’ob
+3293,MENSO,adj. Meelen keep 
+3294,MENSTRUACIÓN,"sus. Ilmaj, jula, k’asal, ulis, uj"
+3295,MENTIR,v.t. Tuus
+3296,MENTIRA,"sus. Tuus, tuusil."
+3297,MENTÓN,sus. No’och
+3298,MEÑIQUE,sus. T’uup
+3299,MEOLLO,sus. Noy
+3300,MERCADO,"sus. Najil koonolo’obi’, u kúuchil koonol."
+3301,MERCANCÍA,sus. Koonol.
+3302,MERMAR,v.i. Jáatspajal
+3303,MES,"sus. Wináal, yuil"
+3304,MESA,sus. Mayak
+3305,MESA DE MADERA,"sus. Mayak che’, táax che’, wi’ileb che’, táas che’."
+3306,MESA DE PIEDRA,sus. Mayak tuunich
+3307,METAMORFOSIS,sus. Wayasbil.
+3308,METATE,sus. Ka’
+3309,METEORO,sus. Túux ka’an
+3310,METER,"v.t. Oks, oksaj, ts’ot"
+3311,METER,v.t. Juup.
+3312,"METER, INTRODUCIR",v.t. Kaap.
+3313,"METER, INSERTAR",v.t. K’aap.
+3314,"METER, EMBUTIR",v.t. Chook’.
+3315,METER POR LA FUERZA EN LUGAR ESTRECHO,v.t. METER DE CUALQUIER
+3316,MANERA,v.t. Chok’la’antaj Chóochook’an.
+3317,METIDO VARIAS VECES,adj.Táatáak.
+3318,MEZCLA,"sus. Xa’ak’, xe’ek’"
+3319,MEZCLADO,adj. Xa’ak’a’an
+3320,MEZCLAR,"v.t. Xa’akit, ta’anbesaj, xa’ak’."
+3321,MI,adj. poses. In.
+3322,MICO DE NOCHE (POTTOS FLAVUS),sus. Áak’ab ma’ax
+3323,MIEDO,"sus. Sajkil, sajak, sajakil"
+3324,MIEDOSO,adj. Sajlu’um
+3325,MIEL,sus. Kaab
+3326,MIEL CUAJADA,sus. Moom
+3327,MIENTRAS,"adv. de t. Kalikil, láakej"
+3328,MIENTRAS,"adv. de t. Kali’ikil, entas."
+3329,"MIERDA, EXCREMENTO",sus. Ta’
+3330,MILAGRO,sus. Maktsil
+3331,MILES,sus. Jun pik
+3332,MILPA,sus. Kool.
+3333,MILPA DEL PRIMER AÑO DE TUMBA,sus. Ch’áakbeen.
+3334,MOLLEJÓN O PIEDRA DE AFILAR,sus. Jux
+3335,MOMENTO,adv. de t. Súutuk
+3336,MOMOTO TURQUÍ,sus. Tooj
+3337,MONDONGO,sus. s’áanchakbil u tsuukel
+3338,MILPERO,"sus. Koolnáal,Aj koolkaab"
+3339,MINOTAURO,sus. Aj wíinik wakax.
+3340,MÍO,pron. poses. Intia’al
+3341,MIRADOR,sus.Ka’anal kisneb naaj.
+3342,MIRAR,"v.i., v.t. Paakat, cha’ant, il."
+3343,MIRAR DE SOSLAYO O CON DISCRECIÓN,v.i. Báa
+3344,"MIRAR DURAMENTE, CON FIEREZA",v.i. Lek’
+3345,NECESITADO,adj. Aj numya
+3346,MISA,Sus. Noj k’ul t’aan.
+3347,MISERIA,sus. Munya
+3348,MISERABLE,"adj. J máan óotsil, J munyaj."
+3349,MISERICORDIA,sus. Yatsil
+3350,MISMO,sus. Batsil
+3351,MISTERIO,sus. Talam
+3352,MITAD,"sus. Táankuch, táan chúumuk, tánkoch, búuj."
+3353,MIXTO,adj.Xa’ak’a’an
+3354,MOCO,sus. Síim.
+3355,MODO,"sus. Yalul, bixil."
+3356,MOFA,sus. P’a’as
+3357,"MOFAR, BURLAR, DESDEÑAR",v.t. P’a’as.
+3358,MOFETA,sus. Pay ooch
+3359,MOHO,sus. Kuuxum
+3360,MOJADO,"adj. Poopoop, ch’uul."
+3361,"MOJAR, HUMEDECER","v.t. Ch’uul, Ch’u’ulul."
+3362,MOJÓN,sus. Multun
+3363,MOJONERA,"sus. Multun, xu’uk’."
+3364,MOLCAJETE,"sus. X k’uutub, k’uut ka’"
+3365,MOLER,v.t. Juuch’.
+3366,"MOLIDO, MASA",sus. Juuch’.
+3367,"MOLER, TRITURAR, REDUCIR A POLVO","v.t. Mux MOLDEAR, MODELAR, FORMAR. V.t. Paat."
+3368,MOLER EL NIXTAMAL,v.t. Juuch’
+3369,MOLESTAR,"v.t. Top, p’u’ujsaj."
+3370,MOLESTAR,v.i. P’úup’u’uj.
+3371,MOLESTO,"adj. Ts’íik, k’uux, p’u’uj, níichbal, k’áax elenche’ ch’úup. wakax."
+3372,MONEDA,sus. Táak’in.
+3373,MONEDA DE ORO,sus. K’an táak’iin
+3374,MONO ARAÑA (ATELES SP),sus. Ma’ax
+3375,MONO AULLADOR (ALOUATTA PALLATA MEXICANA),sus. Ba’ats’
+3376,MONTAÑA,sus. Bolon wits
+3377,MONTAR,v.t. Naat’
+3378,"MONTARÁZ, ARISCO, HURAÑO",adj. K’o’ox.
+3379,MONTE,sus. K’áax
+3380,MONTE ALTO,"sus. Ka’anal k’áax, nukuch"
+3381,MONTE BAJO,"sus. Jubche’, jub che’, ju’che’, ke"
+3382,MONTE DE ALTURA MEDIANA,sus. Ka’a kool
+3383,MONTE DE VENUS,sus.Cho’ono’ob u chíikul x
+3384,MONTÍCULOS,sus. P’óop’ool.
+3385,MONTÓN,adv de cantidad.
+3386,"MAÍZ, TIERRA",sus. Ban
+3387,MONTÓN DE GRANOS O COSAS MENUDAS,sus. Tsuk
+3388,MONTONES,sus.Túutúuk.
+3389,MONTÓN PEQUEÑO DE CUALQUIER COSA,sus. Nik
+3390,MONTURA,sus. Xek
+3391,MOÑO,sus. T’uuch
+3392,MORADO,"adj. sus. Chak ya’ax, ya’ax ch’ooj."
+3393,MORAR,v.i. Kaaj
+3394,MORAR ENTRE MUCHOS,v.i. Molkaajtal
+3395,MORCILLA O MORONGA,sus. Alimento que se prepara rellenando el intestino del ma
+3396,MORDER,"v.t. Chi’b, chi’, níich’."
+3397,"MORDER, LADRAR",v.i. Chi’ibal
+3398,MORDER CON LOS INCISIVOS COMO LA TUZA,v.t. p’uja’an. Néet’.
+3399,MORDIDO VARIAS VECES,adj. Náanaachan.
+3400,MORDISCO,sus. Níich’.
+3401,MORDISQUEADO,adj. Níiniich’.
+3402,MORIR,"v.i. Kíimil, kíim"
+3403,MORRAL DE FIBRA DE HENEQUÉN,sus. Sáa
+3404,MORTAJA,sus. Tep’ kiimén
+3405,MOSCA,sus. Ya’ax kach
+3406,MOSCA GRANDE DE COLOR VERDE,sus. Al ya’ax
+3407,MOSCA VERDE,sus. Tsíintsíin.
+3408,MOSCO,sus. K’oxol
+3409,MOSTRAR LOS DIENTES,v.t. Nich’
+3410,"MOSTRAR, EXHIBIR, ENSEÑAR",v.t. E’es
+3411,MOTAS DE ALGODÓN O HILO,sus. Mamil taman
+3412,MOTÍN,sus. P’ujul
+3413,MOTIVAR,v.t. Ts’a óol
+3414,MOVER,"v.t. Péek, péeks."
+3415,"MOVER, REVOLVER",v.t. Chíik. MOVER UN ALIMENTO LÍQUIDO Y ESPESO DURANTE
+3416,SU COCIMIENTO,v.t. Júuy.
+3417,MUJER,"sus. Ko’olel, x ba’al"
+3418,MUJER NOBLE,sus. X ajauil
+3419,MULTIPLICAR,"sus. Ya’abal, aalan kil."
+3420,"MULTIPLICARSE, AUMENTARSE",v.i. Chaketjal.
+3421,MULTITUD,"sus. Piktanil , múuch’ul"
+3422,MUNDO,sus. Kaab
+3423,MUNICIPIO,sus. Méek’tan kaajil
+3424,MUÑECO,sus. Wenak
+3425,MURALLA,"sus. Pa’, tulum, pa’ tuun."
+3426,MURCIÉLAGO,sus. Soots’
+3427,MURMURAR,v.t. Mukul t’aan
+3428,MÚSCULO,sus. Bak’
+3429,MUSGO,"sus. Tsuk max, me’ex cháak"
+3430,MÚSICA,sus. Páax
+3431,MÚSICO,"sus. Aj páax, j páax, j páaxnáal."
+3432,MUSLO,sus. Muk’ ook
+3433,MUY,adv. Paymun MUY (PREFIJO PARA FORMAR EL SUPERLATIVO DE LOS
+3434,ADJETIVOS CALIFICATIVOS),"Sem, jach, lem, lemkech, seten, semkech, jéet, jeta’an, táaj."
+3435,MUCHACHA,"sus. Ch’úupal, x ch’úupal"
+3436,MUCHACHO,"sus. Xi’ipal, xi’ib pal, xi’ipaj."
+3437,MUCHAS VECES,adv. de c. Junak
+3438,MUCHO,"adv. de c. Ya’ab, ya’abach, ya’abkach,"
+3439,MUY APRETADO,adj. Jíich’il
+3440,MUY ATADO,adj. K’ak’áax
+3441,MUY FRESCO Y LIMPIO,adj. Kekexki.
+3442,"MUY LLENO DE AGUA, O QUE SE INUNDA",adj . tinbantsil.
+3443,"MUCHÍSIMO, DEMASIADO",adv. Séeséen.
+3444,MUDAR,"v.i. Jelep, jeel, jelkunaj"
+3445,MUDAR DE PIEL LA VÍBORA,v.i. Jeleb.
+3446,MUDARSE,v.i. Jelaj
+3447,"MUDARSE, CAMBIARSE DE ROPA",v.t. Jeel.
+3448,MUDARSE DE VIDA,v.i. Jeelbes a kuxtal
+3449,MUDO,adj. Toot
+3450,MUELA,"Cha’an koj, cha’am"
+3451,MUERTE,sus. Chamay baak
+3452,MUERTO,sus. Kimen
+3453,MUESTRA,"sus. Yalul, chíikul Búubuulki."
+3454,MUY CURVEADO,adj. Lo’olo’ochki.
+3455,MUY DERRUMBADO,adj. Níiniik.
+3456,MUY LLENO DE COMIDA,adj. Na’aj
+3457,MUY MAGULLADO,adj. Nunulaja’an
+3458,MUY MANCHADO O SUCIO,adj. K’ook’ool.
+3459,MUY METIDO,adj. Láalaanki.
+3460,MUY MOJADO,adj.Susulki.
+3461,MUY MOLESTO (A),adj. P’úup’u’uja’an.
+3462,MUY MOLIDO,adj. Múumuuxki.
+3463,MUY MOJADO,adj. Poopoopki.
+3464,MUY ODIADO,adj. P’éep’eeka’an.
+3465,NÁCAR,sus. Mak.
+3466,NACER,"v.i. Síijil, síij, yaantal"
+3467,NACIMIENTO,sus. Síijil.
+3468,NADA,adv. de n. Mixba’al
+3469,NADAR,"v.i. Báab, báaxal ja’"
+3470,NADAR DEBAJO DEL AGUA,v.i. Muuk ja’
+3471,NADIE,adv. de n. Mix máak
+3472,NALGA,sus. P’u’uk iit
+3473,NANA,sus. X kanan paal.
+3474,NARANJA AGRIA (CITRUS AURANTIUM L),sus.
+3475,NERVIO,sus. Xich’
+3476,NI,adv. de n. Mix
+3477,NI HABLAR,adv. de n. Mix t’aan
+3478,"NI MODO, NI REMEDIO",adv. de n. Ja’alibe’.
+3479,NIDO,sus. K’u’
+3480,NIETO,"sus. Áabil, wáabil, áabitsil."
+3481,NIGROMÁNTICO,sus. Wáay xibalbailo’
+3482,NIGUA (DERMATOPSYLLA PENETRANS),sus. Al ch’ik
+3483,NINGUNO (PERSONA),pron ind. Mixmáak.
+3484,NINGUNO (PERSONA O ANIMAL),pron ind.Mix
+3485,"NARANJA DULCE ( CITRUS SINENSIS, OSB)",sus. Suuts’ pak’áal Ch’ujuk pak’áal.
+3486,NARIZ,sus. Ni’
+3487,NARRADOR DE HISTORIAS,"sus. Aj kansiyaan, Aj tsikbal k’ajlay."
+3488,NARRAR,v.t. Tsikbal.
+3489,NATA,sus. Oots’
+3490,NAUFRAGAR,"v.i. Nokop, sat, búulul"
+3491,NAUFRAGIO,sus. Nokopa’il
+3492,NAÚFRAGO,adj. Aj nokop.
+3493,NAVEGAR,"v.i. Báab, bubil, cheemul, xot ja’"
+3494,NAVEGANTE,sus. J cheemnáal.
+3495,NEBLINA,sus. Ye’eb
+3496,NECESARIO,"adj. K’a’anan, k’a’ana’an, k’abéet, k’abeet, kenlik, najbe’en."
+3497,NECESIDAD,sus. Najbe’entsil
+3498,NECRÓPOLIS,sus. Suju’uy lu’um
+3499,NEGLIGENCIA,sus. Náay óolal
+3500,NEGRO,"adj. Boox, éek’"
+3501,NEGRURA,"adj. Éek’ popos, éek’i"
+3502,NEGRUZCO,adj. Éek’tile’en. juntúul.
+3503,NINGUNO (COSA),adv. Mix junp’éel.
+3504,NIÑA,sus. Chan x ch’úupal.
+3505,NIÑA DEL OJO,sus. Néenil ich
+3506,NIÑO,"sus. Paal, chanbal, chanpaal, chan"
+3507,NIVEL,sus. Ka’analil
+3508,NIVELADO O EMPAREJADO CON AGUA,adj.Yuyul
+3509,NO,"adv. de n. Ma’, ma’ach, ma’atan, mix"
+3510,CAL),"sus. K’u’um. taan, mun, ma’ab."
+3511,NO ES CIERTO,"adv. de n. Ma’tech, ma’ jaajil, ma’ jaaji’, mix jaaji’"
+3512,NO HABLAR,v.i. Ch’iikil
+3513,NOCHE,sus. Áak’ab
+3514,NOMBRAMIENTO,sus. Wakunaj
+3515,NOMBRE,sus. K’aaba’
+3516,NOMBRE PROPIO,sus. Noj k’aaba’
+3517,NOPAL,sus. Páak’am.
+3518,NORMAL,"adj. Ma’alob yaanil, tu beel yaanil."
+3519,NORTE,sus. Xaman.
+3520,NOSOTROS,pron. pers. To’on
+3521,NOTICIA,"sus. K’aj óolal, k’ajóolo, ojelil, k’uben t’aan, péeksilo’, ts’áaj ojeltbil."
+3522,NOVENTA,sus. Lajun p’éel ti’ jo’o k’áal
+3523,NOVIA,sus. X ba’al
+3524,NUBE,sus. Múuyal
+3525,NUBLADO,adj. Nookoy
+3526,NUBLAR,"v.i. Nookoytal, nookoychajal."
+3527,NUCA,sus. Pachkab
+3528,NUDO,sus. Jook’
+3529,NUDO EN LA SOGA,sus. Mok.
+3530,NUERA,sus. Ilib
+3531,NUERA,"sus. X ilibtsil, x ilibtsile’"
+3532,NUESTRO,pron. poses. K
+3533,NUESTRO,adj. poses. K tia’al
+3534,NUEVAMENTE,"adv. Tu ka’atéen, túunbenil."
+3535,NUEVE,sus. Bolon
+3536,NUEVO,adj. Túunben
+3537,NUMERAR,v.t. Ts’áaj xookul.
+3538,NÚMERO,sus. P’éelel
+3539,NUMEROSO,adj. Jach táaj ya’ab.
+3540,NUNCA,adv. de n. Mixbik’iin
+3541,O,conj. disyunt. Wáa
+3542,OBEDIENCIA,"sus. Ch’a t’aan, u’uy t’aan."
+3543,OBEDIENTE,adj. U’baj t’aan
+3544,OBJETO,sus . Ba’al.
+3545,OBJETIVO,sus. Ba’al unaj u beeta’al.
+3546,OBLIGACIÓN,sus. K’ochbesajul.
+3547,OBLIGAR Y CULPAR,v.t. K’uchbesaj
+3548,OBLIGAR A HACER O NO HACER ALGO,v.t. Taataak
+3549,OBLIGAR,v.t. Ts’alpaachtik.
+3550,OBRA QUE UNO HA HECHO,sus. Kelemal.
+3551,OBSCURECER,"v.i. Eéjoch’e’ental , e’same’en."
+3552,OBSCURO,"adj. Ee’joch’e’en, e’same’en."
+3553,OBSEQUIO,sus. Siibal.
+3554,OBSERVAR,"v.t. Cha’ant, cha’an, il."
+3555,OBSIDIANA,sus. Sim tun
+3556,OBTENER,v.t. Aantal.
+3557,OBSTINACIÓN,sus. Nolmail
+3558,OBSTINADO,adj. Nonolki
+3559,OCASO,"sus. Éemel kaab, t’úubul k’iine’"
+3560,OCIO,sus Mak’ óolal.
+3561,OCIOSO,adj. J mak’ óolal.
+3562,OCTAVO,adj. U waxakp’éel.
+3563,OCULTAR,v.t. Ta’ak
+3564,"OCULTAR, ESCONDER, ENCUBRIR",v.t. Baal.
+3565,OCUPACIÓN,"sus. Al sawa’nil, meyaj."
+3566,"OCURRIR, SUCEDER",v.t.Úuchul.
+3567,OCHAVARIO (OCHO DÍAS DESPUÉS DE FINADOS O CELE,
+3568,BRACIÓN DE LOS SANTOS DIFUNTOS),sus. Biix
+3569,OCHO MIL,sus. Jun pik
+3570,OCHO,sus. Waxak
+3571,ODIAR,v.t. P’eek.
+3572,ODIO,sus. P’eek.
+3573,OESTE,sus. Chik’iin
+3574,"OFENDER, INJURIAR",v.t. Pooch’
+3575,OFENSA,sus. K’aas pooch’
+3576,"OFENSA, INSULTO",sus. Pooch’il.
+3577,OFICIO,sus. Yits’atil
+3578,OFRECER,"v.t. Chaybesaj, ts’áabilaj"
+3579,OFRECER AYUDA,v.t. Kóoybaj áantaj
+3580,OFRECER O DONAR LO OFRECIDO,v.t. Ts’áabilaj.
+3581,OFRENDA,"sus. Jo’oche’, tiich’, loojil, ti’ibil óo"
+3582,OÍDO,sus. Xikin
+3583,"OÍR, ESCUCHAR",v.i. U’uy
+3584,OIR CON MUCHA ATENCIÓN,v.i.Ch’éenxikintik.
+3585,OJAL,sus. U joolil nook’. ¡OJALÁ!.
+3586,OJIZARCO,sus. Saak buye’en ich
+3587,OJO,sus. Ich
+3588,OJO DE AGUA,"sus. Aklin, sayab, sayabil."
+3589,OLA,sus. Kukul
+3590,OLA DE AGUA,sus. Ts’ikit ja’
+3591,OLAS DEL MAR,sus. Yaam
+3592,OLER,"v.i. Utsben, u’ts’ben"
+3593,OLFATEAR,"v.t. Tsukul iik’taj, úuts’bentik, ch’a’"
+3594,OLFATEAR PARA SACAR POR EL RASTRO,v.t. book. Bobokni’ktik
+3595,OLFATO,sus.Uts’banaj.
+3596,OLOR,sus. Book
+3597,OLOROSO,adj. Ki’ibook
+3598,OLVIDAR,"v.t. Tu’ubs, tu’ub, tubul."
+3599,OLVIDO,sus. Manak’óol
+3600,OLLA,sus. Kuum
+3601,OMBLIGO,sus. Tuuch
+3602,OMNIPOTENTE,adj. Uchuk tuméen sinil.
+3603,ONCE,sus. Buluk
+3604,ONDEAR,v.i. Wilta’al
+3605,ONDULAR,v.i. Wilta’al
+3606,OPACIDAD DEL CRISTALINO DEL OJO,sus. Sak
+3607,OPORTUNIDAD,sus. U k’iinil
+3608,"OPRIMIR, PRENSAR, APLASTAR",v.t. Peets’
+3609,ORACIÓN,sus. Payalchi’
+3610,ORADOR,"sus. Aj ku’chlu’um t’aan, Aj tse’ek t’aj t’aan."
+3611,ORDEN,sus. Tsool.
+3612,"ORDEN, DISPOSICIÓN",sus. A’almaj t’aan
+3613,ORDENADO,adj. Tsoola’an
+3614,ORDENAR,"v.t. A’almaj, ts’áaj u tumutil, tsool, tun t’aan."
+3615,ORGULLO,"sus. Nojbail, tsikbail"
+3616,ORGULLOSO,adj. J nojbail.
+3617,ORIENTAR,v.t. Nu’uk bej.
+3618,ORIENTE,sus. Lak’iin
+3619,ORIGEN,"sus. Chuun, chúunuk"
+3620,ORILLA,"sus. Jáal, chi’"
+3621,ORINA,sus. Wíix’
+3622,ORINADO,"adj. Wíixbil, wíixa’an."
+3623,ORINAR,v.i. Wíix
+3624,ORO,sus. K’an táak’iin
+3625,OROPÉNDOLA,sus. Yúuyum
+3626,ORTIGA (URERA SPP),sus. Laal
+3627,ORUGA,sus. Balnak’ péepen.
+3628,OSAR,v.i. Xet’ óolal
+3629,OSO HORMIGUERO,sus. J chab
+3630,OSO COLMENERO,sus. Sam jo’ol
+3631,OTRA PARTE,adv. de l. Tanxel
+3632,OTRA VEZ,adv. de
+3633,ORDENAR Y CONCERTAR LO QUE UNO VA A HACER,"ka’ajtéeno’, tu ka’atéen v.t. Mamak t’aan"
+3634,ORDEÑAR,"v.t. Poots’, puts’"
+3635,OREJA,sus. Xikin
+3636,"OREJÓN, PAROTA,GUANACASTLE",sus. Piich
+3637,ORGANIZADOR,sus. Aj nu’ukbesaj
+3638,ORGANIZAR,v.t. Tsool
+3639,ORGASMO,"sus. Xexbail. t. Tu ka’ajtéen, tu"
+3640,OTRO,sus. Uláak’
+3641,"OTRO, OTRA, COSA DIFERENTE","Pron.Yaanal, u yaanal, jela’an."
+3642,OVALADO,"adj. Túuts’, k’ak’atak.’"
+3643,OVAR,"v.t. E’elankil, e’elankal, e’el, ye’el, je’eankil."
+3644,PALO MULATO (BURSERA SIMARUBA (L) SARG),
+3645,PACIENCIA,"sus. Taj muk’óolal, muk’ óolal."
+3646,PACIENTE,"adj. K’uchpaja’an yóol, aj muk’"
+3647,PACIFICAR,v.t. Toj jal óol
+3648,PACTO,"sus. Ts’áaj t’aantanba, k’aax t’aan."
+3649,PADECER,v.i. Muk’yaj.
+3650,PADRASTRO,"sus. Sak yuum, majan taata."
+3651,PADRE,"sus. Taata, taat, yuum."
+3652,"PADRE, SACERDOTE","sus. K’iin, Yuum K’iin."
+3653,PADRES,sus. Taatatsilo’ob
+3654,PADRINO,sus. Ye yuum
+3655,PAGAR,"v.t. Bo’ol, bo’ot."
+3656,"PAGO, SALARIO","sus. Bo’ol, bo’ot."
+3657,PAILA,sus. Máaskab kuum
+3658,PAÍS,sus. Noj lu’um.
+3659,"PAJA, ZACATE",sus. Su’uk.
+3660,PÁJARO,sus. Ch’íich’
+3661,PÁJARO CARPINTERO,"sus. Ch’ejob, ch’ejum,"
+3662,PÁJARO NEGRO DE OJOS COMO BRASAS,sus.
+3663,PALABRA,sus. T’aan
+3664,PALACIO DE GOBIERNO,sus. Noj najil jala’ach
+3665,PALADAR,"sus. Mábka’an, mab ka’an, náab ch’ojom. Ts’iiw ka’an."
+3666,"PALEAR, CUCHAREAR",v.t. Jo’op.
+3667,PALENQUE,sus. Jil che’
+3668,PÁLIDO,adj. Sakpile’en
+3669,PALILLO,sus. Ch’ilib
+3670,PALIZADA,"sus. Jil che’, pa’, suup’."
+3671,PALMA ( REINHARDTIA SP),"sus. Xa’an, ch’iit"
+3672,PALMEAR,v.t. Pak’laj PALO DE TINTE (HAEMATOXYLON CAMPECHIANUM
+3673,L),sus. Éek’ sus. Chakaj.
+3674,PALOMA AZUL,sus. Ch’ooj tsúutsuy
+3675,PALOMA DE PICO NEGRO,sus. Úukum
+3676,PALOMA SILVESTRE (LEPTOLILA VERREAUXI FULVIVEN,
+3677,TRIS) (Lawrence),sus. Tsúutsuy .
+3678,PALOMA SILVESTRE DE PICO ROJO,sus. X chúu
+3679,PALOMA TORCAZA DE ALAS BLANCAS (ZENAIDA ASIÁ,
+3680,TICA),sus. Sakpakal.
+3681,PALPAR,v.t. Tatal k’abtik.
+3682,PALPITAR,"v.i. Kil, kil kil."
+3683,PALUDISMO,sus. Yax ke’el
+3684,PAN,sus. Waaj
+3685,PANADERO,sus. Aj meen waaj.
+3686,PÁNCREAS,sus. Pék
+3687,PAN DE TRIGO,sus. Kastlan waaj
+3688,PANAL,sus. Chúujil kaab.
+3689,PAN TOSTADO,sus. Oop’
+3690,PANELA,sus. Monkaab
+3691,PANTALÓN,"sus. Eex, chowak eex."
+3692,PANTALETAS,sus. Eex
+3693,PANTORRILLA,"sus. P’ul ook, P’ul t’óon"
+3694,"PANZA, BUCHE",sus. Tsuukel
+3695,PAÑO,sus. Nook’
+3696,PAÑUELO,"sus. Cho’ob, k’axab ich, tanjay, x tanja’il, cho’obol ni’."
+3697,PAPADA,sus. K’o’
+3698,PAPAYA (CARICA PAPAYA L),sus. Puut
+3699,PAPEL,sus. Ju’un
+3700,PARA,"prep. Yook’lal, yo’osal, yook’sal. PARA."
+3701,PARAGUAS,sus. Balab ja’.
+3702,PARA QUE,conj. fin. Utia’al.
+3703,PARA QUE,conj. Yo’sal. ¿PARA QUÉ?.
+3704,PARA SIEMPRE,adv. de t. K’atun
+3705,PARÁBOLA,"sus. Etjun t’aan, keet t’aan."
+3706,PARADO,"adj. Kuma’an, wa’alaja’an, wa’akbal"
+3707,PARAR,v.i. Wa’atal
+3708,PARCELA,sus. U kúuchil ichankil che’ob
+3709,PARECIDO,"adj. Chika’an, bayjal, kéet."
+3710,PARED,sus. Pak’
+3711,PAREJA,"sus. Nuup, nuupul"
+3712,"PAREJO, IDÉNTICO, IGUAL",sus. Kéet
+3713,PARENTESCO,"sus. Makil, láak’tsilil."
+3714,PARIENTE,"sus. Láak’, láak’tsil."
+3715,"PARIR, DAR A LUZ",v.i. Alankil
+3716,PAROTA (ENTEROLOBIUM CYCLOCARPUM (JACQ),sus. Piich
+3717,PARPADEO,sus. Múumuts’
+3718,PÁRPADO,"sus. Paach ich, boxel ich."
+3719,PARQUE,sus. K’íiwik
+3720,PARTE,sus. Tsúkul
+3721,"PARTE, PÁRRAFO, CAPÍTULO",sus. Tsúuk
+3722,PARTE DE ALGO,"sus. Jaatsul, jaatsil."
+3723,PARTE DE UNA LECTURA,"sus. Jaats, jaatsul, ja"
+3724,PARTE DEL CUERPO O DE CUALQUIER ANIMAL,sus.
+3725,"PARTICIPAR EN ALGO, INVOLUCRARSE EN ALGO","v.t. Etpaljal, táakpajal"
+3726,PARTIR,"v.t. Buuj, tej"
+3727,"PARTIRSE, QUEBRARSE",v.i. Xíikil.
+3728,"PARTO, ALUMBRAMIENTO","sus. K’ojol , aalankil, atsil. Bayel síijil."
+3729,PASADO,"sus. Máanlil, máaja’an."
+3730,PASADO MAÑANA,adv. de t. Ka’abej
+3731,PASAR,v.i. Máan
+3732,"PASAR LA LENGUA A ALGO, LAMER",v.t. Ma’ats’ 
+3733,PASAR GENERALMENTE POR UN LUGAR,v.i. Mal
+3734,PASAR SOBRE ALGO,v.t. Xáak’a’at
+3735,PASATIEMPO,sus. Máansaj k’iin.
+3736,PASEAR,v.i. Xíinbal
+3737,PASO,sus. Chek ok
+3738,PASOS LARGOS,sus. Xáak’ab
+3739,PATA DE AVE,"sus. Mooch’, xaaw."
+3740,PATA HENDIDA EN DOS PARTES,sus. Maay
+3741,PATEAR,"v.t. Koko’chaak, kóochak’"
+3742,PATEAR ALOCADAMENTE,v.t. T’íint’íinkóochak’.
+3743,PATEAR VARIAS VECES,v.t. Jáajaancha’ata.
+3744,PATILLA,sus. Me’ex p’u’uk.
+3745,PATIO,sus. Táankab
+3746,PATO,sus. Kúuts ja’
+3747,PATRÓN,"sus. Yuum. yuumil, ts’uul, ts’uulil."
+3748,PAUSA,sus. Junp’éel xanlil.
+3749,PAUSADA,adj.Chaanbéelil.
+3750,PAVA,sus. X tuux
+3751,PAVITO,sus. Mejen úulum
+3752,PAVO DOMÉSTICO,"sus. Tso’, úulum"
+3753,PAVO SILVESTRE,sus. Kúuts
+3754,PAZ,"sus. Ts’akin, jets’ óolil."
+3755,PECADO,"sus. K’eban, si’ipil"
+3756,PECADOR,adj. J k’eeban wíinik.
+3757,PECADORA,adj. X k’eeban ko’olel.
+3758,PECHO,sus. Tseem
+3759,PEDAZO,"sus. Xeet’,xóot’"
+3760,PEDERNAL,"sus. Tok’, tok’ tuunich"
+3761,PEDIR,v.t. K’áat.
+3762,PEDIR PRESTADO,v.t. Majan
+3763,PEDO,sus. Kiis
+3764,PEDREGOSO,"adj. Mulu’uch, k’o’lemak, tsek’el."
+3765,PEGADA A OTRA,adv. de l. Naak’
+3766,PEGADO,adj. Taak’al
+3767,"PEGAR CON GOMA, ENGRUDO, ETC",v.t.Taak’ PEGAR O GOLPEAR VARIAS VECES CON LA PALMA DE
+3768,LA MANO,v.t. Láalaaja. PEINADO.
+3769,PEINE,"sus. Xáache’,xáacheb."
+3770,PEINAR,"v.t. Xáache’, xáacheb, ts’íik pool, xáache’ pool."
+3771,PELADO,"adj. Ts’i’its’i’ip, ts’íila’an, súusa’an,"
+3772,PERDERSE,v.i. Sa’atal
+3773,PERDERSE U OCULTARSE EN VARIAS OCASIONES,
+3774,PELADO EN VARIAS PARTES,adj. Ts’íits’íip.
+3775,"PELAR CON LOS DIENTES, DESCORTEZAR",v.t. v.i. Sa’asaat. k’oosa’an. Nóot’ PERTINAZ
+3776,PELAR A UN ANIMAL CAZADO,"v.t. Ts’íil, jo’och."
+3777,PELAR O CORTAR EL CABELLO,v.t. K’oos
+3778,PELAR UNA FRUTA,v.t. Súus
+3779,PELAR O CEPILLAR MADERA,v.t. Súus.
+3780,PELDAÑO,sus. Tem
+3781,PELEA,sus. Ba’ate’el
+3782,PELEAR,v.t. Ba’ate’el
+3783,PELEAR CUERPO A CUERPO,v.t. P’is
+3784,PELÍCANO MORENO,"sus. P’oto’, p’onto’"
+3785,PELIGRO,sus. Sajbe’enile’
+3786,PELO,sus. Tso’ots
+3787,PELOTA,"sus. P’ok, wóolis báaxal."
+3788,"PELUQUEAR, CORTAR EL PELO, RAPAR",v.t. K’oos
+3789,PELUQUERO,sus. J k’oos.
+3790,"PELUQUERA, ESTILISTA",sus. X k’oos.
+3791,PELLEJO,sus. Oot’
+3792,PELLIZCAR,v.t. Xe’ep’
+3793,PENA,"sus. Loob, munya, nat’ tseemil, ok’om óolal"
+3794,PENAS,sus. Numyail
+3795,PENDEJO,adj. Nun keep.
+3796,PENDÓN,"sus. Láakam, pan."
+3797,PENE,"sus. Keep, toon"
+3798,PENITENCIA,"sus. Xoot óol, yaayatulul, ch’abtanil."
+3799,PENSADOR,sus. Aj tuukul.
+3800,PENSAR,"v.t. Nen óol, num óol, ts’áaj, tuukul."
+3801,PENUMBRA,sus. K’aas bo’oy
+3802,PEÓN DE HACIENDA,sus. Palitsil
+3803,PEÓN QUE DA MEZCLA AL MAESTRO ALBAÑIL,sus.
+3804,PEOR,adj. Paynum lobil
+3805,"PEPITA, O SEMILLA DE CUALQUIER FRUTA",sus. Ts’áaj luuk’ Neek’.
+3806,PEPITA DE CALABAZA,sus. Sikil
+3807,PEQUEÑO,"adj. Chichan, chan, mejen."
+3808,PERDER,v.t. Saat. PERDERSE EN ALGÚN OFICIO v.i. Ch’ejel
+3809,PERDICIÓN,sus. Saatal
+3810,PERDIDO,adj. Saata’an
+3811,PERDIZ,sus. Noom
+3812,PERDÓN,"sus. Sa’as si’ipil, sa’as k’eeban."
+3813,PERDONAR,"v.t. Sa’as si’ipil, satal k’eeban"
+3814,PERDURABLE,adj. Mina’an u xuul.
+3815,PERFIDIA,sus. K’eeban t’aan
+3816,PERFORADO,adj. Jom
+3817,PERFORAR,"v.t. Poot, jool"
+3818,PERFUME,sus. Yelma
+3819,PERICO DE OJOS ROJOS,sus. K’ili’
+3820,"PERIÓDICO, DIARIO","sus. Xookbil ju’un , xook"
+3821,PERLA,sus. Yaxil tun.
+3822,PERMANECER,"v.i. Baili’, t’ilil, t’íilit"
+3823,PERMITIR,"v.t. Cha’, silk’a"
+3824,PERO,"conj. advers. Jebak, kúum, kux, ba’ale’, chéen ba’axe’."
+3825,PERONÉ,sus. Lák’ bak ook
+3826,PERPETUAMENTE,adv. de t. Junk’uli’
+3827,PERPETUAR,v.i. Baili’
+3828,PERRO,sus. Peek’
+3829,PERSEGUIR,"v.t. Áalkab paach, áalkabtaj , ch’a paach , ts’ay tu paach."
+3830,PERSEGUIR EL PERRO A SU PRESA,"v.t. Toojol,ch’a’ paach, tsáayalpaach."
+3831,PERSIGNARSE,v.i. Ts’íibil ich
+3832,PERSONA,sus. Máak
+3833,"PERSONA ALTA Y MUY DELGADA, GIGANTE MITOLÓ",
+3834,GICO,sus. Wa paach
+3835,PERSONA CON LA QUE SE HABLA,sus. Éet máa
+3836,PERSONA QUE SUPERA TODO OBSTÁCULO PARA LLE,
+3837,GAR AL FIN PROPUESTO,adj. Aj k’uchpaja’an yóol
+3838,PERTENECER,"v.t. Yaantal ichil, táakpajal kil ichil."
+3839,PERTINAZ,adj. K’uchpaja’an yóol
+3840,PESADO,adj. Aal
+3841,PESAR,v.t. P’iis aalil.
+3842,"PESAR, TRISTEZA","sus. Muuk’ yaaj, yaaj óolal."
+3843,PESCADO,sus. Kay
+3844,PESCADOR,sus. Aj chuk kay
+3845,PESTAÑA,sus. Máatsab
+3846,PETATE,sus. Poop
+3847,PETO,sus. U piix tseem.
+3848,PETRÓLEO,sus. Boox yiits lu’um
+3849,PEZÓN,"sus. Chu’uch, chúuch"
+3850,PEZUÑA,sus. Maay
+3851,PICADA,sus. T’oja’antak
+3852,PICANTE,adj. Páap
+3853,PICAR,"v.t. T’óoch, t’óoj"
+3854,PICAR EL AVE O LA CULEBRA,v.t. T’óoch
+3855,PICAR LAS AVES,v.t. T’ooj
+3856,PICAR LAS PIEDRAS,v.t. T’ooj
+3857,PICO,sus. Koj
+3858,PIE,sus. Ook
+3859,PIEDAD,sus.Ok’ol ich.
+3860,PIEDRA,sus. Tuunich
+3861,PIEDRA ADIVINATORIA,sus. Sáastun
+3862,PIEDRA DE LA CLARIDAD,sus. Sáastun
+3863,PIEDRA PLANA SUPERFICIAL,sus. Chaltun
+3864,PIEDRA PLANA Y GRANDE,sus. Chaltun
+3865,PIEL,sus. Oot’
+3866,PIERNA,sus. Muk’ook
+3867,"PILAR, COLUMNA, POSTE",sus. Okom
+3868,PILETA,sus. Panab
+3869,PIMIENTA (COLUBRINA FERRUGINOSA BRONGN),sus. Ts’ulubmay
+3870,PINCEL,sus. Cheeb
+3871,PINCHAR,"v.t. Loom, juup’."
+3872,"PINCHAR VARIAS VECES, APUÑALAR",v.t. Lóo
+3873,PINOLE (BEBIDA HECHA CON MAÍZ TOSTADO Y MOLIDO),loom. sus. K’aj
+3874,PINTADO,adj. Boona’an
+3875,PINTAR,"v.t. Boonik, boon."
+3876,PINTURA,"sus. Boon, wooj"
+3877,PIÑATA,sus. Pa’ p’úul
+3878,PIÑUELA (BROMELIA PINGUIN L),"sus. Ch’om,  ch’am"
+3879,PIOJO,sus. Uk’
+3880,PIRÁMIDE,sus. K’u
+3881,PISAR,v.t. Pe’echak’
+3882,PISAR,"v.t. Jakche’etaj, ts’anchak’"
+3883,PISAR ALGO SUAVE,v.t. Júupchak’.
+3884,"PISOTEAR, PISAR ALGO VARIAS VECES",v.t. Ts’áats’áanchak’
+3885,PISO,"sus. Lu’um,"
+3886,PISO FIRME Y PLANO,sus. Báabáaxki.
+3887,PITAHAYA (CEREUS UNDATUS (HAW),sus. Woob
+3888,PITAYA ROJA (CACTACEAE (HYLACEREUS UNDATUS)),
+3889,PIZOTE O TEJÓN (NASUA NARICA YUCATANICA ALLEN),sus. Chak woob sus. Chi’ik
+3890,PLACENTA,"sus. Yibnel paal, ibnel, ibnil."
+3891,PLANCHAR,"v.t. Báay, ji’ik, ji’b, tats’, ji’ nook’."
+3892,PLANCHAR ROPA,v.t. Ji’ik nook’.
+3893,PLANICIE,sus. Táax lu’um.
+3894,PLANO,adj. Táax
+3895,PLANTA,sus. Che’ PLANTA CUYAS RAMAS SON UTILIZADAS POR LOS
+3896,YERBATEROS PARA SANTIGUAR A LOS ENFER,
+3897,MOS,sus. Sip che’
+3898,PLANTA DE LA MANO,sus. Táan k’ab
+3899,PLANTA DEL PIE,"sus. Táan ook PLANTA PERENNE, ERECTA (NYCTAGINACEAE (PISONIA"
+3900,ACULEATA L),"sus. Beeb PLANTA PERENNE, TREPADORA (EUPHORBIACEAE)"
+3901,QUE PRODUCE COMEZÓN,sus. P’op’ox
+3902,PLANO,adj. Táax.
+3903,PLANTA TREPADORA,sus. Aak’il
+3904,PLANTÍO,"sus. Pak’áal, pok’al."
+3905,PLÁTANO (MUSA PARADIASÍACA L),sus. Ja’as
+3906,PLATICAR,v.t. Tsikbal.
+3907,PLATO,"sus. Lak, chób,"
+3908,PLAYA,"sus. Jáal ja´, chi’ja’, páay."
+3909,PLAZA,"sus. K’íiwik, chúumuk ti’ kaaj."
+3910,PLEGAR,v.t. Paak
+3911,"PLEGAR, DOBLAR",v.t. Wuuts’.
+3912,PLÉYADES,sus. Tsáab
+3913,PLOMADA,"sus. Ch’uyub máaskab, ch’uyub"
+3914,PLOMO,sus. Ta’ uj
+3915,PLUMA,sus. K’u’uk’um
+3916,PLUMAJE,sus. K’u’uk’umel
+3917,PLURAL,sus. Ya’ab
+3918,POBLADO,"sus. Kaaj, kaajal"
+3919,POBLADOR,sus. Kaajnáalil
+3920,POBRE,"adj. Aj numya, óotsil"
+3921,POBREZA,sus. Óotsilil
+3922,POCO,"adv. de c. P’íit, jun p’íit"
+3923,POCO A POCO,adv. de m. Jujunp’íitile’
+3924,PODER,"sus. Kal, lox t’aan, páajtal, páajtalil."
+3925,PODRIDO,adj. Jojok’ki.
+3926,POEMA,"sus. Iik’ t’aan, yóolil tsikbal"
+3927,POETA,sus. Aj iik’t’aan
+3928,POLEM,sus. Jujuy lu’um lool
+3929,POLICÍA,sus. Túupil
+3930,POLILLA,"sus. Ik’el, sajkay"
+3931,POLÍTICA,"sus. Almejen wíinikil, chuk ku’uk yo’olal. prep. Yail"
+3932,"POR CAUSA GRANDE, GRAVE Y DE IMPORTANCIA",
+3933,"PORCIÓN, PARTE","sus. Jaatsul, jaatsil."
+3934,POR ÉL,prep. Tu yo’olal
+3935,POR ESO,"prep. La’aten, lebetik, le óolal, le o’olale’, tuméen, tu yo’olal"
+3936,POR LA MAÑANA,"adv. de t. Ja’atskab k’iin, jatskaab"
+3937,POR PEDAZOS O ÁREAS,adv. T’óot’ool.
+3938,POR POCO,adv. de c. Óolak
+3939,PORQUE,Conj. Tuméen. ¿POR QUÉ?.
+3940,POR SÍ SOLO,adv. Tu ba
+3941,PORTAL,"sus. Noj joonaj, nojoch joonaj."
+3942,POR TERCERA VEZ,adv. de t. Tu yóoxpáake’.
+3943,POR CUARTA VEZ,adv de t. Tu kanpáake’.
+3944,POR QUINTA VEZ,adv de t. Tu jo’opáake’.
+3945,PORQUE,"conj. caus. Meentun, tuméen, yo"
+3946,POLUCIÓN,sus. Xexbail
+3947,POLVO,"sus. Ma’ay lu’um, jujuy lu’um"
+3948,PÓLVORA,sus. Sabak
+3949,POLLITO,sus. Mejen káax
+3950,PÓMULO,"sus. P’u’uk bakel, p’u’uk ich."
+3951,PONER,"v.t. Ts’aa, ts’áaj, ts’ik."
+3952,PONER CUESTA ABAJO,v.t. Nix
+3953,"PONER DISCORDIA, RENCILLA O CIZAÑA",v.t. Tak t’aan
+3954,PONER EN FILA U ORDEN,"v.t. T’is, t’isaj, t’isbi PONER EN POSICIÓN AL BEBÉ PARA QUE ORINE O DEFEQUE, ACOMPAÑANDO LA ACCIÓN CON UN"
+3955,BISBISEO PECULIAR,v.t. Kéex.
+3956,PONER FIJA UNA COSA,v.t. Aktal.
+3957,PONER O VOLVER BOCA ABAJO,v.t. Nok
+3958,PONERSE DE CUATRO PATAS,v.i. Xak
+3959,"PONERSE DE PUNTILLAS, O DE PUNTITAS",v.i. Liit’ib
+3960,PONERSE LA ROPA,v.t. Búuk
+3961,"PONIENTE, OESTE",sus. Chik’iin
+3962,PONZOÑA,"sus. K’inam, ts’akil"
+3963,POR,"prep. Óok’lal, o’olal, tio’olal, tu yo’olal, ¿POR QUÉ?."
+3964,POSARSE EL AVE,"v.i. T’úuch, t’úuchul."
+3965,POSIBILIDAD,sus. Lox t’aan
+3966,POSIBLE,"adj. Úuchak, beychajak, jop’bentil, páajtal."
+3967,POSICIÓN DE ALERTA,adj. Béejbeechki.
+3968,POSTE,sus. Okom
+3969,POSTEMA,sus. Chu’chum
+3970,POZO,sus. Ch’e’en
+3971,POZO QUE SE FORMA EN LOS SUELOS PANTANOSOS,sus. Xuuch
+3972,POZOLE,sus. K’eyem
+3973,PRACTICAR,"v.t. Túumtaj, túuntaj."
+3974,PRECAUCIÓN,sus. Kananil
+3975,PRECAVIDO,adj. Aj na’at ach
+3976,PRECIO,sus. Tojol
+3977,PRECIOSA Y DE RICA ESTIMA,adj. Koj
+3978,PRECISIÓN,sus. Najbe’ntsil
+3979,PRECISO,adj. Najbe’en.
+3980,PRÉDICA,sus. Tse’ek
+3981,PREDICAR,v.t. Tsé’ekt
+3982,PREDICAR CON VOZ CLARA Y RECIA,v.t. Salkaltal
+3983,PREDICCIÓN,"sus. Tomoxchi’, tamaxchi’"
+3984,PREFERIR,v.i. Pay num.
+3985,PREGONAR,"v.t. K’a’ayt, k’a’ay."
+3986,PREGUNTA,"sus. K’áat t’aan, k’áat chi’"
+3987,PREGUNTAR,"v.t. K’áat, k’áat chi’"
+3988,PREMIO,sus. Makul
+3989,PREMONICIÓN,"sus. Tomoj chi’, tomox chi’"
+3990,PRENDIDO,adj. Ch’iika’an.
+3991,PRENDER,v.t. Ch’iik.
+3992,PRENDIDO CON FUERZA,adj. Ch’íich’iiknak.
+3993,PREOCUPAR,v.i. Tuukul.
+3994,PREPARACIÓN,sus. Ch’alba
+3995,PREPARAR ALGUN OBJETO O ALIMENTO,v.t. Ma’ak’antik.
+3996,PREPOTENCIA,sus. Paynumil
+3997,PRESENTAR,v.t. E’esaj
+3998,"PRESENTE, A LA VISTA",sus.Tak’kabal ich
+3999,PRESENTIR,v.i. Kóojol
+4000,PRESO,"sus. K’ala’an, j k’ala’an"
+4001,PRÉSTAMO DE DINERO,sus. Páay
+4002,PRESTAR ALGUNA COSA,"v.t. Majáant, páay PRESUMIR"
+4003,ENVANECERSE,O v.i. Nojba’alkuntikubáa.
+4004,PRESUNCIÓN,sus. Nonojbail
+4005,PRESUMIDO,sus. Aj nonojbail.
+4006,PRETÉRITO,"sus. K úuchi, máanlil."
+4007,PREVENIR,"v.t. Ch’aba, paybe"
+4008,PRIMAVERA,sus. Yáax k’iin
+4009,PRIMERAMENTE,"adv. de t. Bat’an, paybe’en"
+4010,PRIMERO,"adj. Yáax, yáax táanil"
+4011,PRIMERO,adv. de l. o t. Bat’an
+4012,PRIMICIA,sus. K’aam.
+4013,PRIMA,sus. Ka’a kiik.
+4014,PRIMO,sus. Ka’a suku’un.
+4015,PRINCIPAL,"adj. K’ojol, noj lail"
+4016,PRINCIPIO,"sus. Chuun, chúunuk"
+4017,PRINGAR O SALPICAR,v.t. Wíiwíits’.
+4018,PRISIÓN,"sus. che’,núup’. K’alab máaskab, k’aal"
+4019,"PROBAR, EXPERIMENTAR","v.t. Túumtaj, túum, túuntaj. "
+4020,PROBLEMA,sus. Toop
+4021,PRODIGABILIDAD,sus. Síij óol.
+4022,PRÓDIGO,adj. Aj síij óol.
+4023,PRODUCIR,"v.t. Beete, meent."
+4024,PROFETA,"sus. Aj bobat, aj chilam"
+4025,PRÓFUGO,sus. Aj puuts’ul
+4026,PROFUNDO,adj. Taam
+4027,"PROHIBIDO, VEDADO",adj. Weet’a’an
+4028,"PROHIBIR, IMPEDIR, VEDAR",v.t. Weet’
+4029,PRÓJIMO,sus. Éetwíinikil
+4030,"PRÓLOGO, INTRODUCCIÓN","sus. Pay bet’aan, oksaj t’aan."
+4031,PROMESA,"sus. Jóok’ chi’, pa chi’"
+4032,PROMETER,"v.t. Chi’isaj, jok’ chi, sebchi’tik."
+4033,PROMOVER A OFICIO,v.t. Kumbinaj
+4034,PRONÓSTICO,sus. K’iinyaj t’aan
+4035,PRONTO,"adv. de t. Téek, séeba’an, séebik"
+4036,PRONUNCIACIÓN,sus. Sutupak
+4037,PRONUNCIAR,v.t. A’al.
+4038,PROPORCIONAR,"v.t. Tich’, ts’a."
+4039,PROPÓSITO,sus. Tuukul
+4040,PROTECCIÓN,sus. Mak bo’oy
+4041,PROTEGER,"v.t. Bo’oybesaj, mak paach,"
+4042,PROTEGERSE DEL SOL O DE LA LLUVIA,v.t. Bo’oy
+4043,PROVERBIO,sus. Ts’áaj tuukul
+4044,PROVISIONALMENTE,adj.Chéen ts’e’ets’ek chajal k’iin
+4045,PROVINCIA,sus. Kuchkabal
+4046,PROVOCAR LA GUERRA,v.t. Tsay k’atun
+4047,PRUDENCIA,"sus. Kux óol, tumut óolal"
+4048,PRUDENTE,adj. Aj kux óol.
+4049,PRUEBA,sus. Tumut
+4050,PUBLICADO,"adj. Jok’a’an, ts’áaj ojeltan."
+4051,PUDRIRSE,v.i. Tu’tak
+4052,PUEBLO,sus. Kaaj
+4053,PUEDE SER,"adv. de d. Bey wale’, uchak"
+4054,PUENTE,sus. Péepen che’.
+4055,"PUERCA, MARRANA",sus. X leech.
+4056,PUERCO,sus. K’éek’en
+4057,PUERCO ESPÍN,sus. K’ixpachoch
+4058,PUERTA,"sus. Joonaj, jool naaj"
+4059,PUES,"conj. Kuun, Bakáan."
+4060,"PUESTO, LUGAR",sus. Kúuchil.
+4061,PUJAR INFLÁNDOSE,v.i. P’uru’us
+4062,PULGA,sus. Ch’ik
+4063,"PULIDO, DEMASIADO LISO",adj. Ts’íits’íiki.
+4064,PULIR,v.t. Jalbakunsik.
+4065,PULMÓN,sus. Soorot’
+4066,PULPA,sus. Nooy.
+4067,PULSERA,sus. K’aap
+4068,"PULSO, LATIDO, PULSACIÓN","sus.Kil, kilbail, kikil."
+4069,"PULVERIZAR, ASTILLAR",v.t. P’uuy
+4070,PUMA,sus. Koj
+4071,PUNTA DEL ESTERNÓN,sus. Puytanil.
+4072,PUNTAPIÉ,sus. Kóochak
+4073,PUNTIAGUDA,"adj.Ts’ut, pu’upuuts’ki’"
+4074,PUNTO,sus. Tak’ sabak
+4075,PUNTO DE ESCRIBIR,sus. T’unil ts’íib
+4076,PUNTO DE ESCRITURA,"sus. T’un, t’unil ts’íib"
+4077,PUNTO SOBRE LA I,sus. X t’un
+4078,PUNZAR,"v.t. Tok’, ch’iik,loom."
+4079,PUNZAR CON ARMA O INSTRUMENTO PUNTIAGU,
+4080,DO,v.t. Loom
+4081,PUNZÓN,"sus. Yokob, bajab"
+4082,PUÑADO DE COSAS,adv. de c. Láap’
+4083,PUÑAL,sus. Lomob máaskab
+4084,PUÑETAZO,sus. Loox
+4085,PUÑETAZOS DADOS VARIAS VECES,v.t. Lóoloox.
+4086,PUPILA,sus. Neek’ ich
+4087,PUREZA,adj. Suju’uyil
+4088,PURO,adj. Suju’uy
+4089,QUE,adv. Ok’ol
+4090,QUE,conj. cop. Ka
+4091,QUÉ,pron. rel. Ba’ax
+4092,QUE,"adv. de d. Mia, mi"
+4093,QUE ARDE Y BRILLA,adj. Léemléemki.
+4094,QUE CAMINA RÁPIDO EN PUNTILLAS,adv.de m. Tsa’atsa’ap. Sa’asa’ak’ol. Sáansaanki.
+4095,QUE TIENE MUCHA SALUD O VITALIDAD,adj.
+4096,QUE CORRE MUCHO O QUE NO SE DETIENE,adj.
+4097,QUE CAUSA COMEZÓN,adj. Sa’asa’apki.
+4098,QUE CAUSA COMEZÓN,adj. Tsa’atsa’apki.
+4099,QUE SE DESPRENDE CON FACILIDAD,adj.
+4100,QUE ESTÁ EMPONZOÑADO,sus. Ts’aka’n
+4101,QUE ESTÁ LEJANA O HUNDIDA EN EL HORIZONTE,Joojoots’ki. Líiliit’ki. adj. Lamal
+4102,QUE NO SE PUEDE ERGUIR,adj. Jóojooch’ki.
+4103,"QUE TITILA, SE ENCIENDE Y SE APAGA",adj.Jóojo
+4104,QUEBRADIZO,"adj. Kakachki QUEBRADO EN VARIAS PARTES, APLÍCASE A LOS"
+4105,GAJOS DE LOS ÁRBOLES Y ARBUSTOS,adj. P’íip’iik.
+4106,QUEBRAR,v.i. Káach
+4107,QUEBRAR,v.t. Káach.
+4108,"QUEBRAR, ROMPER",v.t. Jaat.
+4109,QUEDAR,v.i. P’áatal
+4110,QUE ES CIERTO Y POSITIVO,adv. De afir. Jáajbin
+4111,QUEJARSE POR EL DOLOR,v.i. Áakan
+4112,QUEJIDO,sus. Áakam
+4113,QUEMA,sus. Tóok
+4114,QUEMADO,sus. Ela’an
+4115,QUEMADURA,v.t. Chuuj
+4116,QUEMAR,"v.t. Elel, chuuj, tóok."
+4117,QUE SE ESCONDE MUCHO,adj.Babalki
+4118,QUE TIENE COMEZÓN,adj.Níiniich’ki.
+4119,QUE TIENE MUCHAS AMPOLLAS,adj.P’óop’oolki.
+4120,QUE TIENE PEQUEÑAS PROTUBERANCIAS,"adj. P’óop’ootki. panki. T’íit’iilki. Yu’umyu’um. óol, oltaj."
+4121,QUE SE PARTE MUY FÁCIL,adj.Yo’oyo’op’ki.
+4122,QUE NO SE QUEDA EN UN SOLO LUGAR,adj.
+4123,QUE SE MUEVE O MECE MUCHAS VECES,adj.
+4124,QUERER,"v.t. Táan óoltik, k’áat, óoltik, táak"
+4125,"QUERER, AMAR","v.t. Yaakunaj, yaabilaj."
+4126,QUIÉN,"pron. rel. Jensen, je máax ¿QUIÉN?."
+4127,QUIETO,adj. Xoxolki’
+4128,QUIETUD,sus. Ets’a’an óolal
+4129,QUINCE,sus. Jo’olajun
+4130,QUINQUÉ,"sus.Tsuub, sáasil, ch’úuy sáasil."
+4131,QUINTO,adj. U jo’op’éel.
+4132,QUITAR,"v.t. Luk’s, Piit."
+4133,QUITAR UNA PRENDA,v.t. Piit.
+4134,QUIZÁ,"adv. de d. Wale’, úuchak"
+4135,QUIZÁS,"adv. de d. Bey wale’, binakí, mia’,"
+4136,QUE TIENE MUCHOS ORIFICIOS,adj. Chaachaab.
+4137,COMEZÓN,adj. QUE TIENE PELUSA Y DA muki.
+4138,RABADILLA,"sus. Bobox, k’ul"
+4139,RABIA,sus. Ko’il
+4140,RABIHORCADO,sus. Jiich’ kaal nej
+4141,RABO,sus. Nej
+4142,RACIMO DE FRUTOS,"sus. Bab, ch’úu"
+4143,RACIMO,sus. P’och
+4144,RADICAR,"v.i. Kaajnáal, kaajakbal, kaajlan."
+4145,RAÍZ,sus. Moots
+4146,RAJAR,"v.t. Buuj, tej, xik"
+4147,"RALO, MUY RALO",adj. T’áach máan t’aach.
+4148,RAMA DE ÁRBOL O ARBUSTO,"sus. K’ab che’, xa’ay che’, jéek’ che’."
+4149,RAMADA DE LA IGLESIA,sus. Makan
+4150,RAMITA SECA,sus. Ch’ilib
+4151,RAMO,sus. Chach
+4152,RAMÓN (BROCIMUM ALICASTRUM SW),sus. Óox
+4153,RANA,sus. X muuch
+4154,RANCHERÍA,sus. Chan kaaj
+4155,RÁPIDAMENTE,"adv. de m. Séebankil, séebik"
+4156,RÁPIDAMENTE,adj. Jáanjaan.
+4157,RÁPIDO,"adj. Séeb, séeba’an"
+4158,RÁPIDO O MUY VELOZ,adj. Lilich’ki.
+4159,"RÁPIDO, MUY RÁPIDO",adj. K’íik’i’itki.
+4160,"RAQUIS , HUESO DE LA MAZORCA",sus. Bakal
+4161,RAQUÍTICO,adj. Ts’uuts’
+4162,RARO,adj. Ma’ napaja’an
+4163,RASAR,"v.t. Jux k’ab, Tax"
+4164,"RASCAR, RASGUÑAR , ARAÑAR","v.t. La’ach RASPAR, RASURAR."
+4165,"RASPOSO, QUE RASPA FINAMENTE",adj. Líiliichki.
+4166,"RASPOSO, MUY RASPOSO",adj. K’óok’ooxki.
+4167,RASTRO,sus. Bilim
+4168,RATO,adv. de t. Súutuk. Junsúut : un rato. Jun súutuk : un rato.
+4169,RATÓN,sus. Ch’o’
+4170,RAYAR,"v.t. Ja’at, jarat’ ts’íibtik, pay ts’íib, jó’ot’"
+4171,RAYO,sus. Jaats’ cháak
+4172,RAYOS DEL SOL,"sus. Matsab k’iin , jul k’iin"
+4173,RAYO O HAZ LUMINOSO,sus. Jul
+4174,RAZA O LINAJE,sus. Ch’i’ibal
+4175,RAZÓN,"sus. Kux óol, na’at, tumut, uchbal."
+4176,REATA,sus. Suum
+4177,REBANAR,v.t. K’uup.
+4178,REBELDE,adj. J ma’ tsíik
+4179,REBELDÍA,sus. Ma’ tsíikil
+4180,REBELIÓN,sus. Líik’saj kaajo’ob.
+4181,REBOSANTE,adj. Yalbanak.
+4182,REBOSAR LO LLENO,"v.i. Man tuljal, mantul."
+4183,REBOZO,sus. Bóoch’
+4184,REBUSCAR,"v.t. Meents’ul, balul, xa’ak’al"
+4185,REBUZNAR,"v.i. Xuxub ni’, jink’i kaal, jenk’aal."
+4186,RECAUDOS,sus. Xa’ak’
+4187,RECIBIR,v.t. K’aam
+4188,"RECIBIR, ATRAPAR CON LAS MANOS",v.t. K’aam.
+4189,RECIEDUMBRE,sus. K’inam
+4190,RECIO,"adj. Chich, k’a’am, ts’u’uy"
+4191,RECÍPROCAMENTE,"adv. de m. Paaklan, pa"
+4192,RECLAMO,sus.Ikin chi’
+4193,RECOGER,"v.t. Ch’íich’, mool"
+4194,RECOMPENSA,sus. K’exul
+4195,RECONOCER UN BENEFICIO,v.t. K’ajsaj ts’aya’.
+4196,RECORDAR,"v.i. K’a’ajs, k’a’ajsik, ch’a’chi’ib."
+4197,RECTO,"adj. Toj, tojil"
+4198,RECUERDO,"sus. K’a’ajsajul, k’aj lay"
+4199,RED QUE SIRVE DE SACO PARA LLEVAR COSAS FRÁGI,
+4200,LES,sus. Baay
+4201,"REDIMIR, DESAGRAVIAR, RESCATAR",v.t. Loj
+4202,REDONDEAR,v.t. Wóol
+4203,REDONDO,adj. Wóolis
+4204,REDUCIR A POLVO O PEDAZOS,v.t. P’uuy
+4205,"REFLEJA, QUE REFLEJA MUCHO",adj. Jáajaats’ki. REFLEJO U OLEAJE PRODUCIDO POR EFECTO DE LA
+4206,LUZ SOLAR,sus. Wóowóoch’.
+4207,REFLUJO DE MAR,sus. Toch’il.
+4208,REFRÁN,"sus. Ts’áaj tuukul REFRIGERIO VIRGEN, OFRENDA DE BEBIDA FRESCA"
+4209,VIRGEN,sus. Sujuy síis óola’.
+4210,REFUGIO,sus. Mak bo’oy
+4211,REFUNFUÑAR,v.i. Tutukchi’
+4212,REGALAR,v.t. Síij
+4213,REGALO,sus. Siibal
+4214,"REGAÑAR, AMONESTAR, REPRENDER",v.t. K’eey
+4215,REGAÑAR MUCHAS VECES,v.t. K’éek’eey.
+4216,REGAR,"v.t. Jóoya’, jóoyab"
+4217,REGIA,adj. Ajawiil
+4218,REGIDOR,"sus. Aj beelmal, aj nat be"
+4219,REGIÓN,"sus. Kuchkabal, petén"
+4220,RELOJ,sus. P’iisib k’iin.
+4221,"REGLA, MENSTRUACIÓN","sus. Ula, ilmaj"
+4222,REGRESAR,v.i. Suut
+4223,REÍR,v.i. Che’ej
+4224,REIR A CARCAJADAS,v.i. Jáajaabche’ej.
+4225,RELACIONAR UNA COSA CON OTRA,v.t. Taj ok’oltaj
+4226,RELÁMPAGO,sus. Jats’ yuum cháak
+4227,RELAMPAGUEAR,v.i. Léets’bal
+4228,RELATO,sus. Tsikbalile’
+4229,RELATOR,sus. Aj tsool t’aan 
+4230,RELIGIÓN,sus. Okol k’uj
+4231,RELINCHAR,v.i. P’iit
+4232,"RELLENAR, EMBUTIR",v.t. Buut’
+4233,"RELLENO, EMBUTIDO",adj. Buut’
+4234,REMAR,v.t. Ch’uy
+4235,REMEDAR,v.t. P’a’as
+4236,REMENDAR,v.t. Pak’akok
+4237,REMO,sus. U báabil cheem
+4238,REMOJAR,"v.t. Ts’am, suul."
+4239,"REMOJAR, SUMIR",v.t.T’uub
+4240,"REMOJARSE , ASENTARSE",v.t. Ts’áamal.
+4241,REMOLINO,sus. Moson iik’
+4242,REMOLINO DE LA CABEZA,sus. Su’uy
+4243,RENACUAJO,sus. J bube’
+4244,RENCILLA,"sus. Ok yail, xab óolal"
+4245,RENDIR A OTRO,v.t. Ts’oyesaj
+4246,RENDIRSE,v.t.Oyol óol
+4247,RENEGAR,v.i . Xet’ óolal
+4248,RENUEVO,sus. Alamil
+4249,REÑIR CON RABIA,v.i. Mak’ tanan
+4250,REPARAR,v.t. Utskíinsaj
+4251,REPARTIR,"v.t. Jaats, t’oox"
+4252,REPETIDAMENTE,adv. de m. Ban ban
+4253,REPETIR,v.t. Ka’a púut t’aan
+4254,REPIQUE DE CAMPANAS,v.t. Ban péeks
+4255,"REPLETARSE, HARTARSE",v.i. Balankil kukut
+4256,REPOSO,sus. Ts’akin
+4257,REPRIMIR LA IRA,v.t. Taj muk’
+4258,RESBALAR,"v.i. Jalchajal, jalk’ajal, pitk’ajal, pots’kajal, pots’che’ej"
+4259,RESBALAR ALGO MAL COLOCADO,v.i. Nixk’ajal.
+4260,RESBALOSO,"adj. Popots’ki, jojolki"
+4261,RESBALOSO,"adj. Jáajaalki, jóojoolki."
+4262,RESCATAR,v.t. Loj
+4263,RESCOLDO,sus. Chikix ta’an
+4264,RESECO,"adj. Ts’uuts’, k’ak’al."
+4265,RESECA,adj. Chuchul.
+4266,RESEMBRAR,v.t. Julbe’en.
+4267,RESIDENTE,sus. Kula’an
+4268,RESINA DE LOS ÁRBOLES,sus. Iits
+4269,RESISTIR,v.t. Nup’intaj
+4270,"RESISTENTE, MUY RESISTENTE",adj.T’oot’oochki.
+4271,RESOLVER ALGÚN NEGOCIO,v.t. Jepajal óol
+4272,RESPETAR,"v.t. Tsíikik, tsíik, chíinpool."
+4273,RESPETO,sus. Tsíikbe’enil
+4274,"RESPETUOSO,","adj. Aj tibil be, Aj tibil wíinik"
+4275,RESPIRAR,v.i. Ch’a’iik’
+4276,RESPIRAR TOMANDO EL AIRE CON FUERZA,v.i. Bo
+4277,RESPIRAR POR LA BOCA A CAUSA DE UN ARDOR,
+4278,RESPLANDOR DEL FUEGO,sus. Léets’
+4279,RESPONSABILIDAD,sus. K’ooch.
+4280,RESTA,sus. Lúusbil.
+4281,RESTO,"sus. Xiix, yala’"
+4282,RESUMIR,v.i.Ts’um
+4283,RETENER,v.t. Balinaj
+4284,RETENER EL AGUA,v.t. Jalinaj ja’
+4285,RETENER EL RESUELLO,v.t. Kupaj
+4286,RETENTADO DE ATAQUE O PASIÓN,adj. Leka’an
+4287,RETIRARSE LOS QUE PELEAN,v.i. P’alba.
+4288,RETOÑAR,"v.i. K’uk’ankil , k’u’uk’ankil"
+4289,RETOÑO,"sus. K’uuk’che’, k’uk’, top’ che’"
+4290,RETRATO,"sus. Jochol, etpatkunaj"
+4291,RETROCEDER,"v.i. Kukul iit, kukulpaach."
+4292,RETUMBAR,"v.i. Anal, kulun"
+4293,REUMA,sus. Ch’onoj óol.
+4294,REUNIÓN,"sus. Múuch’tal, múuch’kinaj, mul"
+4295,REUNIR TODO,v.t. Junmooltaj
+4296,REVELAR SECRETOS,v.t. Múukul ya’alabil
+4297,"REVENTAR,ESTALLAR, DETONAR",v.i. Wáak’
+4298,"REVENTAR, ROMPER",v.t. Teep’
+4299,"REVENTAR, ROMPER",v.t. T’ook.
+4300,REVOLCADERO DE ANIMALES,sus. Bilim
+4301,REVOLCAR,"v.i. Bobal, babal"
+4302,REVOLTILLO,sus. Xe’ek’
+4303,REVOLVER,"v.t. Bak’, xa’akit, xa’ak’lal, ta’anbesaj."
+4304,REVOLVER,v.t. Xa’ak’al
+4305,"REVOLVER, MEZCLAR","v.t. Buuk’, xa’ak’, xe’ek’"
+4306,"REVUELTA, ALBOROTO",sus. X wookin.
+4307,REZO,"sus. Kama’t’aan, payalchi’"
+4308,REZONGAR,v.i. Tutukchi’
+4309,RIBERA,"sus. Jáal ja’, chi’, jáal."
+4310,RICO,adj. Ayik’al
+4311,RIENDA,sus. Jok’ ni’
+4312,RINCÓN,"sus. Tu’uk’, xu’uk’il, ti’itsil."
+4313,RINCÓN DE LA CASA,sus.Tuuk’ naaj.
+4314,RIÑA ENTRE MUCHOS,"sus. Buuj, pa’al a bu’uj"
+4315,RIÑÓN,"sus. Is, yis."
+4316,RÍO,"sus. Uk’um, bel ja’, áalkab ja’."
+4317,RIQUEZA,sus. Ayik’alil
+4318,RISA,sus. Che’ej
+4319,RITUAL,sus.Tsolante.
+4320,RIVALIDAD,"sus.Tsa, tsaul."
+4321,"RIZADO, MUY RIZADO",adj. Múumuuch.
+4322,ROBAR,v.t. Óokol
+4323,ROBLE (EHRETIA TINIFOLIA L),sus. Béek
+4324,ROBUSTO,adj. Noj ach
+4325,ROCIAR,v.t. Líil.
+4326,"ROCIAR, ESCURRIR",v.t.Tsíits.
+4327,ROCÍO,sus. P’uja’
+4328,RODAJA,sus. Me’et
+4329,RODAR,"v.i. Balak’, balk’ajal, bak’al."
+4330,RODEAR,"v.t. Bak’ paach, ba’apaachmil."
+4331,RODILLA,sus. Píix.
+4332,ROER,"v.t. K’úux, néet’, nées."
+4333,ROGAR,"v.i. Pay chi’, payalchi’"
+4334,ROJO,adj. Chak
+4335,ROJOS,sus. Chaktak.
+4336,ROLLO,sus. Koots’
+4337,ROMPER CUERDA O BEJUCO,v.t. T’aak.
+4338,ROMPER PAPEL,"v.t. Jaat, xeet’."
+4339,"ROMPER PLATO, CAJETE, CÁNTARO",v.t. Pa’
+4340,ROMPER VIDRIO,v.t. Kaach.
+4341,ROMPER EL VIENTO,v.t. Pa’ iik’
+4342,RONCAR,v.i. Nóok’
+4343,RONQUIDO,sus. Nóok’
+4344,ROPA,"sus. Nook’, búukina’"
+4345,ROPA EN GENERAL,sus. Nook’
+4346,ROSADO,"adj. Chaksak, sakpile’en chak."
+4347,ROSTRO,sus. Ich .
+4348,ROTO,"adj. Jaatal, pa’al, xeet’el"
+4349,RÓTULA,sus. Lakil píix.
+4350,ROZA,sus. Ch’akbeen
+4351,RUBIO,adj. Ch’eel
+4352,RUECA,sus. Tunul pechéch.
+4353,RUEGO,sus. Ok’otba.
+4354,RUFIÁN QUE VENDE MUJERES,sus. Aj konkooil
+4355,RUGIR,v.i. Áakan
+4356,RUIDO,sus. Juum
+4357,RUIDO QUE HACE LA SERPIENTE DE CASCABEL,sus. Tirix
+4358,RUISEÑOR,sus. X k’ook’
+4359,RUMBO,"sus. Jel, belil"
+4360,SABANA,sus. Chak’an
+4361,SÁBANA,"sus. Táas, teep’, buklis"
+4362,SABER,sus. Its’atil pool
+4363,SABER,"v.i. Ojelt, ojel, ojéel."
+4364,SABIDURÍA,"sus. Ojelil, yits’atil."
+4365,SÁBILA (ALOE VERA L),sus. Petk’inki
+4366,SABIO,"sus. Aj miats, aj baal kajil miats"
+4367,SABOR,"sus. Ki’il, kii’"
+4368,"SABROSO, MUY SABROSO",adj. Kíiki’iki.
+4369,SACAR,"v.t. Jíil, jo’osik, jó’os, jóok’s."
+4370,"SACAR,DESENTERRAR",v.t. Jáal
+4371,SACAR CON LOS DEDOS UN POCO DE ALGO MASOSO,v.t. Jo’ots’
+4372,SACAR CON VIOLENCIA,v.t.Tojoch’iin.
+4373,SACAR DE LA FUNDA,v.t. Jiilt SACAR DE LA OLLA Y SACAR LO QUE SE CUECE BAJO tik
+4374,LA TIERRA,v.t. Jáal
+4375,SACAR PUNTA,v.t.Ts’uts’utkin.
+4376,SACERDOTE,"sus. J k’iin, yuum k’iin"
+4377,SACERDOTE AGRARIO,sus. J men
+4378,SACO,sus. Mukuk
+4379,SACRIFICIO,"sus. Kukuleb, suy k’up"
+4380,SACUDIR,"v.t. Púust, púusk, tíit , líil."
+4381,SAGACIDAD,sus. Noj ach óolal
+4382,SAGRADO,adj. K’uyen
+4383,SALTAR,"v.i. Síit’, p’iit"
+4384,SAL,sus. Ta’ab
+4385,SAL MUY GRUESA,sus. Sim tuun ta’ab
+4386,SALADO,adj. Ch’óoch’
+4387,SALAR,v.t. Ta’abt
+4388,SALARIO,sus. Náajal
+4389,SALCOCHAR,v.t. Chaak
+4390,SALINA,sus. Chi’ib
+4391,SALIR,"v.i. Jóok’ol, tíip’il"
+4392,SALIR EL MAÍZ,v.i. Jóok’ol
+4393,SALIR LA YERBA,v.i. Jóok’ol
+4394,SALITRE,sus.Sak ta’ab.
+4395,SALIVA,sus. Túub
+4396,SALPICAR,v.t. Wits’
+4397,SALPULLIDO,sus. Uusáan
+4398,"SALTAR, BRINCAR","v.i. P’iitik, síit’, p’íit."
+4399,SALTAR LAS GOTAS DE UN LÍQUIDO QUE SE DERRA,
+4400,MA,"v.i. Tits’, tiis."
+4401,SALUD,sus. Toj óol.
+4402,SALUDABLE,adj. Tojóolal
+4403,SALUDAR INCLINANDO LA CABEZA,v.t. Chíinpool
+4404,"SALUDO, TRAER Y SALUDAR",v.t.Julesaj.
+4405,"SALVADOR, REDENTOR, LIBERTADOR",sus. aj Tóoksaj.
+4406,"SALVAR, DAR AUXILIO, REDIMIR",v.t. Tóoksaj
+4407,SANAR,v.i. Utstal
+4408,SANAR,v.t. Mal
+4409,SANDÍA,sus. Chak bojonja’
+4410,SANGRE,sus. K’i’ik’
+4411,SANGRE CUAJADA,sus. Olom
+4412,SANGRÍA,"sus. Kokan SANGRIENTO, buk’e’en."
+4413,ENCARNIZADO,adj. Chak
+4414,SANTIFICADO,adj. Kili’ichkuntabak
+4415,SANTIGUARSE,"v.i. Chikilbesaj ich,"
+4416,SANTO,sus. Kili’ich
+4417,SAPO,sus. Muuch
+4418,SARAGUATO (ALOUATTA PALLATA MEXICANA),sus.
+4419,SARAMUYO (ANNONACEA ( ANNONA RETICULATA)),sus. Ts’almuy
+4420,SARGAZO,sus. Ta’il k’áanab
+4421,SARNA,"sus. Jaway, chachak uay"
+4422,SARTENEJA (OQUEDAD EN LA PIEDRA EN QUE SE ACUMU,
+4423,LA EL AGUA DE LLUVIA),sus. Jaltun
+4424,SASTRE,"sus. J chuuy, j chuuy nook’"
+4425,SATISFECHO,adj. Tuup óol.
+4426,SAÚCO AMARILLO (TECOMA STANS (L)H B ET K),sus. X k’anlol
+4427,SAZÓN DEL MAÍZ,sus. Yij
+4428,"SAZÓN, MUY SAZÓN",adj. K’aank’aanki.
+4429,SECARSE,v.i. Tijil.
+4430,SECARSE,v.i. Sap
+4431,SECARSE UN POZO O AGUADA,v.i. Sa’ap’ak
+4432,SECO,adj. Tikin
+4433,"SECO, MUY SECO",adj. Wóowooki.
+4434,"SECO, DESHIDRATADO",adj. Síisiiki
+4435,"SECO, MUY SECO",adj. K’áak’áalki.
+4436,SECRETO,sus. Ta’ak tsikbal
+4437,SECUESTRAR,v.t.Chuk ba’alba.
+4438,SED,sus. Uk’aj
+4439,SEDIMENTO,sus. Xiix
+4440,SEGUIR A OTRO,"v.t. Ch’a’ ook, ch’a’ ookil."
+4441,"SEGUIR, CONTINUAR",v.i.Baykunaj.
+4442,SEGUIR EL RASTRO,"v.t. T’ul, t’u’ulpachto’ob"
+4443,SEGÚN,"prep. Je’ebik, je’ebix"
+4444,SEGURIDAD,sus. Toj óolal
+4445,SEGURO,adj. Muuk’a’an
+4446,SEIS,sus. Wáak
+4447,SELECCIONAR,"v.t. Téet, yéey"
+4448,SELVA,"sus. Jub che’, k’áax, ka’anal k’áax"
+4449,SELLADO,adj. Ts’ala’an
+4450,SELLAR,v.t. Ts’al
+4451,SELLO,sus. Ts’al
+4452,"SEMBRADO, SIEMBRO",sus. Pak’áal.
+4453,SEMBRAR,v.t. Páak’al.
+4454,SEMBRAR MAÍZ,"v.t. Oksaj, páak’al."
+4455,SEMEJANTE,"adj. Ket, bayjal"
+4456,SEMEJANTE,"sus. Éetwíinikil, yéet, wéet, bat"
+4457,SEMEN,"sus. Sa’il keep, k’oy, lel,lal, xex."
+4458,SEMILLA,sus. Neek’
+4459,SEMILLA DE CALABAZA,sus. Sikil
+4460,SEMILLA DE MAÍZ,sus. I’inaj
+4461,SENCILLO,adj. Joya’n
+4462,SENDERO,"sus. T’ulbe, éek’bej"
+4463,SENO,sus. Im
+4464,SENSIBILIDAD,sus.Chajil.
+4465,SENSITIVA,sus. X mumuts’
+4466,SENTAR,v.i. Kutáal.
+4467,SENTARSE,"v.i. Kutal, pek’, kultal"
+4468,SENTENCIA,"sus. Ts’áaj tuukul, xoot k’iin, xoot"
+4469,SENTIR CON EL TACTO O CON EL GUSTO,"v.i. U’ub, k’iin t’aan. u’ubaj, u’uy"
+4470,SENTIR MUCHO UNA COSA,v.t. Najal ti’ol
+4471,SEÑAL,"sus. Bilim, chíikul"
+4472,SEÑALAR,"v.t. Tuch’ub, joch kintaj"
+4473,SEÑOR,"sus. Yuum, taat, yuumtsil"
+4474,SEÑORA,"sus. Ko’olel, xunáan."
+4475,SEÑORITA,sus. X nin.
+4476,SEPARAR,v.t. Jaats.
+4477,"SEPARAR, DISPERSAR",v.t. Jaab.
+4478,"SEPULTAR, ENTERRAR",v.t. Muuk
+4479,SEPULTURA,sus. Múuknal SEPULTURERO. sus. Aj muuk kimen.
+4480,SEQUÍA,"sus. Yáax k’iin, noj k’iin"
+4481,SER MALIGNO,"sus. Baba’al SER SOBRENATURAL QUE SE PRESENTA EN LA NOCHE BAJO LA SOMBRA DE UNA CEIBA, ADOPTANDO LA FORMA DE UNA MUJER MUY BELLA VESTIDA DE HIPIL PEINANDO SU LARGA CABELLERA PARA"
+4482,SEDUCIR A LOS HOMBRES,sus. X táabay
+4483,SER TRABAJADOR,sus. J meyjil
+4484,SERENATA,"sus. Ye’eblan k’aay, tunar"
+4485,SERMÓN,sus. Tse’ek
+4486,SERMONEAR,v.t. Tse’ekt
+4487,SERPENTEAR,v.i. Bik’chalák. SERPIENTE CORALILLO (MICRURUS).
+4488,"SERVIR, UTILIZAR",v.i. Biilal
+4489,"SERVIR, ATENDER","v.t. Táanlaj, táan óol. sus."
+4490,SERVIR DE ALGO,v.i. Ch’alik
+4491,SESENTA,sus. Óox k’aal
+4492,SESEO,sus. Ses
+4493,SESO,sus. Ts’o’om
+4494,SETENTA,sus. Lajun p’eel ti kan k’áal
+4495,SETO,sus. Jil che’
+4496,SEXO SERVIDORA,"adj., sus. Káakbach"
+4497,SI,"adv. de a. Ajaaj, bey, beyo’, jaaj"
+4498,SI,conj. cond. Wáa
+4499,SIEMPRE,"adv. de t. Bayjal, bayli’, bayli, binili’, jun k’uli’, mantats’, juntiich’."
+4500,SIEMPRE,"conj. cond. Layli’,bayli’, binili’."
+4501,PERMANECER,"v.i. Bayjal, bayli’"
+4502,SIETE,sus. Úuk
+4503,SIGNO,"sus. Chíikul, wooj"
+4504,SILBAR,"v.i. Xóobt, xúuxub, xóob."
+4505,SILBIDO,"sus. Xóob, xúuxub"
+4506,SILENCIO,"sus. Ch’ench’enki, ch’il"
+4507,SILVESTRE,adj. K’áaxil
+4508,SILLA,"sus. Kulxekil, xek, x kulupche’"
+4509,SÍMBOLO,sus. Wooj
+4510,"SIMPLE, SIN AZÚCAR, SIN RECADO",adj. Piits’.
+4511,SIMULTÁNEO,"adv. Éetk’iin, éetk’iinil."
+4512,SIN,"prep. Achak, x ma’"
+4513,SIN CUENTA,"adj. Chaket, cheket, ma’ xulum"
+4514,SIN EMBARGO,Bakakix
+4515,SIN QUE,prep. Achak
+4516,SINO,prep. Achak
+4517,SINVERGÜENZA,adj. J ma’ su’tal
+4518,SIRVIENTA,"sus. Ix k’oos, x k’oos."
+4519,SIRVIENTE,"sus. Aj k’oos, j k’oos"
+4520,"SOBADOR, HUESERO, QUIROPRÁCTICO",sus. Aj
+4521,"SOBAR, MASAJEAR, MANOSEAR","v.t. Páats’, yeet’, páats’, aj yeet’. yoot’. SOPLAR"
+4522,SOBRE,"prep. Yóok’ol, yóok’"
+4523,SOBRESALIENTE,adj. Atpuj.
+4524,SOBRINO,"sus. Sob, achak, ach’ak"
+4525,SOBRIO,adj. Núuk
+4526,SODOMITA,"sus. Aj top it, Aj top lom chun, síis óol."
+4527,"SOSIEGO, PAZ","sus. Ets’a’an óolal, ets’ óol."
+4528,SOGA,sus. Suum
+4529,SOGA DE POZO,sus. Suumil ch’e’en
+4530,SOGUILLA,sus. Léech kaal
+4531,SOJUZGAR,"v.t. Kulkinaj yaalan ook, kukinaj yaalan k’ab, kula’an"
+4532,SOL,sus. K’iin
+4533,SOLDADO,"sus. Jolkan, aj k’a’tun wíinik."
+4534,SOLEDAD,"sus. Ch’eneknakil, chiltal"
+4535,SOLEMNIDAD,sus. Tsiktsilil
+4536,SOLO,"adj. Tu ba, ti’ junal, chéen tu jun."
+4537,SOLTAR DE LA MANO,v.t. Sipit
+4538,SOLLOZO,"sus. Jaja’ok’ol, múukul ok’ol"
+4539,SOMBRA,sus. Bo’oy SOMBRA DE ALGÚN CUERPO PROYECTADA A CAUSA
+4540,DE LA LUZ,sus. Woochel
+4541,SOMBRA DEL CUERPO,sus. Oochel
+4542,SOMBRA Y AMPARO,sus. Boch’
+4543,SOMBRERO,sus. P’óok
+4544,SOMBRILLA,sus.Balab k’iin
+4545,SONAJA,"sus. X tuuch’, so’ot"
+4546,SONÁMBULO,sus.Chukut kibil
+4547,SONAR,v.i. Juum.
+4548,SONAR LA BARRIGA,v.i. Bubulaankil nak’.
+4549,SONAR LA NARIZ EL CABALLO SACUDIÉNDOLA,Po
+4550,SONDEAR,"v.t. Bobojtej, túuntaj, túunt"
+4551,SONIDO MUY HUECO,adj. Jóojoonki.
+4552,SONIDO FUERTE QUE LASTIMA LOS OÍDOS,adj. Ch’e’ej
+4553,SOBERBIA,"sus. Nojbail, nonojbail, tsikbail."
+4554,SOBERBIA,"sus. Ka’anal óol, ka’anan óol."
+4555,SOBERBIO,"sus. Aj nojbail, j nojbail."
+4556,SOBERBIO EN HABLAR,sus. Aj bobok’ t’aanil
+4557,SOBRA,sus. Yala’
+4558,SOBRE,sus. Paymun
+4559,"SONORO, QUE SUENA FUERTE",adj. Chéecheej
+4560,SONREÍR,"v.i. Sakche’ej, che’ej."
+4561,SONRISA,sus. Sak che’ej
+4562,SOÑAR,"v.i. Náayt, wayak’, náay."
+4563,SOPA,"sus. Ya’ach’, chok’ob"
+4564,SOPLAR CON LA BOCA,"v.i. Uust, uustik"
+4565,SOPLAR CON REPETICIÓN,v.t. Jojopsa
+4566,SOPOR,sus. Nikib
+4567,"SORBER, BEBER A SORBOS",v.t. Xúuch
+4568,SORBER ALGÚN LÍQUIDO ESPESO,v.t. Jáap
+4569,SORBO,sus. Xúuch.
+4570,SORDO,sus. Kóok
+4571,SORONGO O CHONGO,sus. T’uuch
+4572,SORPRENDER,v.t. Jak’aj óol
+4573,SOSEGAR,v.i. Toj jal óol
+4574,SOSPECHAR,v.i. Ch’ajal óol
+4575,SOSTENER CON LA PALMA DE LA MANO,v.t. Láat’.
+4576,SOSTENER ALGO EN LA PLANTA DE LA MANO,v.t. Pe’
+4577,SU,adj. poses. U
+4578,SUAVE,"adj. Mamayki, mamaykil, o’olki, ts’u’uts’ukil, ts’u’uts’uki."
+4579,"SUAVE, MUY SUAVE",adj. Biibiiki.
+4580,"SUAVE, MUY SUAVE ( PARA LA ARENA , TIERRA, POL",
+4581,VO),adj. Júujuupki.
+4582,SUBIR,v.i. Na’akal
+4583,SÚBITAMENTE,adv. de m. Chetun
+4584,SUBSTITUIR,"v.t. Jeel, k’eex"
+4585,SUCEDER,"v.t. Úuch chajal, úuchul"
+4586,SUCEDIDO,sus. Máanlil
+4587,SUCESOR,sus. K’exulan
+4588,SUCIO,"adj. Éek’, k’óok’ol, kiirits’"
+4589,"SUCIO, MUY SUCIO",adj. Cha’acha’aki.
+4590,SUDADERO,sus. Taats’ paach.
+4591,SUDARIO,"sus. Cho’ob, k’axab ich"
+4592,SUDAR,"v.i. K’íilkab, k’íilkabankil."
+4593,SUDOR,sus. K’íilkab.
+4594,SUEGRA,"sus. Jawan, x noj na’e’, x jaachil."
+4595,SUEGRA DE LA MUJER,"sus. Noj ko’, x nij ko’"
+4596,SUEGRO,"sus. Jachil, noj yuum, aj jawan, j ja"
+4597,SUELA,"sus. K’éewel, táan xanab."
+4598,SUELDO,sus. Náajal
+4599,SUELO,sus. Biltum
+4600,SUELO AMARILLENTO,sus. Ak’alche’
+4601,SUELO ARCILLOSO,sus. Ak’alche’
+4602,SUELO ARTIFICIAL,sus. Pak’ bitun
+4603,SUELO PEDREGOSO,sus. Tsek’el 
+4604,"SUMIR, HUNDIR",v.i. Laam.
+4605,"SUMIR, REMOJAR, EMPAPAR",v.t. Ts’aam.
+4606,SUEÑO,"sus. Wayak’, náay."
+4607,SUERTE,sus. K’intaj
+4608,SUFICIENTE,adv. Chaan.
+4609,SUFIJO CLASIFICADOR PARA CONTAR AZOTES,Puul SUFIJO CLASIFICADOR PARA CONTAR ANIMALES O
+4610,PERSONAS,Túul
+4611,SUFIJO CLASIFICADOR PARA CONTAR ÁRBOLES,
+4612,SUFIJO CLASIFICADOR PARA CONTAR HOJAS Y DO,
+4613,BLECES,Wáal
+4614,SUFIJO CLASIFICADOR PARA CONTAR OBJETOS,
+4615,SUFIJO CLASIFICADOR PARA CONTAR OBJETOS ALAR,
+4616,"GADOS COMO VELAS, DEDOS, CAÑAS",Ts’iit
+4617,SUFIJO CLASIFICADOR PARA CONTAR PUÑADOS,
+4618,SUFRIMIENTO,"sus. Muk’ óolal, yaayaj kuxtal."
+4619,SUFRIR,v.i. Muk’yaj
+4620,SUICIDARSE,v.i. Kíimsikba
+4621,SUJETAR,"v.t. Kulkinaj yaalan ook, kukinaj Kúul P’éel Lap’ yaalan k’ab, kula’an"
+4622,SUMA,sus. Buk’xookil
+4623,SUMAR,v.t. Bak’ xook
+4624,SUMERGIR,"v.i. Ts’aam, ts’am, buul, ts’oom"
+4625,SUMERGIDO,adj. T’úubent’úub.
+4626,SUMIR,v.t. Lam
+4627,SUPERCHERÍAS,sus. Babal t’aano’ob.
+4628,SUPLENTE,sus. Jeel
+4629,SÚPLICA,"sus. Yaanyan, k’áat, yaayan."
+4630,SUPONER,v.i. Nak’kuktik.
+4631,SUPOSICIÓN,sus. Ch’a
+4632,SUR,sus. Nojol
+4633,SURCO,sus. T’o’ol.
+4634,SUREÑO,adj. J nojolil.
+4635,SUSPENDER,v.t. Jáaw
+4636,"SUSPENDER, ALZAR, LEVANTAR",v.t. Ch’úuy.
+4637,SUSPENSO,sus. Ch’ena’an.
+4638,"SUSTENTAR, ALIMENTAR",v.t. Tséent
+4639,SUSTO,sus. Jak’ óol
+4640,"SUYO, DE ÉL",pron. poses. Utia’al
+4641,"SUYO, DE ELLOS",pron. poses. Utia’alo’ob
+4642,TABACO (NICOTINA TABACUM L),sus. K’úuts
+4643,TÁBANO,sus. Áakach
+4644,TACAÑO,adj. Ts’u’ut
+4645,"TAJAR, PELAR","v.t. Súus, p’e’es."
+4646,TAL VEZ,"adv. de d. Wale’, uale’, úuchak"
+4647,TALA EN GENERAL,sus. Sakal
+4648,TALAR,v.t. Ch’akbe’ent
+4649,TALEGA,sus. Mukuk
+4650,TALENTO,sus. Chich óolal
+4651,TALISMÁN,sus. Yut.
+4652,TALLAR,v.t. Póol
+4653,TALLO,"sus. Che’el, kanil"
+4654,TAMBALEAR,v.i. Takchalaankil.
+4655,TAMBALEO,sus. Takchalaankil.
+4656,TAMBIÉN,"adv. de a. Bey, bey xan, láaylie’, léeyli, xan"
+4657,TAMO O POLVO DEL MAÍZ,sus. May ixi’im
+4658,TAMPOCO,"adv. de n. Mix, mix xan."
+4659,"TAMULADOR, MOLCAJETE",sus. K’utub
+4660,TAPA,"sus. Maak TAPACAMINO (AVE ,CAPRIMULGUS SERICOCAUDATIS"
+4661,SALVINI (HARTER)),sus. Pu’ujuy
+4662,TAPAR,"v.t. Bal, pix, maak."
+4663,TAPIR,sus. Ts’iimin k’áax
+4664,TAQUIGRAFÍA,sus. Taj ts’íibtaj
+4665,TARÁNTULA,"sus. Chíiwoj, x ch’íil tun, x"
+4666,TARDAR,v.i. Xáantal
+4667,TARDE,"sus. Chúunk’iin, oknajk’iin, chíinik k’iin, chíinil k’iin."
+4668,TARTAMUDEAR,"v.i. Altal yaak’, k’alk’alak chiwol t’aan"
+4669,TARTAMUDEZ,sus. Ses
+4670,TARTAMUDO,"adj. Aj al yaak’, aj ses, nuntal"
+4671,TATUAR,v.t. Jots.
+4672,"TECOLOTE, BÚHO (BUBO VIRGINIANUS MAYENSIS)",sus. Tunkuluchuj
+4673,"TEJER, TRENZAR","v.t. Jiit’ TEJÓN,PIZOTE, COATÍ (NASUA NARICA YUCATANICA (ALLEN))."
+4674,TELARAÑA,sus. Mak maktaj k’áan.
+4675,TELÉFONO,sus. Sutuchiilt’aan
+4676,TELÉGRAFO,sus. Jultuchiilt’aan
+4677,TELEVISIÓN,"sus. Náachil e’esaj oochel, máa"
+4678,TEMA,sus. Chich
+4679,TEMBLAR,"v.i. Kikiláankal, kikiláankil"
+4680,TEMBLAR DE MIEDO Y ESPANTO,v.i. Papalankil
+4681,TEMBLAR LA TIERRA,"v.i. Kíilbal, temba, yuk"
+4682,TEMBLOR,sus. Kíilbal
+4683,TEMBLOR DE TIERRA,sus. Yanba lu’um
+4684,TEMER,v.i. Sajaktal
+4685,TEMIBLE,"adj. Sajbe’en, sajbe’entsil"
+4686,TEMOR,"sus. Sajkil, sajak"
+4687,TEMPERAMENTO,sus. K’íinal óol.
+4688,TEMPLADO,adj. Núuk.
+4689,TEMPLANZA,sus. P’iis bail
+4690,TEMPORAL,adj. Xululte
+4691,TEMPRANO,adv. de t. Ja’atskab
+4692,TENAZAS,sus. Nat’ab
+4693,TENDER,"v.t. Jayba, jaybaj."
+4694,TENDER LA ROPA,v.t Le’
+4695,TENDER POR EL SUELO,v.t. jayaj
+4696,TENDIDO,"adj. Síin, te’a, ja’aya, ja’ayan"
+4697,TENDÓN,"sus. Xiich’, t’in xich’"
+4698,TENER,v.t. Yaan.
+4699,"TENSAR, TENDER",v.t. T’iin
+4700,"TENSO, A PUNTO DE REVENTAR",adj. T’íint’iinki.
+4701,TENSAR VARIAS VECES CON FUERZA UNA CUERDA,
+4702,TENTACIÓN,"sus. Túuntabail, tutajuli’"
+4703,TEPEZCUINTLE,(CUNICULUS PACA NELSONI).
+4704,TERCIAR,v.t. Ch’aal t’aan
+4705,TERCO,adj. Nonolki
+4706,TERMINADO,adj. Ts’o’ok beyo’
+4707,TERMINAR,"v.t. Jaw, ts’o’okol, xuul"
+4708,TÉRMINO,"sus. Cheel, ts’o’ok, xuul"
+4709,TÉRMINO DE PLAZO SEÑALADO,sus. P’elk’iin
+4710,TÉRMINO DE TIEMPO,sus. P’elk’iin
+4711,TERNURA,sus. Muun óol
+4712,TERQUEDAD,sus. Nonojbail
+4713,TERCO,sus. Aj nonojbail.
+4714,TERCA,sus. Ix nonojbail.
+4715,TERRENO ABANDONADO,sus. X tokoy
+4716,TERRENO BAJO,sus. Ak’alche’
+4717,TERRENO CON MATORRALES,sus. Ak’alche’
+4718,TERRENO CON SUELO DE RENDZINA NEGRA,sus. Ak’alche’
+4719,TERRENO INUNDABLE,sus. Ak’alche’
+4720,TESTIGO,"sus. Ts’áaj jaajil, aj jaajkuns t’aan."
+4721,TESTIMONIO,"sus. Kunaj t’aan, tojol t’aan"
+4722,TÍA,sus. Ix kit
+4723,TIBIO,"adj. K’inal, pa’a síis, síis chokoj"
+4724,TIBURÓN,sus. K’an xok
+4725,TIEMPO,sus. K’iin
+4726,TIEMPO DE FRÍO,sus. Ke’elil.
+4727,TIEMPO DE LLUVIA,"sus. Ja’ja’lil, ja’aja’al"
+4728,TIEMPO DE SEQUÍA,"sus. Noj k’iinil, yáax k’iin"
+4729,TIEMPO EN QUE ABUNDA UNA COSA,sus. K’iinbe’n
+4730,TIEMPO PARA CAPTURAR ANIMALES,sus. Pets’
+4731,TIERNO,"adj. Áak’, muum"
+4732,TIERNA,sus. Ix muun óol.
+4733,TIERNO,sus. Aj muun óol. 
+4734,TIERRA,"sus. Kaab, lu’um"
+4735,TIERRA BLANCA,sus. Saskab
+4736,TIERRA BUENA Y FÉRTIL,Tul lu’um.
+4737,TIERRA MUY PEDREGOSA,sus. Tsek’el
+4738,"TIERRAS QUE DESORIENTAN, QUE NUBLAN EL EN",TENDIMIENTO. EL REMEDIO ES ENCENDERLES
+4739,UNA VELA O VELADORA,sus. Ts’íik lu’um
+4740,TIESO,"adj. To’och, to’otokil."
+4741,"TIESO, MUY TIESO",adj. Tojtojki.
+4742,TIGRILLO,sus. Sak xikin
+4743,TÍMIDO,adj. J nuum
+4744,TÍMPANO,sus. Papatal.
+4745,TINTA NEGRA,sus. Sabak
+4746,TINTINEO,sus. Tsan.
+4747,TINTURA,sus. Boon
+4748,TÍO,"sus. Akan, ts’éyuum"
+4749,TIRA,sus. Wewel
+4750,TIRAR,"v.t. Ch’iin, puul."
+4751,"TIRAR, AVALANZAR, ARROJAR",v.i. Puul DERRIBAR TIRAR VARIAS O Lúulu’usik.
+4752,VECES,v.t.
+4753,TIRAR PARA ASUSTAR,v.t.To’onto’onch’íin. TIRAR Y REVOLVER ALGUNAS
+4754,COSAS,v.t. Xéexeek’.
+4755,TIRAR POR TIRAR,v.t. Ch’íinch’iin.
+4756,TIRAR SIN PUNTERÍA CON ARMA DE FUEGO,v.t.
+4757,TIRAR CON ARMA DE FUEGO VARIAS VECES,v.t. Báabaalts’oon. Ts’oonts’oon.
+4758,TITILAR,"v.i. Jojopaankil, léembal"
+4759,TIZNE,sus. Sabak
+4760,TIZÓN,sus. Naxche’ TLACUACHE Ooch (DIDELPHYS MESOAMERICANA).
+4761,TOALLA,"sus. Cho’ob, k’axab ich"
+4762,TOBILLO,sus. Kuy
+4763,TOCAR UN INSTRUMENTO,v.t. Páax
+4764,TODA,"adv. de c. Mal, tuláakal."
+4765,TODA LA NOCHE,adv. de t. Buláak’ab
+4766,TODAVÍA,adv. de t. Asab
+4767,TODO,"adv. de c. Láaj, mal, tuláakal, tusinil"
+4768,TODO EL DÍA,adv. de t. Bulk’iin
+4769,TODO ENTERO,adv. de c. Petel
+4770,TODO JUNTO,adv. de m. Wol
+4771,TODOS NOSOTROS,pron. indef. Tuláaklo’on.
+4772,TOLERANCIA,sus. Máansaj óolal.
+4773,TOMAR,v.t. Ch’a’b
+4774,TOMAR POSESIÓN,v.t. Pach
+4775,TOMAR PRESTADO,v.t. Majan
+4776,TOMATE (LYCOPERSICUM ESCULENTUN),sus. P’aak
+4777,TONTERA,sus. Netsil.
+4778,TONTO,"adj. Nets, nuun, nóol (Hondzonot,"
+4779,"TOSCO, RÚSTICO",adj. To’och.
+4780,TOSER,"v.i. Se’enak, se’en."
+4781,TOSER PARA ACLARAR LA VOZ,v.i. Babkaltaj
+4782,TOSER POR COMEZÓN EN LA GARGANTA,v.i. Sáasaak’kaal.
+4783,TOSFERINA,"sus. T’uju’, x t’ujub"
+4784,TOSTAR,"v.t. K’éel , póok, k’áak’t."
+4785,TRABAJADOR,sus. Sa’ak’ol
+4786,TRABAJAR,v.i. Meyaj
+4787,TRABAJO COLECTIVO,"sus. Múul meyaj, múu"
+4788,TORCER,"v.t. Bil, juk’, ch’eet."
+4789,"TORCER, EXPRIMIR, DARLE VUELTAS A ALGO",v.t.
+4790,"TRABAJOS, PESARES, DIFICULTADES",sus. Num
+4791,TRABALENGUAS,"sus. K’alk’alak t’aan, t’iit’il"
+4792,"TORCERSE, CERRAR UN CANDADO",v.t. Ch’óotol
+4793,TORDILLO,adj. Chukim
+4794,"TORDO, GRAJO O ZANATE DE YUCATÁN (MEGAQUIS",
+4795,CALUS MAJOR MACROURUS (SWANSON),"sus. K’a’au, k’a’aw."
+4796,TOREAR,"v.t. Paay, páayal"
+4797,TOSTAR,"v.t. K’éel, póok."
+4798,TOSTADA,sus. Oop’.
+4799,TORCERSE,v.i. Ch’ettal.
+4800,TORERO,sus. J paay wakax
+4801,TORMENTOS,sus. Numyail
+4802,TORNAR,v.i. Walk’ajal
+4803,TORNO DE ALFARERO,"sus.K’abal, K’aba’al."
+4804,TORO,sus. Xiibil wakax
+4805,TORRE,sus. Julbil naaj.
+4806,TORTEAR (HACER TORTILLAS CON LAS MANOS),v.t. Pak’ach
+4807,TORTILLA DE MAIZ,sus. Waaj
+4808,TORTILLA DE MAIZ NUEVO,sus. Iis waaj
+4809,TORTILLA DURA,sus. Chuchul waaj TORTILLA GRUESA QUE SE CUECE DIRECTAMENTE
+4810,SOBRE LA BRASA,sus. Péenkuch
+4811,TORTILLA RESECA,sus. Chuchul waaj
+4812,TORTILLA TOSTADA,"sus. Oop’ TÓRTOLA, (COLUMBIGALLINA PASSERINA PALLESCENS (BAIRD)) ."
+4813,TORTUGA,sus. Áak
+4814,TOS,"sus. Sa’asak, sasa’kaal yail aak’ luuk’."
+4815,TRABAR,v.t. Léech
+4816,TRAER,"v.t. Taas, taasik, púut."
+4817,"TRAFICADO, MUY TRAFICADO",adj. K’áak’aatki.
+4818,TRAGAR,v.t. Luuk’
+4819,TRAGAR CON PRESTEZA,"v.t. Pot luuk’, totop"
+4820,TRAGADO RÁPIDO,adv. de m.Lúuluuk’bil
+4821,TRAIDOR,sus. Aj k’uubilaj.
+4822,TRAICIÓN,"sus. K’uubilaj, k’uuba’an paach."
+4823,TRAJE DE LAS MUJERES INDÍGENAS DE YUCATÁN,
+4824,TRAJE NEGRO,sus. Sabak nook’.
+4825,TRAMPA DE LAZO,sus. Léech
+4826,TRANCA DE LA PUERTA,"sus. No’ox che’, k’aal sus. Iipil che’"
+4827,TRANQUILIDAD,"sus. Ets’a’an óolal, ts’akin"
+4828,TRASCENDER,"v.t. Balk’ajal, buyul."
+4829,TRANSFIGURARSE,v.i. Jeelpaji’ u yich
+4830,TRANSPORTAR OBJETOS O FRUTAS,v.t. Púut
+4831,TRAQUEA,sus. Yúul
+4832,TRASPARENTE,"adj. Sáapik’en, saask’alen, saast’en"
+4833,TRASPLANTAR,v.t. Xaab.
+4834,TRATO,"sus. Nuupt’aan, k’aax t’aan."
+4835,TRAVIESO,"adj.(m) J ko’ , (f) Ix ko’."
+4836,TRÉBOL,sus. Xchiople’
+4837,TRECE,sus. Óox lajun p’éel.
+4838,TREINTA,sus. Lajun p’éel ti ka’a k’aal
+4839,"TRENZADO, MUY ENREDADO",adj. Jíijiit’.
+4840,TREPAR,v.t. Na’akal
+4841,TRES,sus. Óoxp’éel.
+4842,TRIBULACIÓN,sus. Numya
+4843,"TRILLADO, MUY TRILLADO","v.t. T’uut’uulki, t’áat’aalki."
+4844,TRINCHERA,"sus. Pa’, tulum."
+4845,TRISTE,"adj. J k’om óol ich, J yaaj óol ich."
+4846,TRISTEZA,"sus. Yaaj óolal, ok’om óolal."
+4847,TRITURAR,"v.t. Juch’, mux"
+4848,TROCAR,v.t. Jelkunaj
+4849,TROJE DE MAÍZ,"sus. Ch’iil, kumche’"
+4850,TROMPETA,sus. Jom
+4851,TRONAR,v.i. Kíilbal
+4852,TRONCO,sus. Chuun
+4853,TRONERA,sus. Kisneb
+4854,TRONO,"sus. Nak, ts’am, k’áanche’ ajau."
+4855,TROPEZAR,"v.i. T’óochpajal, t’óochpaj"
+4856,"TROZAR, DESPEDAZAR",v.t. Koots
+4857,TRUENO,"sus. Kíilbal cháak, péek cháak"
+4858,TRUEQUE,"sus. Jeel, k’ex, k’exul"
+4859,TU,adj. poses. A
+4860,TUBÉRCULO,sus. K’uk’ut
+4861,TUBERCULOSO,sus. Aj bakil
+4862,TUCÁN,sus. Pan ch’eel
+4863,TUERTO,adj. Ch’óop
+4864,TUMBA DE LA SELVA,sus. Kool.
+4865,"TUMBA, SEPULTUA",sus. Múuknal
+4866,TUMBAR,"v.t. Kool, nix"
+4867,TUMOR,"sus. Chu’chum, chu’uchum"
+4868,TUMULTO,sus. P’ujul TUNA (OPUNTIA DILLENII (KER
+4869,TURBADO,adj. Kilba óol
+4870,TURBIO,adj. Puuk’
+4871,TUYO,pron. poses. Atia’al.
+4872,"TUZA (HETEROGEOMYS, HÍSPIDUS (SAY))",sus. Baj sus.
+4873,UBRE,"sus. Chu’uch ba’alche’, yiim ba’alche’"
+4874,ÚLTIMO,sus. Ts’o’ok
+4875,UN INSTANTE,adv. de t. Jun súutuk
+4876,UN POCO,"adv. de c. Ts’e’ets’ek, jun p’íit, jun"
+4877,UNA VEZ,"adv. de t. Jun jets’ake’, junténajkij, p’íitil juntéenekij"
+4878,"ÚNICO, COSA SOLITARIA",sus. Junab.
+4879,UNIDO,adj. Nuupan
+4880,UNIDOS POR GRUPOS,adv. de c. Lo’olo’ot.
+4881,UNIÓN,sus. Jun óolal
+4882,UNIR,"v.t. Nup, nup’, nuupik."
+4883,"UNIR, PEGAR, EMBONAR",v.t. Tak’
+4884,"UNIR, JUNTAR, PEGAR",v.t. Loot.
+4885,UNTAR,v.t. Ku’ul.
+4886,"UNTAR, PEGAR","v.t Paak’ UNTAR EL BOCADO EN LA COMIDA,PRESIONAR LA CARNE GUISADA .v.t. Ts’aal"
+4887,UNTAR,"v.t. Ji’, ji’i, ji’ik"
+4888,UÑA,sus. Iich’ak
+4889,UÑA DE GATO (PISONIA AULEATA),sus. Beeb
+4890,URDIMBRE,sus. Mamak
+4891,URDIR,v.t. Waak’
+4892,URDIR HAMACA,v.t. Waak’k’áan
+4893,URGENTE,adv. de m. Séeb
+4894,URRACA,sus. Ch’eel
+4895,USTEDES,pron. pers. Te’ex
+4896,UTENSILIO,sus. Nu’ukul UTENSILIO DE LA COCINA MAYA QUE CONSISTE EN
+4897,UNA CIRCUNFERENCIA DE BEJUCO CUYO INTE,
+4898,RIOR ESTÁ TEJIDO CON HILOS DE HENEQUÉN,sus. Peten aak’
+4899,ÚTERO,"sus. Sayomal, soyem."
+4900,ÚTIL,adj. K’abéet
+4901,UVA DE LA COSTA,sus. Mixche’
+4902,UVA DE MAR (COCCOLOBA UVÍFERA (L) JACQ),sus.
+4903,UNIVERSIDAD,"sus. U molay kanbal, noj na"
+4904,UNO,sus. Jun
+4905,UVAS,sus. Sak tabka’an
+4906,UVERO,sus. Mixche’ UVERO
+4907,VACA,sus. Ch’úupul wakax
+4908,VACIAR,v.t. Láal
+4909,"VACIAR, TRASEGAR",v.t. Báab
+4910,VACIAR ALGÚN LÍQUIDO EN EMBASE DE BOCA AN,
+4911,GOSTA O CUELLO DELGADO,v.t. T’ooj.
+4912,"VACILAR, BROMEAR",v.i. Tuuskeep
+4913,VACÍO,adj. Joch.
+4914,VACUNA,sus. Jup’lants’aako’
+4915,VAGABUNDO,sus. Aj nunum
+4916,VAGINA,sus. Peel
+4917,VAHÍDO,sus. Tupul ich
+4918,VAHO,sus. Owox
+4919,VAINA,sus. Piix
+4920,VALENTÍA,"sus. Chichil óolal, jolkanil"
+4921,VALIENTE,adj. Aj koo
+4922,"VALIOSO, NECESARIO","adj. K’a’anan, k’a’ana’an"
+4923,"VALOR, PRECIO","sus. Tojol, tojoj."
+4924,"VALOR, VALENTÍA","sus. Xet’ óolal, yail, j ma’ sajkil, x ma’ sajkil."
+4925,VALLE,sus. Jem
+4926,VANAGLORIA,sus. Nonojbail
+4927,VANIDAD,sus. Ma’ba’lil
+4928,VANIDOSA,adj. X ka’amal
+4929,VANIDOSO,adj. J ka’amal.
+4930,VAPOR,"sus. Ooxol, owox"
+4931,VAQUERO,sus. J kanan wakax VARA PARA MEDIR QUE TIENE LA SEXTA PARTE DE
+4932,"UN MECATE, ES DECIR 333 m",sus. P’iisiche’
+4933,VARIEDAD DE AVISPA DE GRAN TAMAÑO CUYA PICA,
+4934,DURA PROVOCA FIEBRE,sus. Bobo’te’ 
+4935,VARIEDAD DE FRIJOL NEGRO,sus. Tsama’
+4936,VARIEDAD DE MOSCA PEQUEÑA,sus. Us
+4937,VECINO,sus. Et chi’ na
+4938,VEINTE,sus. Jun k’aal
+4939,VEINTIUNO,sus. Jun p’éel ti ka’a k’aal
+4940,VEJEZ,sus. Ch’íijil
+4941,VEJIGA,"sus. Chim, chimix"
+4942,VELA,sus. Kib
+4943,VELAR,"v.t. Kanankimén, kalankimén"
+4944,VELO DE NOVIA,sus. K’asab nook’
+4945,VELORIO,sus. Kanankimén.
+4946,VELOZ,"adj. Séeb, séeba’an"
+4947,VELLOS,sus. Ts’ukuti
+4948,VENA,sus. Beel k’i’ik’
+4949,VENADO COLA BLANCA,sus. Kéej
+4950,VENADO ENANO (MAZAMA PANDORA (MERRIAM)),
+4951,VENADO CON CUERNO DE UNA PUNTA,sus.
+4952,VENADO CON CUERNOS RAMIFICADOS,sus. Nikte’ sus. Yuuk. Púuts’nab. baak.
+4953,VENCER,"v.t. Baksaj, pa’ muuk’"
+4954,VENCER A OTRO,v.t. Ts’oyesaj
+4955,VENCIDO,"sus. Baksaj, kuch chimal"
+4956,VENDER,v.t. Kóonol
+4957,VENENO,"sus. Ts’akil, yek’el."
+4958,VENENO DE ANIMALES,sus. K’inam.
+4959,VENERAR,v.t. K’ul.
+4960,VENGANZA,"sus. Ch’atoj, ch’atojil"
+4961,VENIR,"v.i. Taal , taalel."
+4962,VENTA,sus. Koonol
+4963,VENTAJA,sus. Paynumil
+4964,VENTANA,"sus. Kalom k’iin, kisneb naaj"
+4965,VENTERA DE AGUA,sus. X koon ja’
+4966,VENTOSA,"sus. Ch’ut, nup’ luuch"
+4967,VENTOSA INTESTINAL,sus. Kiis.
+4968,VENTOSEAR,v.i. Kiis.
+4969,VENUS,sus. Noj eek’
+4970,VER,v.i. Il
+4971,VER CON DELEITE,v.t. Cha’ant
+4972,VERA,adv. de l. Tséel
+4973,VERA,sus. Jáal
+4974,VERBO AUXILIAR CON QUE SE CONJUGA EL PRESEN,
+4975,TE DE INDICATIVO DE TODOS LOS VERBOS NEU,TROS Y SIGNIFICA ESTARSE VERIFICANDO EL
+4976,VERBO,Ka’aj
+4977,VERDAD,"sus. Jaaj, jaajil, máasa, máasima’"
+4978,VERDADERO,adj. Ajajbil
+4979,"VERDE, COLOR VERDE",adj. Ya’ax.
+4980,"VERDE, INMADURO","adj., sus. áak’, ya’ax."
+4981,VERDE ESMERALDA,adj. Ya’aya’ax
+4982,VERDÍN,sus. Kuuxum
+4983,VERDUGO,sus.Aj ch’uy tab.
+4984,VERDUZCO,adj Ya’axele’en.
+4985,VEREDA,"sus. T’ulbe’, éek’bej"
+4986,VER FANTASMAS O ALGÚN MAL AGÜERO,v.i. Ma
+4987,VERGA,"sus. Keep, toon"
+4988,VERGÜENZA,"sus. Subtal, su’tal"
+4989,VERRACO,sus. Beel
+4990,VERRUGA,sus. Aax
+4991,VERTER,"v.t. Bab, láal, piich."
+4992,VERTER COMO SEA,v.t. Chóochooblaalbil.
+4993,VESÍCULA BILIAR,sus. K’aj
+4994,VESTIDO,"sus. Búuko’, nook’"
+4995,"VESTIDO CON ELEGANCIA, BIEN VESTIDO",adj. P’íip’iiki
+4996,VESTIR,"v.t. Búuk, búukinaj."
+4997,VIAJERO,"sus. Aj xíinbal, j xíinbal VOLAR"
+4998,VÍA LÁCTEA,"sus. Tamakas, tamkas."
+4999,VÍBORA,sus. Kaan
+5000,VÍBORA CORALILLO,sus. Kalam
+5001,VÍBORA DE CASCABEL,"sus. Ajau kaan, tsáab kaan"
+5002,VIBRAR,v.i. Bik’chalák
+5003,VICTORIA,sus. Ts’oysaj
+5004,VICTORIOSO,adj. Aj ts’oye saj
+5005,VIDA,"sus. Iik’, kuxtal"
+5006,VIEJO,"adj. Ch’iija’an, laab, nuxib, nuxiib, úu"
+5007,VIENTO,sus. Iik’
+5008,VIENTO CON LLUVIA,sus. Ak’ ya’abil iik’
+5009,VIENTO MANSO Y BLANDO,sus. Juyuknak iik’
+5010,VIENTO QUE VIENE ANTES DEL AGUACERO,sus. Yiik’al ja’
+5011,VIENTRE,sus. Jobnel
+5012,VIGILANTE,"adj. P’ix ich, Aj kanan bej."
+5013,VIGILAR,v.t. Kanan
+5014,VIGILIA,sus. P’ix ich
+5015,VIGOR,"sus. K’inam, muuk’"
+5016,VINAGRE,sus. Suuts’ki
+5017,VIOLACIÓN,sus. Sat suju’uyil
+5018,VIOLÍN,sus. Jichoch
+5019,VIRGEN,"adj. Suju’uy, sujuy"
+5020,VIRILIDAD,sus. Toonil
+5021,VIRTUD,"sus. Chich óolal, tumut óolal, utsil, xiuil, tibilil."
+5022,VIRUELA,"sus. K’áak’, usam k’áak’"
+5023,VÍSCERAS,sus. Jobnel
+5024,VISIBLE,adj. Chika’an
+5025,VISIÓN,sus. Waya’as.
+5026,VISIÓN ENTRE SUEÑOS,sus. Nayal
+5027,VISITA,sus. Yu’ulab.
+5028,VISTO,adj. Ila’an
+5029,VIVIR,"v.i. Kaajnáal, kaajakbal, kuxtal, kuxtaj"
+5030,VOCABULARIO,"sus. Tsoola’an t’aan, molay t’aano’ob."
+5031,VOLAR,"v.i. Xik’nal, popok xik’"
+5032,VOLCADO,adj. Noka’an.
+5033,VOLTEARSE O HACER RODAR,v.t. Balak’taj
+5034,VOLUNTAD,"sus. Óol, óolaj, yot óol."
+5035,"VOLVER, GIRAR",v.i. Suut
+5036,VOMITAR,v.t. Xeej
+5037,VÓMITO,sus. Xeej.
+5038,VORAZ,adj. Aj balnak
+5039,VUELTA,sus. Suut
+5040,VUELTA QUE HACE EL CAMINO,sus. Wats’ bej
+5041,VUELTA Y COMBA QUE HACE EL MADERO,sus. Loch
+5042,VUESTRO,pron. poses. Atia’ale’ex
+5043,"VULVA, VAGINA",sus. Peel Y Yerba Z Zopilote
+5044,Y,conj. cop. que sólo se usa para numera
+5045,Y,"conj. cop. Kux, i’ix"
+5046,Y,conj. cop. Yéetel
+5047,YERBA,sus. Xíiw
+5048,YERNO,sus. Ja’an
+5049,YO,pron. pers. Teen
+5050,YUCA (MANIHOT ESCULENTA (CRANTZ)),sus. Ts’íim
+5051,YUGO PARA UNIR UNA BESTIA CON OTRA,sus. Yukache’
+5052,ZACATE,sus. Su’uk
+5053,"ZAFAR, SACAR, DESCLAVAR, DESENCAJAR","v.t. Joots’, jook"
+5054,ZAFAR,v.t. Jíits’
+5055,ZAFRA,"sus. Ch’ot, ch’óot."
+5056,ZANJA,sus. Jom
+5057,ZAPATO,sus. Xanab
+5058,ZAPATEADO,"adj. Janchalak’ óok’ot. ,ZAPOTE (MANILKARA ZAPOTA (L) VAN ROYEN)."
+5059,ZAPOTE AMARILLO,sus. K’anisté
+5060,ZAPOTE NEGRO (DIESPYRUS DIGYNA (JACQ),sus.
+5061,ZARIGÜEYA,sus. Ooch
+5062,ZOPILOTE,sus. Ch’oom
+5063,ZOPILOTE DE CABEZA ROJA (CATHARTES AURA AURA),sus. K’uch
+5064,ZORRA,"sus. Ch’omak, ch’amak"
+5065,ZORRILLO,sus. Pay ooch
+5066,ZOZOBRA,sus. Ik’il iik’.


### PR DESCRIPTION
In an effort to avoid repeating words that have been chosen on previous days, this PR:

- Adds a feature to keep track of the words that are chosen during each run of the script
- Adds a feature to subset the list of all Maya words to only those that have not been chosen before on previous days