### PR TITLE
Feature: Add ability to send email to more than one receiver

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,3 +1,3 @@
-EMAIL_SENDER =
-EMAIL_PW =
-EMAIL_RECEIVER =
+EMAIL_SENDER = 'email_sender@gmail.com'
+EMAIL_PW = 'PaSsW0rD_123!'
+EMAIL_LIST = '["email1@gmail.com", "email2@gmail.com"]'

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import pandas as pd
 from datetime import date
 from pathlib import Path
 import csv
+import json
 
 # Load in email-related environmental variables
 load_dotenv()
@@ -96,4 +97,6 @@ context = ssl.create_default_context()
 # Log in and send email
 with smtplib.SMTP_SSL('smtp.gmail.com', 465, context=context) as smtp:
     smtp.login(email_sender, email_password)
-    smtp.sendmail(email_sender, email_receiver, em.as_string())
+    email_list = json.loads(os.environ['EMAIL_RECEIVER'])
+    for email_receiver in email_list:
+        smtp.sendmail(email_sender, email_receiver, em.as_string())


### PR DESCRIPTION
Previously, the script only allowed for an email to be sent to one person assigned to the `EMAIL_RECEIVER` environmental variable within the `.env` file. This PR:

- Updates the `.env` file to replace the `EMAIL_RECEIVER` environmental variable with a new environmental variable named `EMAIL_LIST` that will take a JSON-like list of emails for the script to send an email to.
- Updates the `main.py` file to incorporate this new environmental variable to loop over all emails and send an email to each one with the same word of the day
- Updates the `.env-template` with example of inputs for helpful reference.

Helpful Resource: [How to pass a list as an environment variable?](https://stackoverflow.com/questions/31352317/how-to-pass-a-list-as-an-environment-variable)